### PR TITLE
orchestrator/clickhouse: Add kafka consumers group name as config parameter

### DIFF
--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -697,6 +697,9 @@ provided:
     the Kafka topic. It is silently bound by the maximum number of threads
     ClickHouse will use (by default, the number of CPUs). It should also be less
     than the number of partitions: the additional consumers will stay idle.
+  - `group-name` defines the group name consumers will use to consume messages from the
+    Kafka topic.
+    The default value is "clickhouse".
   - `engine-settings` defines a list of additional settings for the Kafka engine
     in ClickHouse. Check [ClickHouse documentation][] for possible values. You
     can notably tune `kafka_max_block_size`, `kafka_poll_timeout_ms`,

--- a/orchestrator/clickhouse/config.go
+++ b/orchestrator/clickhouse/config.go
@@ -68,6 +68,9 @@ type KafkaConfiguration struct {
 	kafka.Configuration `mapstructure:",squash" yaml:"-,inline"`
 	// Consumers tell how many consumers to use to poll data from Kafka
 	Consumers int `validate:"min=1"`
+	// GroupName defines the Kafka consumers group used to poll data from topic,
+	// shared between all Consumers.
+	GroupName string
 	// EngineSettings allows one to set arbitrary settings for Kafka engine in
 	// ClickHouse.
 	EngineSettings []string
@@ -79,6 +82,7 @@ func DefaultConfiguration() Configuration {
 		Configuration: clickhousedb.DefaultConfiguration(),
 		Kafka: KafkaConfiguration{
 			Consumers: 1,
+			GroupName: "clickhouse",
 		},
 		Resolutions: []ResolutionConfiguration{
 			{0, 15 * 24 * time.Hour},                   // 15 days

--- a/orchestrator/clickhouse/migrations_helpers.go
+++ b/orchestrator/clickhouse/migrations_helpers.go
@@ -188,7 +188,7 @@ func (c *Component) createRawFlowsTable(ctx context.Context) error {
 			strings.Join(c.config.Kafka.Brokers, ",")),
 		fmt.Sprintf(`kafka_topic_list = '%s-%s'`,
 			c.config.Kafka.Topic, hash),
-		`kafka_group_name = 'clickhouse'`,
+		fmt.Sprintf(`kafka_group_name = '%s'`, c.config.Kafka.GroupName),
 		`kafka_format = 'Protobuf'`,
 		fmt.Sprintf(`kafka_schema = 'flow-%s.proto:FlowMessagev%s'`, hash, hash),
 		fmt.Sprintf(`kafka_num_consumers = %d`, c.config.Kafka.Consumers),


### PR DESCRIPTION
This PR allows to configure the Kafka group name used by ClickHouse to consume messages from topic. Default value is left as the previous "clickhouse".

This is mandatory for Kafka brokers that enforce syntax validation on group names, with for example provider-specific prefixes.
