### PR TITLE
feat: add option for materialized types & improve filter performance for materialized prefixes

### DIFF
--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -159,9 +159,10 @@ func flows() Schema {
 				ConsoleNotDimension: true,
 			},
 			{
-				Key:                ColumnSrcNetPrefix,
-				ClickHouseMainOnly: true,
-				ClickHouseType:     "String",
+				Key:                        ColumnSrcNetPrefix,
+				ClickHouseMainOnly:         true,
+				ClickHouseType:             "String",
+				ClickHouseMaterializedType: "LowCardinality(String)",
 				ClickHouseAlias: `CASE
  WHEN EType = 0x800 THEN concat(replaceRegexpOne(IPv6CIDRToRange(SrcAddr, (96 + SrcNetMask)::UInt8).1::String, '^::ffff:', ''), '/', SrcNetMask::String)
  WHEN EType = 0x86dd THEN concat(IPv6CIDRToRange(SrcAddr, SrcNetMask).1::String, '/', SrcNetMask::String)

--- a/common/schema/root.go
+++ b/common/schema/root.go
@@ -30,8 +30,14 @@ func New(config Configuration) (*Component, error) {
 			if column.ClickHouseAlias != "" {
 				column.ClickHouseGenerateFrom = column.ClickHouseAlias
 				column.ClickHouseAlias = ""
+				column.ClickHouseMaterialized = true
 			} else {
 				return nil, fmt.Errorf("no alias configured for %s that can be converted to generate", k)
+			}
+
+			// in case we have another data type for materialized columns, set it
+			if column.ClickHouseMaterializedType != "" {
+				column.ClickHouseType = column.ClickHouseMaterializedType
 			}
 		}
 	}

--- a/common/schema/types.go
+++ b/common/schema/types.go
@@ -39,14 +39,18 @@ type Column struct {
 	// instead of being retrieved from the protobuf. `TransformFrom' and
 	// `TransformTo' work in pairs. The first one is the set of column in the
 	// raw table while the second one is how to transform it for the main table.
-	ClickHouseType          string
-	ClickHouseCodec         string
-	ClickHouseAlias         string
-	ClickHouseNotSortingKey bool
-	ClickHouseGenerateFrom  string
-	ClickHouseTransformFrom []Column
-	ClickHouseTransformTo   string
-	ClickHouseMainOnly      bool
+	ClickHouseType             string
+	ClickHouseMaterializedType string
+	ClickHouseCodec            string
+	ClickHouseAlias            string
+	ClickHouseNotSortingKey    bool
+	ClickHouseGenerateFrom     string
+	ClickHouseTransformFrom    []Column
+	ClickHouseTransformTo      string
+	ClickHouseMainOnly         bool
+
+	// ClickHouseMaterialized indicates that the column was materialized (and is not by default)
+	ClickHouseMaterialized bool
 
 	// For the console. `ClickHouseTruncateIP' makes the specified column
 	// truncatable when used as a dimension.

--- a/console/filter/parser.peg
+++ b/console/filter/parser.peg
@@ -78,8 +78,8 @@ ConditionPrefixExpr "condition on prefix" ←
    operator:("=" / "!=") _
    prefix:SourcePrefix {
      switch toString(operator) {
-       case "=": return []any{c.getColumn("SrcAddr"), prefix}, nil
-       case "!=": return []any{"NOT (", c.getColumn("SrcAddr"), prefix, ")"}, nil
+       case "=": return []any{prefix}, nil
+       case "!=": return []any{"NOT (", prefix, ")"}, nil
      }
      return "", nil
    }
@@ -87,8 +87,8 @@ ConditionPrefixExpr "condition on prefix" ←
    operator:("=" / "!=") _
    prefix:DestinationPrefix {
      switch toString(operator) {
-       case "=": return []any{c.getColumn("DstAddr"), prefix}, nil
-       case "!=": return []any{"NOT (", c.getColumn("DstAddr"), prefix, ")"}, nil
+       case "=": return []any{prefix}, nil
+       case "!=": return []any{"NOT (", prefix, ")"}, nil
      }
      return "", nil
    }


### PR DESCRIPTION
This PR adds some improvements to materialized dimensions, especially prefixes:
- it saves the Src/DstNetPrefix as LowCardinality, as we have a high repeatability here
- a flag indicates if a column was materialized
- the filters can be adjusted to use a more performant direct query in case of materialized columns, which is done for prefixes
- tests for the "fast" materialized prefix query are added