### PR TITLE
inlet/bmp: avoid long lock times when flushing peers

### DIFF
--- a/common/helpers/norace.go
+++ b/common/helpers/norace.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package helpers
+
+// RaceEnabled reports if the race detector is enabled.
+const RaceEnabled = false

--- a/common/helpers/race.go
+++ b/common/helpers/race.go
@@ -1,0 +1,6 @@
+//go:build race
+
+package helpers
+
+// RaceEnabled reports if the race detector is enabled.
+const RaceEnabled = true

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -13,6 +13,7 @@ identified with a specific icon:
 
 ## Unreleased
 
+- 🌱 *inlet*: reduce impact on flow ingestion when handling BMP peer removals 
 - 🌱 *console*: <kbd>Ctrl-Enter</kbd> or <kbd>Cmd-Enter</kbd> when editing a filter now applies the changes.
 
 ## 1.6.2 - 2022-11-03

--- a/inlet/bmp/config.go
+++ b/inlet/bmp/config.go
@@ -20,15 +20,27 @@ type Configuration struct {
 	CollectCommunities bool
 	// Keep tells how long to keep routes from a BMP client when it goes down
 	Keep time.Duration `validate:"min=1s"`
+	// PeerRemovalMaxTime tells the maximum time the removal worker should run to remove a peer
+	PeerRemovalMaxTime time.Duration `validate:"min=10ms"`
+	// PeerRemovalSleepInterval tells how much time to sleep between two runs of the removal worker
+	PeerRemovalSleepInterval time.Duration `validate:"min=10ms"`
+	// PeerRemovalMaxQueue tells how many pending removal requests to keep
+	PeerRemovalMaxQueue int `validate:"min=1"`
+	// PeerRemovalMinRoutes tells how many routes we have to remove in one run before yielding
+	PeerRemovalMinRoutes int `validate:"min=1"`
 }
 
 // DefaultConfiguration represents the default configuration for the BMP server
 func DefaultConfiguration() Configuration {
 	return Configuration{
-		Listen:             "0.0.0.0:10179",
-		Keep:               5 * time.Minute,
-		CollectASNs:        true,
-		CollectASPaths:     true,
-		CollectCommunities: true,
+		Listen:                   "0.0.0.0:10179",
+		CollectASNs:              true,
+		CollectASPaths:           true,
+		CollectCommunities:       true,
+		Keep:                     5 * time.Minute,
+		PeerRemovalMaxTime:       200 * time.Millisecond,
+		PeerRemovalSleepInterval: 500 * time.Millisecond,
+		PeerRemovalMaxQueue:      10000,
+		PeerRemovalMinRoutes:     5000,
 	}
 }

--- a/inlet/bmp/metrics.go
+++ b/inlet/bmp/metrics.go
@@ -6,16 +6,19 @@ package bmp
 import "akvorado/common/reporter"
 
 type metrics struct {
-	openedConnections *reporter.CounterVec
-	closedConnections *reporter.CounterVec
-	peers             *reporter.GaugeVec
-	routes            *reporter.GaugeVec
-	ignoredNlri       *reporter.CounterVec
-	messages          *reporter.CounterVec
-	errors            *reporter.CounterVec
-	unhandledFamily   *reporter.CounterVec
-	panics            *reporter.CounterVec
-	locked            *reporter.SummaryVec
+	openedConnections    *reporter.CounterVec
+	closedConnections    *reporter.CounterVec
+	peers                *reporter.GaugeVec
+	routes               *reporter.GaugeVec
+	ignoredNlri          *reporter.CounterVec
+	messages             *reporter.CounterVec
+	errors               *reporter.CounterVec
+	unhandledFamily      *reporter.CounterVec
+	panics               *reporter.CounterVec
+	locked               *reporter.SummaryVec
+	peerRemovalDone      *reporter.CounterVec
+	peerRemovalPartial   *reporter.CounterVec
+	peerRemovalQueueFull *reporter.CounterVec
 }
 
 // initMetrics initialize the metrics for the BMP component.
@@ -90,5 +93,26 @@ func (c *Component) initMetrics() {
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"reason"},
+	)
+	c.metrics.peerRemovalDone = c.r.CounterVec(
+		reporter.CounterOpts{
+			Name: "peer_removal_done_total",
+			Help: "Number of peers removed from the RIB.",
+		},
+		[]string{"exporter"},
+	)
+	c.metrics.peerRemovalPartial = c.r.CounterVec(
+		reporter.CounterOpts{
+			Name: "peer_removal_partial_total",
+			Help: "Number of peers partially removed from the RIB.",
+		},
+		[]string{"exporter"},
+	)
+	c.metrics.peerRemovalQueueFull = c.r.CounterVec(
+		reporter.CounterOpts{
+			Name: "peer_removal_queue_full_total",
+			Help: "Number of time the removal queue was full.",
+		},
+		[]string{"exporter"},
 	)
 }

--- a/inlet/bmp/remove.go
+++ b/inlet/bmp/remove.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package bmp
+
+import (
+	"context"
+	"time"
+)
+
+func (c *Component) peerRemovalWorker() error {
+	for {
+		select {
+		case <-c.t.Dying():
+			return nil
+		case pkey := <-c.peerRemovalChan:
+			exporterStr := pkey.exporter.Addr().Unmap().String()
+			for {
+				// Do one run of removal.
+				removed, done := func() (int, bool) {
+					ctx, cancel := context.WithTimeout(c.t.Context(context.Background()),
+						c.config.PeerRemovalMaxTime)
+					defer cancel()
+					c.mu.Lock()
+					start := c.d.Clock.Now()
+					defer func() {
+						c.mu.Unlock()
+						c.metrics.locked.WithLabelValues("stale").Observe(
+							float64(c.d.Clock.Now().Sub(start).Nanoseconds()) / 1000 / 1000 / 1000)
+					}()
+					pinfo := c.peers[pkey]
+					removed, done := c.rib.flushPeer(ctx, pinfo.reference, c.config.PeerRemovalMinRoutes)
+					if done {
+						// Run was complete, remove the peer (we need the lock)
+						delete(c.peers, pkey)
+					}
+					return removed, done
+				}()
+				c.metrics.routes.WithLabelValues(exporterStr).Sub(float64(removed))
+				if done {
+					// Run was complete, update metrics
+					c.metrics.peers.WithLabelValues(exporterStr).Dec()
+					c.metrics.peerRemovalDone.WithLabelValues(exporterStr).Inc()
+					break
+				}
+				// Run is incompletem, update metrics and sleep a bit
+				c.metrics.peerRemovalPartial.WithLabelValues(exporterStr).Inc()
+				select {
+				case <-c.t.Dying():
+					return nil
+				case <-time.After(c.config.PeerRemovalSleepInterval):
+				}
+			}
+		}
+	}
+}

--- a/inlet/bmp/rib_test.go
+++ b/inlet/bmp/rib_test.go
@@ -4,6 +4,7 @@
 package bmp
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net/netip"
@@ -285,7 +286,7 @@ func TestRIB(t *testing.T) {
 
 		// Remove everything
 		for _, peer := range peers {
-			r.flushPeer(peer)
+			r.flushPeer(context.Background(), peer, 100)
 		}
 
 		// Check for leak of route attributes


### PR DESCRIPTION
When the RIB is locked for too long, inlet is hung. Try to ensure give a bit of time for the inlet to move forward between two flush of the RIB. There are various knobs not documnted yet until we get better defaults:

- `inlet.bmp.peer-removal-max-time`: how long to keep the lock
- `inlet.bmp.peer-removal-sleep-interval`: how long to sleep between two runs if we were unable to flush the whole peer
- `inlet.bmp.peer-removal-max-queue`: maximum number of flush requests
- `inlet.bmp.peer-removal-min-routes`: minimum number of routes to flush before yielding

May fix #253