### PR TITLE
Improve loglevel load

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,10 +25,11 @@ var RootCmd = &cobra.Command{
 		} else {
 			log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
 		}
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		logLevel := zerolog.InfoLevel
 		if debug {
-			zerolog.SetGlobalLevel(zerolog.DebugLevel)
+			logLevel = zerolog.DebugLevel
 		}
+		zerolog.SetGlobalLevel(logLevel)
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,


### PR DESCRIPTION
Use a variable to store the global logging level rather than calling `zerolog.SetGlobalLevel` every time. This will reduce the number of function calls and improve code efficiency.