### PR TITLE
orchestrator/kafka: alter topic configuration only when needed (config diff)

### DIFF
--- a/common/helpers/maps.go
+++ b/common/helpers/maps.go
@@ -1,0 +1,32 @@
+package helpers
+
+import "reflect"
+
+// IsMapSubset validates that a map is a proper subset of another parent map.
+func IsMapSubset(mapSet interface{}, mapSubset interface{}) bool {
+
+	mapSetValue := reflect.ValueOf(mapSet)
+	mapSubsetValue := reflect.ValueOf(mapSubset)
+
+	if mapSetValue.Kind() != reflect.Map || mapSubsetValue.Kind() != reflect.Map {
+		return false
+	}
+	if reflect.TypeOf(mapSetValue) != reflect.TypeOf(mapSubsetValue) {
+		return false
+	}
+	if len(mapSubsetValue.MapKeys()) == 0 {
+		return true
+	}
+
+	iterMapSubset := mapSubsetValue.MapRange()
+
+	for iterMapSubset.Next() {
+		k := iterMapSubset.Key()
+		v := iterMapSubset.Value()
+
+		if v2 := mapSetValue.MapIndex(k); !v2.IsValid() || v.Interface() != v2.Interface() {
+			return false
+		}
+	}
+	return true
+}

--- a/common/helpers/maps_test.go
+++ b/common/helpers/maps_test.go
@@ -1,0 +1,26 @@
+package helpers
+
+import "testing"
+
+func TestIsMapSubset(t *testing.T) {
+	referenceTestFoo := "foo"
+	referenceTestBar := "bar"
+	cases := []struct {
+		parent   interface{}
+		child    interface{}
+		expected bool
+	}{
+		{map[string]string{"a": "b", "c": "d", "e": "f"}, map[string]string{"a": "b"}, true},
+		{map[string]string{"a": "b", "c": "d", "e": "f"}, map[string]string{"b": "a"}, false},
+		{"a", "b", false},
+		{map[string]*string{"a": &referenceTestFoo, "c": &referenceTestBar}, map[string]*string{"a": &referenceTestFoo}, true},
+	}
+	for _, tc := range cases {
+		got := IsMapSubset(tc.parent, tc.child)
+		if got && !tc.expected {
+			t.Errorf("%q is a subset of %q, but expected it is not", tc.child, tc.parent)
+		} else if !got && tc.expected {
+			t.Errorf("%q is not a subset of %q but expected it is", tc.child, tc.parent)
+		}
+	}
+}

--- a/orchestrator/kafka/functional_test.go
+++ b/orchestrator/kafka/functional_test.go
@@ -46,6 +46,13 @@ func TestTopicCreation(t *testing.T) {
 				"cleanup.policy": &cleanupPolicy,
 			},
 		}, {
+			Name: "Do not alter equivalent config",
+			ConfigEntries: map[string]*string{
+				"retention.ms":   &retentionMs,
+				"segment.bytes":  &segmentBytes2,
+				"cleanup.policy": &cleanupPolicy,
+			},
+		}, {
 			Name: "Remove item",
 			ConfigEntries: map[string]*string{
 				"retention.ms":  &retentionMs,

--- a/orchestrator/kafka/root.go
+++ b/orchestrator/kafka/root.go
@@ -5,6 +5,7 @@
 package kafka
 
 import (
+	"akvorado/common/helpers"
 	"fmt"
 	"strings"
 
@@ -105,12 +106,14 @@ func (c *Component) Start() error {
 			l.Warn().Msgf("mismatch for replication factor: got %d, want %d",
 				topic.ReplicationFactor, c.config.TopicConfiguration.ReplicationFactor)
 		}
-		if err := admin.AlterConfig(sarama.TopicResource, c.kafkaTopic, c.config.TopicConfiguration.ConfigEntries, false); err != nil {
-			l.Err(err).Msg("unable to set topic configuration")
-			return fmt.Errorf("unable to set topic configuration for %q: %w",
-				c.kafkaTopic, err)
+		if !helpers.IsMapSubset(topic.ConfigEntries, c.config.TopicConfiguration.ConfigEntries) {
+			if err := admin.AlterConfig(sarama.TopicResource, c.kafkaTopic, c.config.TopicConfiguration.ConfigEntries, false); err != nil {
+				l.Err(err).Msg("unable to set topic configuration")
+				return fmt.Errorf("unable to set topic configuration for %q: %w",
+					c.kafkaTopic, err)
+			}
+			l.Info().Msg("topic updated")
 		}
-		l.Info().Msg("topic updated")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR allows orchestrator to alter Kafka topic configuration only if config has changed, instead of each time. 
This is mandatory for Kafka brokers that does not allow specific config entries alter.