### PR TITLE
Update build docs to reflect necessary NodeJS version

### DIFF
--- a/console/data/docs/01-install.md
+++ b/console/data/docs/01-install.md
@@ -35,7 +35,7 @@ Currently, only a pre-built binary for Linux x86-64 is provided.
 ## Compilation from source
 
 You need a proper installation of [Go](https://go.dev/doc/install) (1.19+), and
-[NodeJS](https://nodejs.org/en/download/) (14+) with NPM (6+). For example, on
+[NodeJS](https://nodejs.org/en/download/) (16+) with NPM (6+). For example, on
 Debian:
 
 ```console


### PR DESCRIPTION
I tried to build the code using `make` with node `v14.16.0` but I got the following error:

```
failed to load config from /home/rnavarro/workspace/akvorado/console/frontend/vite.config.ts
error during build:
Error: Cannot find module 'node:path'

```

A little research showed:

`node:` protocol support for CJS was added only in v16.

After updating to v16+ running `make` succeeded

This PR updates the docs to reflect that.