### PR TITLE
inlet/metadata: allow definition of multiple providers

### DIFF
--- a/cmd/inlet.go
+++ b/cmd/inlet.go
@@ -52,7 +52,7 @@ func (c *InletConfiguration) Reset() {
 		Core:      core.DefaultConfiguration(),
 		Schema:    schema.DefaultConfiguration(),
 	}
-	c.Metadata.Provider.Config = snmp.DefaultConfiguration()
+	c.Metadata.Providers = []metadata.ProviderConfiguration{{Config: snmp.DefaultConfiguration()}}
 	c.Routing.Provider.Config = bmp.DefaultConfiguration()
 }
 

--- a/cmd/testdata/configurations/gnmi/expected.yaml
+++ b/cmd/testdata/configurations/gnmi/expected.yaml
@@ -1,27 +1,27 @@
 ---
 paths:
-  inlet.0.metadata.provider:
-    type: gnmi
-    timeout: "1s"
-    minimalrefreshinterval: "1m0s"
-    ports:
-      ::/0: 9339
-    targets: {}
-    settarget: {}
-    authenticationparameters: {}
-    models:
-      - name: custom
-        ifindexpaths:
-          - /some/path
-        ifdescriptionpaths:
-          - /some/other/path
-        ifnamekeys: []
-        ifnamepaths:
-          - /something
-        ifspeedpaths:
-          - path: /path1
-            unit: mbps
-          - path: /path2
-            unit: ethernet
-        systemnamepaths:
-          - /another/path
+  inlet.0.metadata.providers:
+    - type: gnmi
+      timeout: "1s"
+      minimalrefreshinterval: "1m0s"
+      ports:
+        ::/0: 9339
+      targets: {}
+      settarget: {}
+      authenticationparameters: {}
+      models:
+        - name: custom
+          ifindexpaths:
+            - /some/path
+          ifdescriptionpaths:
+            - /some/other/path
+          ifnamekeys: []
+          ifnamepaths:
+            - /something
+          ifspeedpaths:
+            - path: /path1
+              unit: mbps
+            - path: /path2
+              unit: ethernet
+          systemnamepaths:
+            - /another/path

--- a/cmd/testdata/configurations/gnmi/in.yaml
+++ b/cmd/testdata/configurations/gnmi/in.yaml
@@ -1,16 +1,16 @@
 ---
 inlet:
   metadata:
-    provider:
-      type: gnmi
-      models:
-        - name: custom
-          if-index-paths: /some/path
-          if-description-paths: /some/other/path
-          if-name-paths: /something
-          if-speed-paths:
-            - path: /path1
-              unit: mbps
-            - path: /path2
-              unit: ethernet
-          system-name-paths: /another/path
+    providers:
+      - type: gnmi
+        models:
+          - name: custom
+            if-index-paths: /some/path
+            if-description-paths: /some/other/path
+            if-name-paths: /something
+            if-speed-paths:
+              - path: /path1
+                unit: mbps
+              - path: /path2
+                unit: ethernet
+            system-name-paths: /another/path

--- a/cmd/testdata/configurations/snmp-communities-migration/expected.yaml
+++ b/cmd/testdata/configurations/snmp-communities-migration/expected.yaml
@@ -1,13 +1,13 @@
 ---
 paths:
-  inlet.0.metadata.provider:
-    type: snmp
-    pollerretries: 1
-    pollertimeout: 1s
-    communities:
-      ::/0: [yopla]
-      203.0.113.0/24: [yopli]
-    securityparameters: {}
-    agents: {}
-    ports:
-      ::/0: 161
+  inlet.0.metadata.providers:
+    - type: snmp
+      pollerretries: 1
+      pollertimeout: 1s
+      communities:
+        ::/0: [yopla]
+        203.0.113.0/24: [yopli]
+      securityparameters: {}
+      agents: {}
+      ports:
+        ::/0: 161

--- a/cmd/testdata/configurations/snmp-ports/expected.yaml
+++ b/cmd/testdata/configurations/snmp-ports/expected.yaml
@@ -1,4 +1,4 @@
 ---
 paths:
-  inlet.0.metadata.provider.ports:
+  inlet.0.metadata.providers.0.ports:
     ::/0: 1611

--- a/cmd/testdata/configurations/snmp-to-metadata/expected.yaml
+++ b/cmd/testdata/configurations/snmp-to-metadata/expected.yaml
@@ -7,14 +7,14 @@ paths:
     cacherefresh: 30m0s
     cachecheckinterval: 2m0s
     cachepersistfile: ""
-    provider:
-      type: snmp
-      pollerretries: 3
-      pollertimeout: 1s
-      agents:
-        192.0.2.10: 192.0.2.11
-      communities:
-        ::/0: [private]
-      ports:
-        ::/0: 161
-      securityparameters: {}
+    providers:
+      - type: snmp
+        pollerretries: 3
+        pollertimeout: 1s
+        agents:
+          192.0.2.10: 192.0.2.11
+        communities:
+          ::/0: [private]
+        ports:
+          ::/0: 161
+        securityparameters: {}

--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -379,14 +379,17 @@ providers available to poll metadata. The following keys are accepted:
   read them back on startup
 - `workers` tell how many workers to spawn to fetch metadata.
 - `max-batch-requests` define how many requests can be batched together
-- `provider` defines the provider configuration
+- `providers` defines the provider configurations
 
 As flows missing interface information are discarded, persisting the
 cache is useful to quickly be able to handle incoming flows. By
 default, no persistent cache is configured.
 
-The `provider` key contains the configuration of the provider. The provider type
-is defined by the `type` key.
+The `providers` key contains the configuration of the providers. For each, the
+provider type is defined by the `type` key. When using several providers, they
+will be queried in order and the process stops on the first to accept to handle
+a query. Currently, only the `static` provider can skip a query. Therefore, you
+should put it first.
 
 #### SNMP provider
 
@@ -419,7 +422,7 @@ For example:
 ```yaml
 metadata:
   workers: 10
-  provider:
+  providers:
     type: snmp
     communities:
       ::/0:
@@ -460,7 +463,7 @@ For example:
 
 ```yaml
 metadata:
- provider:
+ providers:
   type: gnmi
   authentication-parameters:
    ::/0:
@@ -507,28 +510,32 @@ an exporter configuration. An exporter configuration is map:
 
 An interface is a `name`, a `description` and a `speed`.
 
-For example:
+For example, to add an exception for `2001:db8:1::1`, then use SNMP for
+other exporters:
 
 ```yaml
 metadata:
-  provider:
-    type: static
-    exporters:
-      2001:db8:1::1:
-        name: exporter1
-        default:
-          name: unknown
-          description: Unknown interface
-          speed: 100
-        ifindexes:
-          10:
-            name: Gi0/0/10
-            description: PNI Netflix
-            speed: 1000
-          11:
-            name: Gi0/0/15
-            description: PNI Google
-            speed: 1000
+  providers:
+    - type: static
+      exporters:
+        2001:db8:1::1:
+          name: exporter1
+          default:
+            name: unknown
+            description: Unknown interface
+            speed: 100
+          ifindexes:
+            10:
+              name: Gi0/0/10
+              description: PNI Netflix
+              speed: 1000
+            11:
+              name: Gi0/0/15
+              description: PNI Google
+              speed: 1000
+    - type: snmp
+      communities:
+        ::/0: private
 ```
 
 The `static` provider also accepts a key `exporter-sources`, which will fetch a
@@ -553,7 +560,7 @@ For example:
 
 ```yaml
 metadata:
-  provider:
+  providers:
     type: static
     exporter-sources:
       gostatic:

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -16,6 +16,7 @@ identified with a specific icon:
 - ✨ *inlet*: add gNMI metadata provider
 - ✨ *inlet*: static metadata provider can provide exporter and interface metadata
 - ✨ *inlet*: static metadata provider can fetch its configuration from an HTTP endpoint
+- ✨ *inlet*: metadata can be fetched from multiple providers (eg, static, then SNMP)
 - ✨ *inlet*: add support for several SNMPv2 communities
 - 🩹 *cmd*: fix parsing of `inlet`→`metadata`→`provider`→`ports`
 - 🩹 *console*: fix use of `InIfBoundary` and `OutIfBoundary` as dimensions

--- a/inlet/metadata/config.go
+++ b/inlet/metadata/config.go
@@ -4,6 +4,8 @@
 package metadata
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"akvorado/common/helpers"
@@ -11,6 +13,8 @@ import (
 	"akvorado/inlet/metadata/provider/gnmi"
 	"akvorado/inlet/metadata/provider/snmp"
 	"akvorado/inlet/metadata/provider/static"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 // Configuration describes the configuration for the metadata client
@@ -24,8 +28,8 @@ type Configuration struct {
 	// CachePersist defines a file to store cache and survive restarts
 	CachePersistFile string
 
-	// Provider defines the configuration of the provider to sue
-	Provider ProviderConfiguration
+	// Provider defines the configuration of the providers to use
+	Providers []ProviderConfiguration
 
 	// Workers define the number of workers used to poll metadata
 	Workers int `validate:"min=1"`
@@ -42,6 +46,40 @@ func DefaultConfiguration() Configuration {
 		CachePersistFile:   "",
 		Workers:            1,
 		MaxBatchRequests:   10,
+	}
+}
+
+// ConfigurationUnmarshallerHook renames "provider" to "providers".
+func ConfigurationUnmarshallerHook() mapstructure.DecodeHookFunc {
+	return func(from, to reflect.Value) (interface{}, error) {
+		if from.Kind() != reflect.Map || from.IsNil() || to.Type() != reflect.TypeOf(Configuration{}) {
+			return from.Interface(), nil
+		}
+
+		// provider → providers
+		{
+			var providerKey, providersKey *reflect.Value
+			fromKeys := from.MapKeys()
+			for i, k := range fromKeys {
+				k = helpers.ElemOrIdentity(k)
+				if k.Kind() != reflect.String {
+					return from.Interface(), nil
+				}
+				if helpers.MapStructureMatchName(k.String(), "Provider") {
+					providerKey = &fromKeys[i]
+				} else if helpers.MapStructureMatchName(k.String(), "Providers") {
+					providersKey = &fromKeys[i]
+				}
+			}
+			if providersKey != nil && providerKey != nil {
+				return nil, fmt.Errorf("cannot have both %q and %q", providerKey.String(), providersKey.String())
+			}
+			if providerKey != nil {
+				from.SetMapIndex(reflect.ValueOf("providers"), from.MapIndex(*providerKey))
+				from.SetMapIndex(*providerKey, reflect.Value{})
+			}
+		}
+		return from.Interface(), nil
 	}
 }
 
@@ -68,6 +106,7 @@ var providers = map[string](func() provider.Configuration){
 }
 
 func init() {
+	helpers.RegisterMapstructureUnmarshallerHook(ConfigurationUnmarshallerHook())
 	helpers.RegisterMapstructureUnmarshallerHook(
 		helpers.ParametrizedConfigurationUnmarshallerHook(ProviderConfiguration{}, providers))
 }

--- a/inlet/metadata/provider/root.go
+++ b/inlet/metadata/provider/root.go
@@ -6,11 +6,16 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"net/netip"
 
 	"akvorado/common/reporter"
 	"akvorado/common/schema"
 )
+
+// ErrSkipProvider is the error returned on lookup for providers unwilling to
+// handle a request.
+var ErrSkipProvider = errors.New("provider skips query")
 
 // Interface contains the information about an interface.
 type Interface struct {

--- a/inlet/metadata/provider/static/root.go
+++ b/inlet/metadata/provider/static/root.go
@@ -51,7 +51,7 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 	exporter, ok := p.exporters.Load().Lookup(query.ExporterIP)
 	if !ok {
-		return nil
+		return provider.ErrSkipProvider
 	}
 	for _, ifIndex := range query.IfIndexes {
 		iface, ok := exporter.IfIndexes[ifIndex]

--- a/inlet/metadata/tests.go
+++ b/inlet/metadata/tests.go
@@ -71,8 +71,8 @@ func (mpc mockProviderConfiguration) New(_ *reporter.Reporter, put func(provider
 // NewMock creates a new metadata component building synthetic values. It is already started.
 func NewMock(t *testing.T, reporter *reporter.Reporter, configuration Configuration, dependencies Dependencies) *Component {
 	t.Helper()
-	if configuration.Provider.Config == nil {
-		configuration.Provider.Config = mockProviderConfiguration{}
+	if configuration.Providers == nil {
+		configuration.Providers = []ProviderConfiguration{{Config: mockProviderConfiguration{}}}
 	}
 	c, err := New(reporter, configuration, dependencies)
 	if err != nil {


### PR DESCRIPTION
This does not work as expected as they are queried asynchronously and the negative cache from a provider can erase the answer from another one.

Would have fixed #1111.