### PR TITLE
Support providing exporter and iface metadata through metadata instead of classifiers

### DIFF
--- a/common/remotedatasourcefetcher/root_test.go
+++ b/common/remotedatasourcefetcher/root_test.go
@@ -1,8 +1,6 @@
 package remotedatasourcefetcher
 
 import (
-	"akvorado/common/helpers"
-	"akvorado/common/reporter"
 	"context"
 	"fmt"
 	"net"
@@ -10,6 +8,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"akvorado/common/helpers"
+	"akvorado/common/reporter"
 )
 
 type remoteData struct {

--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -13,6 +13,18 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+// InterfaceBoundary identifies wether the interface is facing inside or outside the network.
+type InterfaceBoundary uint
+
+const (
+	// InterfaceBoundaryUndefined means we don't know about the interface.
+	InterfaceBoundaryUndefined InterfaceBoundary = iota
+	// InterfaceBoundaryExternal means this interface is facing outside our network
+	InterfaceBoundaryExternal
+	// InterfaceBoundaryInternal means this interface is facing inside our network
+	InterfaceBoundaryInternal
+)
+
 // revive:disable
 const (
 	ColumnTimeReceived ColumnKey = iota + 1
@@ -294,14 +306,14 @@ END`,
 			{Key: ColumnInIfProvider, ParserType: "string", ClickHouseType: "LowCardinality(String)", ClickHouseNotSortingKey: true},
 			{
 				Key:                     ColumnInIfBoundary,
-				ClickHouseType:          "Enum8('undefined' = 0, 'external' = 1, 'internal' = 2)",
+				ClickHouseType:          fmt.Sprintf("Enum8('undefined' = %d, 'external' = %d, 'internal' = %d)", InterfaceBoundaryUndefined, InterfaceBoundaryExternal, InterfaceBoundaryInternal),
 				ClickHouseNotSortingKey: true,
 				ProtobufType:            protoreflect.EnumKind,
 				ProtobufEnumName:        "Boundary",
 				ProtobufEnum: map[int]string{
-					0: "UNDEFINED",
-					1: "EXTERNAL",
-					2: "INTERNAL",
+					int(InterfaceBoundaryUndefined): "UNDEFINED",
+					int(InterfaceBoundaryExternal):  "EXTERNAL",
+					int(InterfaceBoundaryInternal):  "INTERNAL",
 				},
 			},
 			{Key: ColumnEType, ClickHouseType: "UInt32"}, // TODO: UInt16 but hard to change, primary key

--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -4,8 +4,11 @@
 package schema
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+
+	"akvorado/common/helpers/bimap"
 
 	"github.com/bits-and-blooms/bitset"
 	"golang.org/x/exp/slices"
@@ -24,6 +27,44 @@ const (
 	// InterfaceBoundaryInternal means this interface is facing inside our network
 	InterfaceBoundaryInternal
 )
+
+var (
+	interfaceBoundaryMap = bimap.New(map[InterfaceBoundary]string{
+		InterfaceBoundaryUndefined: "undefined",
+		InterfaceBoundaryExternal:  "external",
+		InterfaceBoundaryInternal:  "internal",
+	})
+	errUnknownInterfaceBoundary = errors.New("unknown interface boundary")
+)
+
+// MarshalText turns a SASL algorithm to text
+func (sa InterfaceBoundary) MarshalText() ([]byte, error) {
+	got, ok := interfaceBoundaryMap.LoadValue(sa)
+	if ok {
+		return []byte(got), nil
+	}
+	return nil, errUnknownInterfaceBoundary
+}
+
+// String turns a SASL algorithm to string
+func (sa InterfaceBoundary) String() string {
+	got, _ := interfaceBoundaryMap.LoadValue(sa)
+	return got
+}
+
+// UnmarshalText provides a SASL algorithm from text
+func (sa *InterfaceBoundary) UnmarshalText(input []byte) error {
+	if len(input) == 0 {
+		*sa = InterfaceBoundaryUndefined
+		return nil
+	}
+	got, ok := interfaceBoundaryMap.LoadKey(string(input))
+	if ok {
+		*sa = got
+		return nil
+	}
+	return errUnknownInterfaceBoundary
+}
 
 // revive:disable
 const (

--- a/inlet/core/classifier.go
+++ b/inlet/core/classifier.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"akvorado/common/schema"
+
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/ast"
 	"github.com/antonmedv/expr/vm"
@@ -143,20 +145,11 @@ type interfaceInfo struct {
 	VLAN        uint16
 }
 
-// interfaceBoundary tells if an interface is internal or external
-type interfaceBoundary uint
-
-const (
-	undefinedBoundary interfaceBoundary = iota
-	externalBoundary
-	internalBoundary
-)
-
 // interfaceClassification contains the information about an interface classification
 type interfaceClassification struct {
 	Connectivity string
 	Provider     string
-	Boundary     interfaceBoundary
+	Boundary     schema.InterfaceBoundary
 	Reject       bool
 	Name         string
 	Description  string
@@ -183,14 +176,14 @@ func (scr *InterfaceClassifierRule) exec(si exporterInfo, ii interfaceInfo, ic *
 	classifyConnectivity := classifyString(&ic.Connectivity)
 	classifyProvider := classifyString(&ic.Provider)
 	classifyExternal := func() bool {
-		if ic.Boundary == undefinedBoundary {
-			ic.Boundary = externalBoundary
+		if ic.Boundary == schema.InterfaceBoundaryUndefined {
+			ic.Boundary = schema.InterfaceBoundaryExternal
 		}
 		return true
 	}
 	classifyInternal := func() bool {
-		if ic.Boundary == undefinedBoundary {
-			ic.Boundary = internalBoundary
+		if ic.Boundary == schema.InterfaceBoundaryUndefined {
+			ic.Boundary = schema.InterfaceBoundaryInternal
 		}
 		return true
 	}

--- a/inlet/core/classifier_test.go
+++ b/inlet/core/classifier_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"akvorado/common/helpers"
+	"akvorado/common/schema"
 )
 
 func TestExporterClassifier(t *testing.T) {
@@ -156,11 +157,11 @@ func TestInterfaceClassifier(t *testing.T) {
 		}, {
 			Description:            "constant classifier for boundary external",
 			Program:                `ClassifyExternal()`,
-			ExpectedClassification: interfaceClassification{Boundary: externalBoundary},
+			ExpectedClassification: interfaceClassification{Boundary: schema.InterfaceBoundaryExternal},
 		}, {
 			Description:            "constant classifier for boundary internal",
 			Program:                `ClassifyInternal()`,
-			ExpectedClassification: interfaceClassification{Boundary: internalBoundary},
+			ExpectedClassification: interfaceClassification{Boundary: schema.InterfaceBoundaryInternal},
 		}, {
 			Description: "set name and description",
 			Program:     `SetName("newname") && SetDescription("newdescription")`,
@@ -203,7 +204,7 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")
 			ExpectedClassification: interfaceClassification{
 				Connectivity: "transit",
 				Provider:     "telia",
-				Boundary:     externalBoundary,
+				Boundary:     schema.InterfaceBoundaryExternal,
 			},
 		}, {
 			Description: "classify with VLANs",
@@ -215,7 +216,7 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")
 				VLAN:        100,
 			},
 			ExpectedClassification: interfaceClassification{
-				Boundary: externalBoundary,
+				Boundary: schema.InterfaceBoundaryExternal,
 			},
 		}, {
 			Description: "classify with another VLAN",
@@ -227,7 +228,7 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")
 				VLAN:        200,
 			},
 			ExpectedClassification: interfaceClassification{
-				Boundary: undefinedBoundary,
+				Boundary: schema.InterfaceBoundaryUndefined,
 			},
 		},
 	}

--- a/inlet/core/enricher.go
+++ b/inlet/core/enricher.go
@@ -36,19 +36,19 @@ func (c *Component) enrichFlow(exporterIP netip.Addr, exporterStr string, flow *
 			c.metrics.flowsErrors.WithLabelValues(exporterStr, "SNMP cache miss").Inc()
 			skip = true
 		} else {
-			flowExporterName = answer.ExporterName
-			expClassification.Region = answer.ExporterRegion
-			expClassification.Role = answer.ExporterRole
-			expClassification.Tenant = answer.ExporterTenant
-			expClassification.Site = answer.ExporterSite
-			expClassification.Group = answer.ExporterGroup
+			flowExporterName = answer.Exporter.Name
+			expClassification.Region = answer.Exporter.Region
+			expClassification.Role = answer.Exporter.Role
+			expClassification.Tenant = answer.Exporter.Tenant
+			expClassification.Site = answer.Exporter.Site
+			expClassification.Group = answer.Exporter.Group
 			flowInIfIndex = flow.InIf
-			flowInIfName = answer.InterfaceName
-			flowInIfDescription = answer.InterfaceDescription
-			flowInIfSpeed = uint32(answer.InterfaceSpeed)
-			inIfClassification.Provider = answer.InterfaceProvider
-			inIfClassification.Connectivity = answer.InterfaceConnectivity
-			inIfClassification.Boundary = answer.InterfaceBoundary
+			flowInIfName = answer.Interface.Name
+			flowInIfDescription = answer.Interface.Description
+			flowInIfSpeed = uint32(answer.Interface.Speed)
+			inIfClassification.Provider = answer.Interface.Provider
+			inIfClassification.Connectivity = answer.Interface.Connectivity
+			inIfClassification.Boundary = answer.Interface.Boundary
 			flowInIfVlan = flow.SrcVlan
 		}
 	}
@@ -63,19 +63,19 @@ func (c *Component) enrichFlow(exporterIP netip.Addr, exporterStr string, flow *
 				skip = true
 			}
 		} else {
-			flowExporterName = answer.ExporterName
-			expClassification.Region = answer.ExporterRegion
-			expClassification.Role = answer.ExporterRole
-			expClassification.Tenant = answer.ExporterTenant
-			expClassification.Site = answer.ExporterSite
-			expClassification.Group = answer.ExporterGroup
+			flowExporterName = answer.Exporter.Name
+			expClassification.Region = answer.Exporter.Region
+			expClassification.Role = answer.Exporter.Role
+			expClassification.Tenant = answer.Exporter.Tenant
+			expClassification.Site = answer.Exporter.Site
+			expClassification.Group = answer.Exporter.Group
 			flowOutIfIndex = flow.OutIf
-			flowOutIfName = answer.InterfaceName
-			flowOutIfDescription = answer.InterfaceDescription
-			flowOutIfSpeed = uint32(answer.InterfaceSpeed)
-			outIfClassification.Provider = answer.InterfaceProvider
-			outIfClassification.Connectivity = answer.InterfaceConnectivity
-			outIfClassification.Boundary = answer.InterfaceBoundary
+			flowOutIfName = answer.Interface.Name
+			flowOutIfDescription = answer.Interface.Description
+			flowOutIfSpeed = uint32(answer.Interface.Speed)
+			outIfClassification.Provider = answer.Interface.Provider
+			outIfClassification.Connectivity = answer.Interface.Connectivity
+			outIfClassification.Boundary = answer.Interface.Boundary
 			flowOutIfVlan = flow.DstVlan
 		}
 	}
@@ -228,7 +228,7 @@ func (c *Component) writeExporter(flow *schema.FlowMessage, classification expor
 
 func (c *Component) classifyExporter(t time.Time, ip string, name string, flow *schema.FlowMessage, classification exporterClassification) bool {
 	// we already have the info provided by the metadata component
-	if classification.Group != "" || classification.Role != "" || classification.Site != "" || classification.Region != "" || classification.Tenant != "" {
+	if (classification != exporterClassification{}) {
 		return c.writeExporter(flow, classification)
 	}
 	if len(c.config.ExporterClassifiers) == 0 {
@@ -292,7 +292,7 @@ func (c *Component) classifyInterface(
 	directionIn bool,
 ) bool {
 	// we already have the info provided by the metadata component
-	if classification.Provider != "" || classification.Connectivity != "" || classification.Boundary != schema.InterfaceBoundaryUndefined {
+	if (classification != interfaceClassification{}) {
 		classification.Name = ifName
 		classification.Description = ifDescription
 		return c.writeInterface(fl, classification, directionIn)

--- a/inlet/core/enricher_test.go
+++ b/inlet/core/enricher_test.go
@@ -350,8 +350,8 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")`,
 					schema.ColumnOutIfDescription: "Interface 200",
 					schema.ColumnInIfSpeed:        1000,
 					schema.ColumnOutIfSpeed:       1000,
-					schema.ColumnInIfBoundary:     internalBoundary,
-					schema.ColumnOutIfBoundary:    internalBoundary,
+					schema.ColumnInIfBoundary:     schema.InterfaceBoundaryInternal,
+					schema.ColumnOutIfBoundary:    schema.InterfaceBoundaryInternal,
 				},
 			},
 		}, {
@@ -452,7 +452,50 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")`,
 					schema.ColumnOutIfBoundary:     2, // internal
 				},
 			},
-		}, {
+		},
+		{
+			Name: "use metatada instead of classifier",
+			Configuration: gin.H{
+				"interfaceclassifiers": []string{
+					`ClassifyProvider("Othello")`,
+					`ClassifyConnectivityRegex(Interface.Description, " (1\\d+)$", "P$1") && ClassifyExternal()`,
+					`ClassifyInternal() && ClassifyConnectivity("core")`,
+				},
+			},
+			InputFlow: func() *schema.FlowMessage {
+				return &schema.FlowMessage{
+					SamplingRate:    1000,
+					ExporterAddress: netip.MustParseAddr("::ffff:192.0.2.142"),
+					InIf:            1010,
+					OutIf:           2010,
+				}
+			},
+			OutputFlow: &schema.FlowMessage{
+				SamplingRate:    1000,
+				ExporterAddress: netip.MustParseAddr("::ffff:192.0.2.142"),
+				ProtobufDebug: map[schema.ColumnKey]interface{}{
+					schema.ColumnExporterName:      "192_0_2_142",
+					schema.ColumnExporterGroup:     "metadata group",
+					schema.ColumnExporterRegion:    "metadata region",
+					schema.ColumnExporterRole:      "metadata role",
+					schema.ColumnExporterSite:      "metadata site",
+					schema.ColumnExporterTenant:    "metadata tenant",
+					schema.ColumnInIfName:          "Gi0/0/1010",
+					schema.ColumnOutIfName:         "Gi0/0/2010",
+					schema.ColumnInIfDescription:   "Interface 1010",
+					schema.ColumnOutIfDescription:  "Interface 2010",
+					schema.ColumnInIfSpeed:         1000,
+					schema.ColumnOutIfSpeed:        1000,
+					schema.ColumnInIfConnectivity:  "p1010",
+					schema.ColumnOutIfConnectivity: "metadata connectivity",
+					schema.ColumnInIfProvider:      "othello",
+					schema.ColumnOutIfProvider:     "metadata provider",
+					schema.ColumnInIfBoundary:      schema.InterfaceBoundaryExternal,
+					schema.ColumnOutIfBoundary:     schema.InterfaceBoundaryExternal,
+				},
+			},
+		},
+		{
 			Name:          "use data from routing",
 			Configuration: gin.H{},
 			InputFlow: func() *schema.FlowMessage {

--- a/inlet/metadata/cache.go
+++ b/inlet/metadata/cache.go
@@ -84,15 +84,14 @@ func (sc *metadataCache) Expire(before time.Time) int {
 
 // NeedUpdates returns a map of interface entries that would need to
 // be updated. It relies on last update.
-func (sc *metadataCache) NeedUpdates(before time.Time) map[netip.Addr]map[uint]Interface {
-	result := map[netip.Addr]map[uint]Interface{}
-	for k, v := range sc.cache.ItemsLastUpdatedBefore(before) {
+func (sc *metadataCache) NeedUpdates(before time.Time) map[netip.Addr][]uint {
+	result := map[netip.Addr][]uint{}
+	for k := range sc.cache.ItemsLastUpdatedBefore(before) {
 		interfaces, ok := result[k.ExporterIP]
 		if !ok {
-			interfaces = map[uint]Interface{}
-			result[k.ExporterIP] = interfaces
+			interfaces = []uint{}
 		}
-		interfaces[k.IfIndex] = v.Interface
+		result[k.ExporterIP] = append(interfaces, k.IfIndex)
 	}
 	return result
 }

--- a/inlet/metadata/cache_test.go
+++ b/inlet/metadata/cache_test.go
@@ -78,16 +78,13 @@ func TestSimpleLookup(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-			InterfaceSpeed:       1000,
+
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit", Speed: 1000},
 		})
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{
-		ExporterName:         "localhost",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "Transit",
-		InterfaceSpeed:       1000,
+		Exporter:  provider.Exporter{Name: "localhost"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit", Speed: 1000},
 	})
 	expectCacheLookup(t, sc, "127.0.0.1", 787, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.2", 676, provider.Answer{})
@@ -113,10 +110,8 @@ func TestExpire(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -124,10 +119,8 @@ func TestExpire(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost2",
-			InterfaceName:        "Gi0/0/0/2",
-			InterfaceDescription: "Peering",
-		})
+			Exporter:  provider.Exporter{Name: "localhost2"},
+			Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -135,47 +128,33 @@ func TestExpire(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost3",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "IX",
-		})
+			Exporter:  provider.Exporter{Name: "localhost3"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	now = now.Add(10 * time.Minute)
 	sc.Expire(now.Add(-time.Hour))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{
-		ExporterName:         "localhost",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "Transit",
-	})
+		Exporter:  provider.Exporter{Name: "localhost"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{
-		ExporterName:         "localhost2",
-		InterfaceName:        "Gi0/0/0/2",
-		InterfaceDescription: "Peering",
-	})
+		Exporter:  provider.Exporter{Name: "localhost2"},
+		Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	expectCacheLookup(t, sc, "127.0.0.2", 678, provider.Answer{
-		ExporterName:         "localhost3",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "IX",
-	})
+		Exporter:  provider.Exporter{Name: "localhost3"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	sc.Expire(now.Add(-29 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{
-		ExporterName:         "localhost2",
-		InterfaceName:        "Gi0/0/0/2",
-		InterfaceDescription: "Peering",
-	})
+		Exporter:  provider.Exporter{Name: "localhost2"},
+		Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	expectCacheLookup(t, sc, "127.0.0.2", 678, provider.Answer{
-		ExporterName:         "localhost3",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "IX",
-	})
+		Exporter:  provider.Exporter{Name: "localhost3"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	sc.Expire(now.Add(-19 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.2", 678, provider.Answer{
-		ExporterName:         "localhost3",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "IX",
-	})
+		Exporter:  provider.Exporter{Name: "localhost3"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	sc.Expire(now.Add(-9 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{})
@@ -186,17 +165,13 @@ func TestExpire(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 	sc.Expire(now.Add(-19 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{
-		ExporterName:         "localhost",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "Transit",
-	})
+		Exporter:  provider.Exporter{Name: "localhost"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 
 	gotMetrics := r.GetMetrics("akvorado_inlet_metadata_cache_")
 	expectedMetrics := map[string]string{
@@ -219,10 +194,8 @@ func TestExpireRefresh(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -230,10 +203,8 @@ func TestExpireRefresh(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/2",
-			InterfaceDescription: "Peering",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -241,10 +212,8 @@ func TestExpireRefresh(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost2",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "IX",
-		})
+			Exporter:  provider.Exporter{Name: "localhost2"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	now = now.Add(10 * time.Minute)
 
 	// Refresh first entry
@@ -256,16 +225,12 @@ func TestExpireRefresh(t *testing.T) {
 
 	sc.Expire(now.Add(-29 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{
-		ExporterName:         "localhost",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "Transit",
-	})
+		Exporter:  provider.Exporter{Name: "localhost"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.2", 678, provider.Answer{
-		ExporterName:         "localhost2",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "IX",
-	})
+		Exporter:  provider.Exporter{Name: "localhost2"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 }
 
 func TestNeedUpdates(t *testing.T) {
@@ -277,10 +242,8 @@ func TestNeedUpdates(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -288,10 +251,8 @@ func TestNeedUpdates(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/2",
-			InterfaceDescription: "Peering",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -299,10 +260,8 @@ func TestNeedUpdates(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost2",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "IX",
-		})
+			Exporter:  provider.Exporter{Name: "localhost2"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX"}})
 	now = now.Add(10 * time.Minute)
 	// Refresh
 	sc.Put(now,
@@ -311,10 +270,8 @@ func TestNeedUpdates(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost1",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost1"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 
 	cases := []struct {
@@ -376,10 +333,8 @@ func TestSaveLoad(t *testing.T) {
 			IfIndex:    676,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "Transit",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -387,10 +342,8 @@ func TestSaveLoad(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost",
-			InterfaceName:        "Gi0/0/0/2",
-			InterfaceDescription: "Peering",
-		})
+			Exporter:  provider.Exporter{Name: "localhost"},
+			Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	now = now.Add(10 * time.Minute)
 	sc.Put(now,
 		provider.Query{
@@ -398,10 +351,8 @@ func TestSaveLoad(t *testing.T) {
 			IfIndex:    678,
 		},
 		provider.Answer{
-			ExporterName:         "localhost2",
-			InterfaceName:        "Gi0/0/0/1",
-			InterfaceDescription: "IX",
-			InterfaceSpeed:       1000,
+			Exporter:  provider.Exporter{Name: "localhost2"},
+			Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX", Speed: 1000},
 		})
 
 	target := filepath.Join(t.TempDir(), "cache")
@@ -418,15 +369,11 @@ func TestSaveLoad(t *testing.T) {
 	sc.Expire(now.Add(-29 * time.Minute))
 	expectCacheLookup(t, sc, "127.0.0.1", 676, provider.Answer{})
 	expectCacheLookup(t, sc, "127.0.0.1", 678, provider.Answer{
-		ExporterName:         "localhost",
-		InterfaceName:        "Gi0/0/0/2",
-		InterfaceDescription: "Peering",
-	})
+		Exporter:  provider.Exporter{Name: "localhost"},
+		Interface: provider.Interface{Name: "Gi0/0/0/2", Description: "Peering"}})
 	expectCacheLookup(t, sc, "127.0.0.2", 678, provider.Answer{
-		ExporterName:         "localhost2",
-		InterfaceName:        "Gi0/0/0/1",
-		InterfaceDescription: "IX",
-		InterfaceSpeed:       1000,
+		Exporter:  provider.Exporter{Name: "localhost2"},
+		Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "IX", Speed: 1000},
 	})
 }
 
@@ -466,10 +413,8 @@ func TestConcurrentOperations(t *testing.T) {
 					ExporterIP: netip.MustParseAddr(fmt.Sprintf("::ffff:127.0.0.%d", ip)),
 					IfIndex:    uint(iface),
 				}, provider.Answer{
-					ExporterName:         fmt.Sprintf("localhost%d", ip),
-					InterfaceName:        "Gi0/0/0/1",
-					InterfaceDescription: "Transit",
-				})
+					Exporter:  provider.Exporter{Name: fmt.Sprintf("localhost%d", ip)},
+					Interface: provider.Interface{Name: "Gi0/0/0/1", Description: "Transit"}})
 				select {
 				case <-done:
 					return

--- a/inlet/metadata/provider/root.go
+++ b/inlet/metadata/provider/root.go
@@ -19,7 +19,23 @@ type Interface struct {
 	Speed        uint   `validate:"required"`
 	Provider     string
 	Connectivity string
-	Boundary     string
+	Boundary     schema.InterfaceBoundary
+}
+
+// Exporter describes a router that exports netflow
+type Exporter struct {
+	// Name is the name of the exporter
+	Name string `validate:"required"`
+	// Region is the general location of the exporter, used to set ExporterRegion.
+	Region string
+	// Role is the role of the exporter, used to set ExporterRole.
+	Role string
+	// Tenant is the owner of the exporter, used to set TenantRole.
+	Tenant string
+	// Site is the location os the exporter, used to set TenantSite.
+	Site string
+	// Group is a functional or organisational identifier for the exporter, used to set ExporterGroup.
+	Group string
 }
 
 // Query is the query sent to a provider.
@@ -36,18 +52,8 @@ type BatchQuery struct {
 
 // Answer is the answer received from a provider.
 type Answer struct {
-	ExporterName          string
-	ExporterRegion        string
-	ExporterRole          string
-	ExporterTenant        string
-	ExporterSite          string
-	ExporterGroup         string
-	InterfaceName         string
-	InterfaceDescription  string
-	InterfaceSpeed        uint
-	InterfaceProvider     string
-	InterfaceConnectivity string
-	InterfaceBoundary     schema.InterfaceBoundary
+	Exporter  Exporter
+	Interface Interface
 }
 
 // Update is an update received from a provider.

--- a/inlet/metadata/provider/root.go
+++ b/inlet/metadata/provider/root.go
@@ -9,13 +9,17 @@ import (
 	"net/netip"
 
 	"akvorado/common/reporter"
+	"akvorado/common/schema"
 )
 
 // Interface contains the information about an interface.
 type Interface struct {
-	Name        string `validate:"required"`
-	Description string `validate:"required"`
-	Speed       uint   `validate:"required"`
+	Name         string `validate:"required"`
+	Description  string `validate:"required"`
+	Speed        uint   `validate:"required"`
+	Provider     string
+	Connectivity string
+	Boundary     string
 }
 
 // Query is the query sent to a provider.
@@ -32,8 +36,18 @@ type BatchQuery struct {
 
 // Answer is the answer received from a provider.
 type Answer struct {
-	ExporterName string
-	Interface
+	ExporterName          string
+	ExporterRegion        string
+	ExporterRole          string
+	ExporterTenant        string
+	ExporterSite          string
+	ExporterGroup         string
+	InterfaceName         string
+	InterfaceDescription  string
+	InterfaceSpeed        uint
+	InterfaceProvider     string
+	InterfaceConnectivity string
+	InterfaceBoundary     schema.InterfaceBoundary
 }
 
 // Update is an update received from a provider.

--- a/inlet/metadata/provider/snmp/poller.go
+++ b/inlet/metadata/provider/snmp/poller.go
@@ -185,10 +185,14 @@ func (p *Provider) Poll(ctx context.Context, exporter, agent netip.Addr, port ui
 				IfIndex:    ifIndex,
 			},
 			Answer: provider.Answer{
-				ExporterName:         sysNameVal,
-				InterfaceName:        ifDescrVal,
-				InterfaceDescription: ifAliasVal,
-				InterfaceSpeed:       ifSpeedVal,
+				Exporter: provider.Exporter{
+					Name: sysNameVal,
+				},
+				Interface: provider.Interface{
+					Name:        ifDescrVal,
+					Description: ifAliasVal,
+					Speed:       ifSpeedVal,
+				},
 			},
 		})
 	}

--- a/inlet/metadata/provider/snmp/poller.go
+++ b/inlet/metadata/provider/snmp/poller.go
@@ -152,14 +152,16 @@ func (p *Provider) Poll(ctx context.Context, exporter, agent netip.Addr, port ui
 	}
 	var (
 		sysNameVal string
-		ifDescrVal string
-		ifAliasVal string
-		ifSpeedVal uint
 	)
 	if !processStr(0, "sysname", &sysNameVal) {
 		return errors.New("unable to get sysName")
 	}
 	for idx := 1; idx < len(requests)-2; idx += 3 {
+		var (
+			ifDescrVal string
+			ifAliasVal string
+			ifSpeedVal uint
+		)
 		ifIndex := ifIndexes[(idx-1)/3]
 		ok := true
 		// We do not process results when index is 0 (this can happen for local
@@ -174,13 +176,7 @@ func (p *Provider) Poll(ctx context.Context, exporter, agent netip.Addr, port ui
 		if ifIndex > 0 && !processUint(idx+2, "ifspeed", &ifSpeedVal) {
 			ok = false
 		}
-		var iface provider.Interface
 		if ok {
-			iface = provider.Interface{
-				Name:        ifDescrVal,
-				Description: ifAliasVal,
-				Speed:       ifSpeedVal,
-			}
 			p.metrics.successes.WithLabelValues(exporterStr).Inc()
 		}
 		put(provider.Update{
@@ -189,8 +185,10 @@ func (p *Provider) Poll(ctx context.Context, exporter, agent netip.Addr, port ui
 				IfIndex:    ifIndex,
 			},
 			Answer: provider.Answer{
-				ExporterName: sysNameVal,
-				Interface:    iface,
+				ExporterName:         sysNameVal,
+				InterfaceName:        ifDescrVal,
+				InterfaceDescription: ifAliasVal,
+				InterfaceSpeed:       ifSpeedVal,
 			},
 		})
 	}

--- a/inlet/metadata/provider/snmp/poller_test.go
+++ b/inlet/metadata/provider/snmp/poller_test.go
@@ -209,8 +209,8 @@ func TestPoller(t *testing.T) {
 			})
 			put := func(update provider.Update) {
 				got = append(got, fmt.Sprintf("%s %s %d %s %s %d",
-					update.ExporterIP.Unmap().String(), update.ExporterName,
-					update.IfIndex, update.InterfaceName, update.InterfaceDescription, update.InterfaceSpeed))
+					update.ExporterIP.Unmap().String(), update.Exporter.Name,
+					update.IfIndex, update.Interface.Name, update.Interface.Description, update.Interface.Speed))
 			}
 			p, err := config.New(r, put)
 			if err != nil {

--- a/inlet/metadata/provider/snmp/poller_test.go
+++ b/inlet/metadata/provider/snmp/poller_test.go
@@ -210,7 +210,7 @@ func TestPoller(t *testing.T) {
 			put := func(update provider.Update) {
 				got = append(got, fmt.Sprintf("%s %s %d %s %s %d",
 					update.ExporterIP.Unmap().String(), update.ExporterName,
-					update.IfIndex, update.Name, update.Description, update.Speed))
+					update.IfIndex, update.InterfaceName, update.InterfaceDescription, update.InterfaceSpeed))
 			}
 			p, err := config.New(r, put)
 			if err != nil {
@@ -226,8 +226,8 @@ func TestPoller(t *testing.T) {
 			if diff := helpers.Diff(got, []string{
 				fmt.Sprintf(`%s exporter62 641 Gi0/0/0/0 Transit 10000`, exporterStr),
 				fmt.Sprintf(`%s exporter62 642 Gi0/0/0/1 Peering 20000`, exporterStr),
-				fmt.Sprintf(`%s exporter62 643   0`, exporterStr), // negative cache
-				fmt.Sprintf(`%s exporter62 644   0`, exporterStr), // negative cache
+				fmt.Sprintf(`%s exporter62 643 Gi0/0/0/2  10000`, exporterStr), // no ifAlias
+				fmt.Sprintf(`%s exporter62 644   0`, exporterStr),              // negative cache
 				fmt.Sprintf(`%s exporter62 0   0`, exporterStr),
 			}); diff != "" {
 				t.Fatalf("Poll() (-got, +want):\n%s", diff)

--- a/inlet/metadata/provider/static/config.go
+++ b/inlet/metadata/provider/static/config.go
@@ -28,6 +28,16 @@ type Configuration struct {
 type ExporterConfiguration struct {
 	// Name is the name of the exporter
 	Name string `validate:"required"`
+	// Region is the general location of the exporter, used to set ExporterRegion.
+	Region string
+	// Role is the role of the exporter, used to set ExporterRole.
+	Role string
+	// Tenant is the owner of the exporter, used to set TenantRole.
+	Tenant string
+	// Site is the location os the exporter, used to set TenantSite.
+	Site string
+	// Group is a functional or organisational identifier for the exporter, used to set ExporterGroup.
+	Group string
 	// Default is used if not empty for any unknown ifindexes
 	Default provider.Interface `validate:"omitempty"`
 	// IfIndexes is a map from interface indexes to interfaces

--- a/inlet/metadata/provider/static/config.go
+++ b/inlet/metadata/provider/static/config.go
@@ -26,18 +26,7 @@ type Configuration struct {
 
 // ExporterConfiguration is the interface configuration for an exporter.
 type ExporterConfiguration struct {
-	// Name is the name of the exporter
-	Name string `validate:"required"`
-	// Region is the general location of the exporter, used to set ExporterRegion.
-	Region string
-	// Role is the role of the exporter, used to set ExporterRole.
-	Role string
-	// Tenant is the owner of the exporter, used to set TenantRole.
-	Tenant string
-	// Site is the location os the exporter, used to set TenantSite.
-	Site string
-	// Group is a functional or organisational identifier for the exporter, used to set ExporterGroup.
-	Group string
+	provider.Exporter `mapstructure:",squash" yaml:"inline"`
 	// Default is used if not empty for any unknown ifindexes
 	Default provider.Interface `validate:"omitempty"`
 	// IfIndexes is a map from interface indexes to interfaces

--- a/inlet/metadata/provider/static/config_test.go
+++ b/inlet/metadata/provider/static/config_test.go
@@ -16,7 +16,9 @@ func TestValidation(t *testing.T) {
 	if err := helpers.Validate.Struct(Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"::ffff:203.0.113.0/120": {
-				Name: "something",
+				Exporter: provider.Exporter{
+					Name: "something",
+				},
 				Default: provider.Interface{
 					Name:        "iface1",
 					Description: "description 1",
@@ -31,7 +33,9 @@ func TestValidation(t *testing.T) {
 	if err := helpers.Validate.Struct(Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"::ffff:203.0.113.0/120": {
-				Name: "something",
+				Exporter: provider.Exporter{
+					Name: "something",
+				},
 				Default: provider.Interface{
 					Name:        "",
 					Description: "description 1",
@@ -46,7 +50,9 @@ func TestValidation(t *testing.T) {
 	if err := helpers.Validate.Struct(Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"::ffff:203.0.113.0/120": {
-				Name: "something",
+				Exporter: provider.Exporter{
+					Name: "something",
+				},
 				Default: provider.Interface{
 					Name:        "iface1",
 					Description: "description 1",

--- a/inlet/metadata/provider/static/root.go
+++ b/inlet/metadata/provider/static/root.go
@@ -9,7 +9,6 @@ import (
 	"akvorado/common/helpers"
 	"akvorado/common/remotedatasourcefetcher"
 	"akvorado/common/reporter"
-	"akvorado/common/schema"
 	"akvorado/inlet/metadata/provider"
 
 	"context"
@@ -48,16 +47,6 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 	return p, nil
 }
 
-func (p *Provider) convertBoundary(boundary string) schema.InterfaceBoundary {
-	switch boundary {
-	case "external":
-		return schema.InterfaceBoundaryExternal
-	case "internal":
-		return schema.InterfaceBoundaryInternal
-	}
-	return schema.InterfaceBoundaryUndefined
-}
-
 // Query queries static configuration.
 func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 	exporter, ok := p.exporters.Load().Lookup(query.ExporterIP)
@@ -75,18 +64,8 @@ func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 				IfIndex:    ifIndex,
 			},
 			Answer: provider.Answer{
-				ExporterName:          exporter.Name,
-				ExporterRegion:        exporter.Region,
-				ExporterRole:          exporter.Role,
-				ExporterTenant:        exporter.Tenant,
-				ExporterSite:          exporter.Site,
-				ExporterGroup:         exporter.Group,
-				InterfaceName:         iface.Name,
-				InterfaceDescription:  iface.Description,
-				InterfaceSpeed:        iface.Speed,
-				InterfaceProvider:     iface.Provider,
-				InterfaceConnectivity: iface.Connectivity,
-				InterfaceBoundary:     p.convertBoundary(iface.Boundary),
+				Exporter:  exporter.Exporter,
+				Interface: iface,
 			},
 		})
 	}

--- a/inlet/metadata/provider/static/root.go
+++ b/inlet/metadata/provider/static/root.go
@@ -9,6 +9,7 @@ import (
 	"akvorado/common/helpers"
 	"akvorado/common/remotedatasourcefetcher"
 	"akvorado/common/reporter"
+	"akvorado/common/schema"
 	"akvorado/inlet/metadata/provider"
 
 	"context"
@@ -47,6 +48,16 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 	return p, nil
 }
 
+func (p *Provider) convertBoundary(boundary string) schema.InterfaceBoundary {
+	switch boundary {
+	case "external":
+		return schema.InterfaceBoundaryExternal
+	case "internal":
+		return schema.InterfaceBoundaryInternal
+	}
+	return schema.InterfaceBoundaryUndefined
+}
+
 // Query queries static configuration.
 func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 	exporter, ok := p.exporters.Load().Lookup(query.ExporterIP)
@@ -64,8 +75,18 @@ func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 				IfIndex:    ifIndex,
 			},
 			Answer: provider.Answer{
-				ExporterName: exporter.Name,
-				Interface:    iface,
+				ExporterName:          exporter.Name,
+				ExporterRegion:        exporter.Region,
+				ExporterRole:          exporter.Role,
+				ExporterTenant:        exporter.Tenant,
+				ExporterSite:          exporter.Site,
+				ExporterGroup:         exporter.Group,
+				InterfaceName:         iface.Name,
+				InterfaceDescription:  iface.Description,
+				InterfaceSpeed:        iface.Speed,
+				InterfaceProvider:     iface.Provider,
+				InterfaceConnectivity: iface.Connectivity,
+				InterfaceBoundary:     p.convertBoundary(iface.Boundary),
 			},
 		})
 	}

--- a/inlet/metadata/provider/static/root_test.go
+++ b/inlet/metadata/provider/static/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/reporter"
+	"akvorado/common/schema"
 	"akvorado/inlet/metadata/provider"
 )
 
@@ -46,6 +47,29 @@ func TestStaticProvider(t *testing.T) {
 					},
 				},
 			},
+			"2001:db8:3::/48": {
+				Name:   "default with metadata",
+				Region: "eu",
+				Role:   "peering",
+				Tenant: "mine",
+				Site:   "par",
+				Group:  "blue",
+				Default: provider.Interface{
+					Name:        "Default0",
+					Description: "Default interface",
+					Speed:       1000,
+				},
+				IfIndexes: map[uint]provider.Interface{
+					10: {
+						Name:         "Gi10",
+						Description:  "10th interface",
+						Speed:        1000,
+						Provider:     "transit101",
+						Connectivity: "transit",
+						Boundary:     "external",
+					},
+				},
+			},
 		}),
 	}
 
@@ -62,6 +86,10 @@ func TestStaticProvider(t *testing.T) {
 	p.Query(context.Background(), provider.BatchQuery{
 		ExporterIP: netip.MustParseAddr("2001:db8:2::10"),
 		IfIndexes:  []uint{9, 10, 11},
+	})
+	p.Query(context.Background(), provider.BatchQuery{
+		ExporterIP: netip.MustParseAddr("2001:db8:3::10"),
+		IfIndexes:  []uint{10},
 	})
 
 	expected := []provider.Update{
@@ -80,12 +108,10 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    10,
 			},
 			Answer: provider.Answer{
-				ExporterName: "nodefault",
-				Interface: provider.Interface{
-					Name:        "Gi10",
-					Description: "10th interface",
-					Speed:       1000,
-				},
+				ExporterName:         "nodefault",
+				InterfaceName:        "Gi10",
+				InterfaceDescription: "10th interface",
+				InterfaceSpeed:       1000,
 			},
 		},
 		{
@@ -94,12 +120,10 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    11,
 			},
 			Answer: provider.Answer{
-				ExporterName: "nodefault",
-				Interface: provider.Interface{
-					Name:        "Gi11",
-					Description: "11th interface",
-					Speed:       1000,
-				},
+				ExporterName:         "nodefault",
+				InterfaceName:        "Gi11",
+				InterfaceDescription: "11th interface",
+				InterfaceSpeed:       1000,
 			},
 		},
 		{
@@ -108,12 +132,10 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    9,
 			},
 			Answer: provider.Answer{
-				ExporterName: "default",
-				Interface: provider.Interface{
-					Name:        "Default0",
-					Description: "Default interface",
-					Speed:       1000,
-				},
+				ExporterName:         "default",
+				InterfaceName:        "Default0",
+				InterfaceDescription: "Default interface",
+				InterfaceSpeed:       1000,
 			},
 		},
 		{
@@ -122,12 +144,10 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    10,
 			},
 			Answer: provider.Answer{
-				ExporterName: "default",
-				Interface: provider.Interface{
-					Name:        "Gi10",
-					Description: "10th interface",
-					Speed:       1000,
-				},
+				ExporterName:         "default",
+				InterfaceName:        "Gi10",
+				InterfaceDescription: "10th interface",
+				InterfaceSpeed:       1000,
 			},
 		},
 		{
@@ -136,12 +156,30 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    11,
 			},
 			Answer: provider.Answer{
-				ExporterName: "default",
-				Interface: provider.Interface{
-					Name:        "Default0",
-					Description: "Default interface",
-					Speed:       1000,
-				},
+				ExporterName:         "default",
+				InterfaceName:        "Default0",
+				InterfaceDescription: "Default interface",
+				InterfaceSpeed:       1000,
+			},
+		},
+		{
+			Query: provider.Query{
+				ExporterIP: netip.MustParseAddr("2001:db8:3::10"),
+				IfIndex:    10,
+			},
+			Answer: provider.Answer{
+				ExporterName:          "default with metadata",
+				ExporterRegion:        "eu",
+				ExporterRole:          "peering",
+				ExporterTenant:        "mine",
+				ExporterSite:          "par",
+				ExporterGroup:         "blue",
+				InterfaceName:         "Gi10",
+				InterfaceDescription:  "10th interface",
+				InterfaceSpeed:        1000,
+				InterfaceProvider:     "transit101",
+				InterfaceConnectivity: "transit",
+				InterfaceBoundary:     schema.InterfaceBoundaryExternal,
 			},
 		},
 	}

--- a/inlet/metadata/provider/static/root_test.go
+++ b/inlet/metadata/provider/static/root_test.go
@@ -18,7 +18,9 @@ func TestStaticProvider(t *testing.T) {
 	config := Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"2001:db8:1::/48": {
-				Name: "nodefault",
+				Exporter: provider.Exporter{
+					Name: "nodefault",
+				},
 				IfIndexes: map[uint]provider.Interface{
 					10: {
 						Name:        "Gi10",
@@ -33,7 +35,9 @@ func TestStaticProvider(t *testing.T) {
 				},
 			},
 			"2001:db8:2::/48": {
-				Name: "default",
+				Exporter: provider.Exporter{
+					Name: "default",
+				},
 				Default: provider.Interface{
 					Name:        "Default0",
 					Description: "Default interface",
@@ -48,12 +52,14 @@ func TestStaticProvider(t *testing.T) {
 				},
 			},
 			"2001:db8:3::/48": {
-				Name:   "default with metadata",
-				Region: "eu",
-				Role:   "peering",
-				Tenant: "mine",
-				Site:   "par",
-				Group:  "blue",
+				Exporter: provider.Exporter{
+					Name:   "default with metadata",
+					Region: "eu",
+					Role:   "peering",
+					Tenant: "mine",
+					Site:   "par",
+					Group:  "blue",
+				},
 				Default: provider.Interface{
 					Name:        "Default0",
 					Description: "Default interface",
@@ -66,7 +72,7 @@ func TestStaticProvider(t *testing.T) {
 						Speed:        1000,
 						Provider:     "transit101",
 						Connectivity: "transit",
-						Boundary:     "external",
+						Boundary:     schema.InterfaceBoundaryExternal,
 					},
 				},
 			},
@@ -99,7 +105,9 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    9,
 			},
 			Answer: provider.Answer{
-				ExporterName: "nodefault",
+				Exporter: provider.Exporter{
+					Name: "nodefault",
+				},
 			},
 		},
 		{
@@ -108,10 +116,14 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    10,
 			},
 			Answer: provider.Answer{
-				ExporterName:         "nodefault",
-				InterfaceName:        "Gi10",
-				InterfaceDescription: "10th interface",
-				InterfaceSpeed:       1000,
+				Exporter: provider.Exporter{
+					Name: "nodefault",
+				},
+				Interface: provider.Interface{
+					Name:        "Gi10",
+					Description: "10th interface",
+					Speed:       1000,
+				},
 			},
 		},
 		{
@@ -120,10 +132,14 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    11,
 			},
 			Answer: provider.Answer{
-				ExporterName:         "nodefault",
-				InterfaceName:        "Gi11",
-				InterfaceDescription: "11th interface",
-				InterfaceSpeed:       1000,
+				Exporter: provider.Exporter{
+					Name: "nodefault",
+				},
+				Interface: provider.Interface{
+					Name:        "Gi11",
+					Description: "11th interface",
+					Speed:       1000,
+				},
 			},
 		},
 		{
@@ -132,10 +148,14 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    9,
 			},
 			Answer: provider.Answer{
-				ExporterName:         "default",
-				InterfaceName:        "Default0",
-				InterfaceDescription: "Default interface",
-				InterfaceSpeed:       1000,
+				Exporter: provider.Exporter{
+					Name: "default",
+				},
+				Interface: provider.Interface{
+					Name:        "Default0",
+					Description: "Default interface",
+					Speed:       1000,
+				},
 			},
 		},
 		{
@@ -144,10 +164,14 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    10,
 			},
 			Answer: provider.Answer{
-				ExporterName:         "default",
-				InterfaceName:        "Gi10",
-				InterfaceDescription: "10th interface",
-				InterfaceSpeed:       1000,
+				Exporter: provider.Exporter{
+					Name: "default",
+				},
+				Interface: provider.Interface{
+					Name:        "Gi10",
+					Description: "10th interface",
+					Speed:       1000,
+				},
 			},
 		},
 		{
@@ -156,10 +180,14 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    11,
 			},
 			Answer: provider.Answer{
-				ExporterName:         "default",
-				InterfaceName:        "Default0",
-				InterfaceDescription: "Default interface",
-				InterfaceSpeed:       1000,
+				Exporter: provider.Exporter{
+					Name: "default",
+				},
+				Interface: provider.Interface{
+					Name:        "Default0",
+					Description: "Default interface",
+					Speed:       1000,
+				},
 			},
 		},
 		{
@@ -168,18 +196,22 @@ func TestStaticProvider(t *testing.T) {
 				IfIndex:    10,
 			},
 			Answer: provider.Answer{
-				ExporterName:          "default with metadata",
-				ExporterRegion:        "eu",
-				ExporterRole:          "peering",
-				ExporterTenant:        "mine",
-				ExporterSite:          "par",
-				ExporterGroup:         "blue",
-				InterfaceName:         "Gi10",
-				InterfaceDescription:  "10th interface",
-				InterfaceSpeed:        1000,
-				InterfaceProvider:     "transit101",
-				InterfaceConnectivity: "transit",
-				InterfaceBoundary:     schema.InterfaceBoundaryExternal,
+				Exporter: provider.Exporter{
+					Name:   "default with metadata",
+					Region: "eu",
+					Role:   "peering",
+					Tenant: "mine",
+					Site:   "par",
+					Group:  "blue",
+				},
+				Interface: provider.Interface{
+					Name:         "Gi10",
+					Description:  "10th interface",
+					Speed:        1000,
+					Provider:     "transit101",
+					Connectivity: "transit",
+					Boundary:     schema.InterfaceBoundaryExternal,
+				},
 			},
 		},
 	}

--- a/inlet/metadata/provider/static/source.go
+++ b/inlet/metadata/provider/static/source.go
@@ -10,8 +10,18 @@ import (
 
 type exporterInfo struct {
 	ExporterSubnet string
-
+	// Name is the hostname of the exporter, used to set ExporterName.
 	Name string `validate:"required"`
+	// Region is the general location of the exporter, used to set ExporterRegion.
+	Region string
+	// Role is the role of the exporter, used to set ExporterRole.
+	Role string
+	// Tenant is the owner of the exporter, used to set TenantRole.
+	Tenant string
+	// Site is the location os the exporter, used to set TenantSite.
+	Site string
+	// Group is a functional or organisational identifier for the exporter, used to set ExporterGroup.
+	Group string
 	// Default is used if not empty for any unknown ifindexes
 	Default provider.Interface `validate:"omitempty"`
 	// IfIndexes is a map from interface indexes to interfaces
@@ -31,6 +41,11 @@ func (i exporterInfo) toExporterConfiguration() ExporterConfiguration {
 
 	return ExporterConfiguration{
 		Name:      i.Name,
+		Region:    i.Region,
+		Role:      i.Role,
+		Tenant:    i.Tenant,
+		Site:      i.Site,
+		Group:     i.Group,
 		Default:   i.Default,
 		IfIndexes: ifindexMap,
 	}

--- a/inlet/metadata/provider/static/source.go
+++ b/inlet/metadata/provider/static/source.go
@@ -9,19 +9,8 @@ import (
 )
 
 type exporterInfo struct {
-	ExporterSubnet string
-	// Name is the hostname of the exporter, used to set ExporterName.
-	Name string `validate:"required"`
-	// Region is the general location of the exporter, used to set ExporterRegion.
-	Region string
-	// Role is the role of the exporter, used to set ExporterRole.
-	Role string
-	// Tenant is the owner of the exporter, used to set TenantRole.
-	Tenant string
-	// Site is the location os the exporter, used to set TenantSite.
-	Site string
-	// Group is a functional or organisational identifier for the exporter, used to set ExporterGroup.
-	Group string
+	provider.Exporter `mapstructure:",squash" yaml:",inline"`
+	ExporterSubnet    string
 	// Default is used if not empty for any unknown ifindexes
 	Default provider.Interface `validate:"omitempty"`
 	// IfIndexes is a map from interface indexes to interfaces
@@ -40,12 +29,7 @@ func (i exporterInfo) toExporterConfiguration() ExporterConfiguration {
 	}
 
 	return ExporterConfiguration{
-		Name:      i.Name,
-		Region:    i.Region,
-		Role:      i.Role,
-		Tenant:    i.Tenant,
-		Site:      i.Site,
-		Group:     i.Group,
+		Exporter:  i.Exporter,
 		Default:   i.Default,
 		IfIndexes: ifindexMap,
 	}
@@ -67,8 +51,10 @@ func (p *Provider) initStaticExporters() {
 		staticExporters = append(
 			staticExporters,
 			exporterInfo{
+				Exporter: provider.Exporter{
+					Name: config.Name,
+				},
 				ExporterSubnet: subnet,
-				Name:           config.Name,
 				Default:        config.Default,
 				Interfaces:     interfaces,
 			},

--- a/inlet/metadata/provider/static/source_test.go
+++ b/inlet/metadata/provider/static/source_test.go
@@ -20,7 +20,9 @@ func TestInitStaticExporters(t *testing.T) {
 	conf := Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"::ffff:203.0.113.0/120": {
-				Name: "something",
+				Exporter: provider.Exporter{
+					Name: "something",
+				},
 				Default: provider.Interface{
 					Name:        "iface1",
 					Description: "description 1",
@@ -46,7 +48,9 @@ func TestInitStaticExporters(t *testing.T) {
 	expected["static"] = []exporterInfo{
 		{
 			ExporterSubnet: "203.0.113.0/24",
-			Name:           "something",
+			Exporter: provider.Exporter{
+				Name: "something",
+			},
 			Default: provider.Interface{
 				Name:        "iface1",
 				Description: "description 1",
@@ -151,7 +155,9 @@ func TestRemoteExporterSources(t *testing.T) {
 	config := Configuration{
 		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
 			"2001:db8:1::/48": {
-				Name: "nodefault",
+				Exporter: provider.Exporter{
+					Name: "nodefault",
+				},
 				IfIndexes: map[uint]provider.Interface{
 					10: {
 						Name:        "Gi10",
@@ -201,12 +207,14 @@ func TestRemoteExporterSources(t *testing.T) {
 			IfIndex:    9,
 		},
 		Answer: provider.Answer{
-			ExporterName: "nodefault",
+			Exporter: provider.Exporter{
+				Name: "nodefault",
+			},
 		},
 	})
 
 	if diff := helpers.Diff(got, expected); diff != "" {
-		t.Fatalf("static provider (-got, +want):\n%s", diff)
+		t.Fatalf("static provider - before remote source load (-got, +want):\n%s", diff)
 	}
 
 	close(ready)
@@ -232,14 +240,18 @@ func TestRemoteExporterSources(t *testing.T) {
 			IfIndex:    1,
 		},
 		Answer: provider.Answer{
-			ExporterName:         "exporter1",
-			InterfaceName:        "iface1",
-			InterfaceDescription: "foo:desc1",
-			InterfaceSpeed:       1000,
+			Exporter: provider.Exporter{
+				Name: "exporter1",
+			},
+			Interface: provider.Interface{
+				Name:        "iface1",
+				Description: "foo:desc1",
+				Speed:       1000,
+			},
 		},
 	})
 
 	if diff := helpers.Diff(got, expected); diff != "" {
-		t.Fatalf("static provider (-got, +want):\n%s", diff)
+		t.Fatalf("static provider  - after remote source load(-got, +want):\n%s", diff)
 	}
 }

--- a/inlet/metadata/provider/static/source_test.go
+++ b/inlet/metadata/provider/static/source_test.go
@@ -232,12 +232,10 @@ func TestRemoteExporterSources(t *testing.T) {
 			IfIndex:    1,
 		},
 		Answer: provider.Answer{
-			ExporterName: "exporter1",
-			Interface: provider.Interface{
-				Name:        "iface1",
-				Description: "foo:desc1",
-				Speed:       1000,
-			},
+			ExporterName:         "exporter1",
+			InterfaceName:        "iface1",
+			InterfaceDescription: "foo:desc1",
+			InterfaceSpeed:       1000,
 		},
 	})
 

--- a/inlet/metadata/root_test.go
+++ b/inlet/metadata/root_test.go
@@ -35,13 +35,19 @@ func TestLookup(t *testing.T) {
 	expectMockLookup(t, c, "127.0.0.1", 999, provider.Answer{})
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName:         "127_0_0_1",
-		InterfaceName:        "Gi0/0/765",
-		InterfaceDescription: "Interface 765",
-		InterfaceSpeed:       1000,
+		Exporter: provider.Exporter{
+			Name: "127_0_0_1",
+		},
+
+		Interface: provider.Interface{Name: "Gi0/0/765",
+			Description: "Interface 765",
+			Speed:       1000,
+		},
 	})
 	expectMockLookup(t, c, "127.0.0.1", 999, provider.Answer{
-		ExporterName: "127_0_0_1",
+		Exporter: provider.Exporter{
+			Name: "127_0_0_1",
+		},
 	})
 }
 
@@ -56,10 +62,14 @@ func TestComponentSaveLoad(t *testing.T) {
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 		time.Sleep(30 * time.Millisecond)
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-			ExporterName:         "127_0_0_1",
-			InterfaceName:        "Gi0/0/765",
-			InterfaceDescription: "Interface 765",
-			InterfaceSpeed:       1000,
+			Exporter: provider.Exporter{
+				Name: "127_0_0_1",
+			},
+
+			Interface: provider.Interface{Name: "Gi0/0/765",
+				Description: "Interface 765",
+				Speed:       1000,
+			},
 		})
 	})
 
@@ -67,10 +77,14 @@ func TestComponentSaveLoad(t *testing.T) {
 		r := reporter.NewMock(t)
 		c := NewMock(t, r, configuration, Dependencies{Daemon: daemon.NewMock(t)})
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-			ExporterName:         "127_0_0_1",
-			InterfaceName:        "Gi0/0/765",
-			InterfaceDescription: "Interface 765",
-			InterfaceSpeed:       1000,
+			Exporter: provider.Exporter{
+				Name: "127_0_0_1",
+			},
+			Interface: provider.Interface{
+				Name:        "Gi0/0/765",
+				Description: "Interface 765",
+				Speed:       1000,
+			},
 		})
 	})
 }
@@ -85,10 +99,15 @@ func TestAutoRefresh(t *testing.T) {
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName:         "127_0_0_1",
-		InterfaceName:        "Gi0/0/765",
-		InterfaceDescription: "Interface 765",
-		InterfaceSpeed:       1000,
+		Exporter: provider.Exporter{
+			Name: "127_0_0_1",
+		},
+
+		Interface: provider.Interface{
+			Name:        "Gi0/0/765",
+			Description: "Interface 765",
+			Speed:       1000,
+		},
 	})
 
 	// Keep it in the cache!
@@ -103,10 +122,14 @@ func TestAutoRefresh(t *testing.T) {
 	mockClock.Add(2 * time.Minute)
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName:         "127_0_0_1",
-		InterfaceName:        "Gi0/0/765",
-		InterfaceDescription: "Interface 765",
-		InterfaceSpeed:       1000,
+		Exporter: provider.Exporter{
+			Name: "127_0_0_1",
+		},
+
+		Interface: provider.Interface{Name: "Gi0/0/765",
+			Description: "Interface 765",
+			Speed:       1000,
+		},
 	})
 
 	gotMetrics := r.GetMetrics("akvorado_inlet_metadata_cache_")

--- a/inlet/metadata/root_test.go
+++ b/inlet/metadata/root_test.go
@@ -22,8 +22,7 @@ import (
 func expectMockLookup(t *testing.T, c *Component, exporter string, ifIndex uint, expected provider.Answer) {
 	t.Helper()
 	ip := netip.AddrFrom16(netip.MustParseAddr(exporter).As16())
-	gotExporterName, gotInterface, _ := c.Lookup(time.Now(), ip, ifIndex)
-	got := provider.Answer{ExporterName: gotExporterName, Interface: gotInterface}
+	got, _ := c.Lookup(time.Now(), ip, ifIndex)
 	if diff := helpers.Diff(got, expected); diff != "" {
 		t.Fatalf("Lookup() (-got, +want):\n%s", diff)
 	}
@@ -36,8 +35,10 @@ func TestLookup(t *testing.T) {
 	expectMockLookup(t, c, "127.0.0.1", 999, provider.Answer{})
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName: "127_0_0_1",
-		Interface:    Interface{Name: "Gi0/0/765", Description: "Interface 765", Speed: 1000},
+		ExporterName:         "127_0_0_1",
+		InterfaceName:        "Gi0/0/765",
+		InterfaceDescription: "Interface 765",
+		InterfaceSpeed:       1000,
 	})
 	expectMockLookup(t, c, "127.0.0.1", 999, provider.Answer{
 		ExporterName: "127_0_0_1",
@@ -55,8 +56,10 @@ func TestComponentSaveLoad(t *testing.T) {
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 		time.Sleep(30 * time.Millisecond)
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-			ExporterName: "127_0_0_1",
-			Interface:    Interface{Name: "Gi0/0/765", Description: "Interface 765", Speed: 1000},
+			ExporterName:         "127_0_0_1",
+			InterfaceName:        "Gi0/0/765",
+			InterfaceDescription: "Interface 765",
+			InterfaceSpeed:       1000,
 		})
 	})
 
@@ -64,8 +67,10 @@ func TestComponentSaveLoad(t *testing.T) {
 		r := reporter.NewMock(t)
 		c := NewMock(t, r, configuration, Dependencies{Daemon: daemon.NewMock(t)})
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-			ExporterName: "127_0_0_1",
-			Interface:    Interface{Name: "Gi0/0/765", Description: "Interface 765", Speed: 1000},
+			ExporterName:         "127_0_0_1",
+			InterfaceName:        "Gi0/0/765",
+			InterfaceDescription: "Interface 765",
+			InterfaceSpeed:       1000,
 		})
 	})
 }
@@ -80,8 +85,10 @@ func TestAutoRefresh(t *testing.T) {
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName: "127_0_0_1",
-		Interface:    Interface{Name: "Gi0/0/765", Description: "Interface 765", Speed: 1000},
+		ExporterName:         "127_0_0_1",
+		InterfaceName:        "Gi0/0/765",
+		InterfaceDescription: "Interface 765",
+		InterfaceSpeed:       1000,
 	})
 
 	// Keep it in the cache!
@@ -96,8 +103,10 @@ func TestAutoRefresh(t *testing.T) {
 	mockClock.Add(2 * time.Minute)
 	time.Sleep(30 * time.Millisecond)
 	expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{
-		ExporterName: "127_0_0_1",
-		Interface:    Interface{Name: "Gi0/0/765", Description: "Interface 765", Speed: 1000},
+		ExporterName:         "127_0_0_1",
+		InterfaceName:        "Gi0/0/765",
+		InterfaceDescription: "Interface 765",
+		InterfaceSpeed:       1000,
 	})
 
 	gotMetrics := r.GetMetrics("akvorado_inlet_metadata_cache_")

--- a/inlet/metadata/tests.go
+++ b/inlet/metadata/tests.go
@@ -26,32 +26,34 @@ type mockProvider struct {
 func (mp mockProvider) Query(_ context.Context, query provider.BatchQuery) error {
 	for _, ifIndex := range query.IfIndexes {
 		answer := provider.Answer{
-			ExporterName: strings.ReplaceAll(query.ExporterIP.Unmap().String(), ".", "_"),
+			Exporter: provider.Exporter{
+				Name: strings.ReplaceAll(query.ExporterIP.Unmap().String(), ".", "_"),
+			},
 		}
 		if ifIndex != 999 {
-			answer.InterfaceName = fmt.Sprintf("Gi0/0/%d", ifIndex)
-			answer.InterfaceDescription = fmt.Sprintf("Interface %d", ifIndex)
-			answer.InterfaceSpeed = 1000
+			answer.Interface.Name = fmt.Sprintf("Gi0/0/%d", ifIndex)
+			answer.Interface.Description = fmt.Sprintf("Interface %d", ifIndex)
+			answer.Interface.Speed = 1000
 		}
 		// in iface with  metadata (overriden by out iface)
 		if ifIndex == 1010 {
-			answer.ExporterGroup = "metadata group"
-			answer.ExporterRegion = "metadata region"
-			answer.ExporterRole = "metadata role"
-			answer.ExporterSite = "metadata site"
-			answer.ExporterTenant = "metadata tenant"
+			answer.Exporter.Group = "metadata group"
+			answer.Exporter.Region = "metadata region"
+			answer.Exporter.Role = "metadata role"
+			answer.Exporter.Site = "metadata site"
+			answer.Exporter.Tenant = "metadata tenant"
 		}
 
 		// out iface with metadata
 		if ifIndex == 2010 {
-			answer.InterfaceBoundary = schema.InterfaceBoundaryExternal
-			answer.InterfaceConnectivity = "metadata connectivity"
-			answer.InterfaceProvider = "metadata provider"
-			answer.ExporterGroup = "metadata group"
-			answer.ExporterRegion = "metadata region"
-			answer.ExporterRole = "metadata role"
-			answer.ExporterSite = "metadata site"
-			answer.ExporterTenant = "metadata tenant"
+			answer.Interface.Boundary = schema.InterfaceBoundaryExternal
+			answer.Interface.Connectivity = "metadata connectivity"
+			answer.Interface.Provider = "metadata provider"
+			answer.Exporter.Group = "metadata group"
+			answer.Exporter.Region = "metadata region"
+			answer.Exporter.Role = "metadata role"
+			answer.Exporter.Site = "metadata site"
+			answer.Exporter.Tenant = "metadata tenant"
 		}
 		mp.put(provider.Update{Query: provider.Query{ExporterIP: query.ExporterIP, IfIndex: ifIndex}, Answer: answer})
 	}

--- a/inlet/metadata/tests.go
+++ b/inlet/metadata/tests.go
@@ -13,6 +13,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/reporter"
+	"akvorado/common/schema"
 	"akvorado/inlet/metadata/provider"
 )
 
@@ -28,11 +29,29 @@ func (mp mockProvider) Query(_ context.Context, query provider.BatchQuery) error
 			ExporterName: strings.ReplaceAll(query.ExporterIP.Unmap().String(), ".", "_"),
 		}
 		if ifIndex != 999 {
-			answer.Interface = Interface{
-				Name:        fmt.Sprintf("Gi0/0/%d", ifIndex),
-				Description: fmt.Sprintf("Interface %d", ifIndex),
-				Speed:       1000,
-			}
+			answer.InterfaceName = fmt.Sprintf("Gi0/0/%d", ifIndex)
+			answer.InterfaceDescription = fmt.Sprintf("Interface %d", ifIndex)
+			answer.InterfaceSpeed = 1000
+		}
+		// in iface with  metadata (overriden by out iface)
+		if ifIndex == 1010 {
+			answer.ExporterGroup = "metadata group"
+			answer.ExporterRegion = "metadata region"
+			answer.ExporterRole = "metadata role"
+			answer.ExporterSite = "metadata site"
+			answer.ExporterTenant = "metadata tenant"
+		}
+
+		// out iface with metadata
+		if ifIndex == 2010 {
+			answer.InterfaceBoundary = schema.InterfaceBoundaryExternal
+			answer.InterfaceConnectivity = "metadata connectivity"
+			answer.InterfaceProvider = "metadata provider"
+			answer.ExporterGroup = "metadata group"
+			answer.ExporterRegion = "metadata region"
+			answer.ExporterRole = "metadata role"
+			answer.ExporterSite = "metadata site"
+			answer.ExporterTenant = "metadata tenant"
 		}
 		mp.put(provider.Update{Query: provider.Query{ExporterIP: query.ExporterIP, IfIndex: ifIndex}, Answer: answer})
 	}


### PR DESCRIPTION
Sometime exporter name and interface description do not carry all the required information for classification and metadata extraction, supporting a way to provide the data through metadata compoenent (only static seems to make sense at this points) enables more use-cases.