### PR TITLE
makefile: Split all target in js and go parts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ all: fmt lint $(GENERATED) | $(BIN) ; $(info $(M) building executable…) @ ## B
 		-ldflags '-X $(MODULE)/cmd.Version=$(VERSION) -X $(MODULE)/cmd.BuildDate=$(DATE)' \
 		-o $(BIN)/$(basename $(MODULE)) main.go
 
+.PHONY: all_js
+all_js: .fmt-js~ .lint-js~ $(GENERATED_JS) console/data/frontend
+
 # Tools
 
 $(BIN):


### PR DESCRIPTION
This PR adds an additional "all_js" target to the makefile. The default behavior should not change.

**Why is this necessary?**
In certain build environments, it is easier to have a build container only for go, and a build container only for node/js-related tasks. With the all task split up, it is possible to do a multi-stage build, first building the js parts in a node-container, while later building the remaining parts in a go container.