### PR TITLE
build: enable loopvar experiment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ Q = $(if $(filter 1,$V),,@)
 M = $(shell if [ "$$(tput colors 2> /dev/null || echo 0)" -ge 8 ]; then printf "\033[34;1m▶\033[0m"; else printf "▶"; fi)
 
 export CGO_ENABLED=0
+export GOEXPERIMENT=loopvar
 
 GENERATED_JS = \
 	console/frontend/node_modules

--- a/common/remotedatasourcefetcher/root.go
+++ b/common/remotedatasourcefetcher/root.go
@@ -137,8 +137,6 @@ func (c *Component[T]) Start() error {
 		if source.Transform.Query == nil {
 			source.Transform.Query, _ = gojq.Parse(".")
 		}
-		name := name
-		source := source
 
 		c.t.Go(func() error {
 			c.metrics.remoteDataSourceCount.WithLabelValues(c.dataType, name).Set(0)

--- a/orchestrator/clickhouse/http.go
+++ b/orchestrator/clickhouse/http.go
@@ -107,8 +107,6 @@ func (c *Component) registerHTTPHandlers() error {
 
 	// Add handler for custom dicts
 	for name, dict := range c.d.Schema.GetCustomDictConfig() {
-		name := name
-		dict := dict
 		c.d.HTTP.AddHandler(fmt.Sprintf("/api/v0/orchestrator/clickhouse/custom_dict_%s.csv", name), http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			file, err := os.ReadFile(dict.Source)
 			if err != nil {

--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -86,8 +86,6 @@ func (c *Component) migrateDatabase() error {
 	// Prepare custom dictionary migrations
 	var dictMigrations []func() error
 	for k, v := range c.d.Schema.GetCustomDictConfig() {
-		k := k
-		v := v
 		var schemaStr []string
 		var keys []string
 		for _, a := range v.Keys {


### PR DESCRIPTION
This is enabled by default once we switch to Go 1.22 (in go.mod). See https://tip.golang.org/wiki/LoopvarExperiment