### PR TITLE
nix: proper reproducible build (WIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     name: 🤖 Check dependabot status
     runs-on: ubuntu-latest
     permissions: {}
+    if: "!startsWith(github.event.head_commit.message, 'build: update flake.nix')"
     steps:
       - name: Fetch dependabot metadata
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,29 @@
+---
+name: Update flake.nix
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+      - console/frontend/package-lock.json
+jobs:
+  flake:
+    name: Update hashs in flake.nix
+    runs-on: ubuntu-latest
+    concurrency:
+      group: update-flake-nix
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+      - name: Update flake.nix
+        run: nix run .#update
+      - name: Push update
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.nix flake.lock
+          ! git commit -m "build: update flake.nix" || git push

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20
-      - name: Update flake.nix
-        run: nix run .#update
+      - name: Update npmDepsHash in flake.nix
+        run: nix run .#default.passthru.update-npmDepsHash
+      - name: Update vendorHash in flake.nix
+        run: nix run .#default.passthru.update-vendorHash
       - name: Push update
         run: |
           git config --local user.name "github-actions[bot]"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mock_*.go
 *~
 /.go-cache
 /.npm-cache
+/result

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 FROM nixpkgs/nix-flakes:latest AS build
 WORKDIR /app
-COPY flake.nix ./
-COPY flake.lock ./
-RUN nix develop -c true
-# Build
 COPY . .
 RUN mkdir -p /output/store
 RUN git describe --tags --always --dirty --match=v* > .version && git add -f .version
-RUN nix build --option sandbox false
-RUN cp -va $(nix-store -qR result) /output/store
-RUN rm -rf /output/store/*-akvorado
+RUN nix run ".#update" \
+ && nix build \
+ && cp -va $(nix-store -qR result) /output/store \
+ && rm -rf /output/store/*-akvorado
 
 FROM scratch
 COPY --from=build /output/store /nix/store

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ $(BIN)/pigeon: PACKAGE=github.com/mna/pigeon@v1.1.0
 WWHRD = $(BIN)/wwhrd
 $(BIN)/wwhrd: PACKAGE=github.com/frapposelli/wwhrd@latest
 
+.PHONY: nix-update
+nix-update: ; $(info $(M) update Nix hashes…) @ ## Update nix hashes
+	$Q nix run ".#update"
+
 # Generated files
 
 .DELETE_ON_ERROR:

--- a/common/clickhousedb/mocks/empty.go
+++ b/common/clickhousedb/mocks/empty.go
@@ -4,4 +4,7 @@
 // Package mocks contains mocks for clickhousedb package.
 package mocks
 
-// This is empty to ensure the package exists to help Dependabot.
+import (
+	_ "github.com/ClickHouse/clickhouse-go/v2/lib/driver" // for mockgen in vendor mode
+	_ "github.com/golang/mock/mockgen/model"              // for mockgen in vendor mode
+)

--- a/conntrackfixer/mocks/empty.go
+++ b/conntrackfixer/mocks/empty.go
@@ -4,4 +4,6 @@
 // Package mocks contains mocks for conntrackfixer package.
 package mocks
 
-// This is empty to ensure the package exists to help Dependabot.
+import (
+	_ "github.com/golang/mock/mockgen/model" // for mockgen in vendor mode
+)

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,32 @@
 {
   "nodes": {
-    "flake-utils": {
+    "asn2org": {
+      "flake": false,
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1682925120,
+        "narHash": "sha256-+xXuvVkqZ5fGImVo/v0J2+Fatm+tqMre3zX+TZPccXU=",
+        "owner": "vincentbernat",
+        "repo": "asn2org",
+        "rev": "aeb2633d96f33e005ea4ac3b4a0e131b1b35edf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vincentbernat",
+        "ref": "gh-pages",
+        "repo": "asn2org",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -17,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682109806,
-        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "lastModified": 1684363872,
+        "narHash": "sha256-jkvhzrICFSmj+NBHksKTWzs8Q3+D7RsVK0wLKacbu8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "rev": "1d77f3b72756ca36f16440c59e6b89a957908647",
         "type": "github"
       },
       "original": {
@@ -31,8 +51,24 @@
     },
     "root": {
       "inputs": {
+        "asn2org": "asn2org",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,43 +2,97 @@
   inputs = {
     nixpkgs.url = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+    asn2org = {
+      url = "github:vincentbernat/asn2org/gh-pages";
+      flake = false;
+    };
   };
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, asn2org }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages."${system}";
-        deps = [
-          pkgs.curl
-          pkgs.git
-          pkgs.go_1_20
-          pkgs.nodejs-18_x
-        ];
-      in
-      {
-        # This can be built with "nix build --option sandbox false".
-        # Not a good example on how to package things for Nix!
-        packages.default = pkgs.stdenv.mkDerivation {
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        nodejs = pkgs.nodejs-18_x;
+        go = pkgs.go_1_20;
+        frontend = pkgs.buildNpmPackage.override { inherit nodejs; } {
+          name = "akvorado-frontend";
+          src = ./console/frontend;
+          npmDepsHash = "sha256-xs2WHPrQFPtcjYEpB2Fb/gegP6Mf9ZD0VK/DcPg1zS8=";
+          installPhase = ''
+            mkdir $out
+            cp -r node_modules $out/node_modules
+            cp -r ../data/frontend $out/data
+          '';
+        };
+        backend = pkgs.buildGoModule.override { inherit go; } {
+          doCheck = false;
           name = "akvorado";
           src = ./.;
-          nativeBuildInputs = deps;
-          configurePhase = ''
-            export HOME=$TMPDIR
-            export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-            export GOFLAGS=-trimpath
+          vendorHash = "sha256-cxL3WuvSKpsutVS3k5kduEDdAvk1ZM2XVU6YjcT+OTk=";
+          buildPhase = ''
+            cp ${asn2org}/asns.csv orchestrator/clickhouse/data/asns.csv
+            cp -r ${frontend}/node_modules console/frontend/node_modules
+            cp -r ${frontend}/data console/data/frontend
+
+            touch .fmt-js~ .fmt.go~ .lint-js~ .lint-go~
+            find . -print0 | xargs -0 touch -d @0
+
+            make all \
+              MOCKGEN=${pkgs.mockgen}/bin/mockgen \
+              GOIMPORTS=${pkgs.gotools}/bin/goimports \
+              PIGEON=${pkgs.pigeon}/bin/pigeon \
+              REVIVE=${pkgs.coreutils}/bin/true
           '';
           # We do not use a wrapper to set SSL_CERT_FILE because, either a
           # binary or a shell wrapper, it would pull the libc (~30M).
-          installPhase = ''
+          installPhase= ''
             mkdir -p $out/bin $out/share/ca-certificates
             cp bin/akvorado $out/bin/.
             cp ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt $out/share/ca-certificates/.
           '';
         };
+      in
+      rec {
+        apps = {
+          update = let
+            script = pkgs.writeShellScriptBin "nix-update-akvorado" ''
+              # go
+              sha256=$(2>&1 nix build --no-link .#backend.go-modules \
+                          | ${pkgs.gnused}/bin/sed -nE "s/\s+got:\s+(sha256-.*)/\1/p")
+              [[ -z "$sha256" ]] || \
+                 ${pkgs.gnused}/bin/sed -Ei "s,^(\s+[v]endorHash =).*,\1 \"''${sha256}\";," flake.nix
+
+              # npm
+              sha256=$(2>&1 nix build --no-link .#frontend.npmDeps \
+                          | ${pkgs.gnused}/bin/sed -nE "s/\s+got:\s+(sha256-.*)/\1/p")
+              [[ -z "$sha256" ]] || \
+                 ${pkgs.gnused}/bin/sed -Ei "s,^(\s+[n]pmDepsHash =).*,\1 \"''${sha256}\";," flake.nix
+
+              # asn2org
+              nix flake lock --update-input asn2org
+            '';
+            in {
+              type = "app";
+              program = "${script}/bin/nix-update-akvorado";
+            };
+        };
+
+        packages = {
+          inherit backend frontend;
+          default = backend;
+        };
 
         # Activate with "nix develop"
         devShells.default = pkgs.mkShell {
           name = "akvorado-dev";
-          buildInputs = deps;
+          nativeBuildInputs = [
+            go
+            nodejs
+            pkgs.git
+            pkgs.curl
+            pkgs.gomod2nix
+          ];
         };
       });
 }


### PR DESCRIPTION
Hi there,

This is WIP attempt to get akvorado to build properly inside nix. This approach aims to include all build dependencies and does not need `--impure` to build.

I basically had to reverse engineer the custom makefile and reproduce some of its logic. This is clearly not optimal, since developers now have two buildsystems to maintain. I am not familiar enough with the go builds system but I wonder if we could get nix to 'pre-fetch' the go dependencies and then just run the makefile.

The build itself succeds but the check phase fails, likely I am not building things correctly.

Let me know if there's interest in pursuing this. I'd love to be able to deploy akvorado automatically with NixOS :) 
