### PR TITLE
Allow using fields of the netflow packet to set the flow TimeReceived

### DIFF
--- a/demoexporter/flows/nfdata_test.go
+++ b/demoexporter/flows/nfdata_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestGetNetflowData(t *testing.T) {
 	r := reporter.NewMock(t)
-	nfdecoder := netflow.New(r, decoder.Dependencies{Schema: schema.NewMock(t)})
+	nfdecoder := netflow.New(r, decoder.Dependencies{Schema: schema.NewMock(t)}, decoder.Option{TimestampSource: decoder.TimestampSourceUDP})
 
 	ch := getNetflowTemplates(
 		context.Background(),

--- a/inlet/flow/config.go
+++ b/inlet/flow/config.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"akvorado/common/helpers"
+	"akvorado/inlet/flow/decoder"
 	"akvorado/inlet/flow/input"
 	"akvorado/inlet/flow/input/file"
 	"akvorado/inlet/flow/input/udp"
@@ -25,11 +26,13 @@ type Configuration struct {
 func DefaultConfiguration() Configuration {
 	return Configuration{
 		Inputs: []InputConfiguration{{
-			Decoder: "netflow",
-			Config:  udp.DefaultConfiguration(),
+			TimestampSource: decoder.TimestampSourceUDP,
+			Decoder:         "netflow",
+			Config:          udp.DefaultConfiguration(),
 		}, {
-			Decoder: "sflow",
-			Config:  udp.DefaultConfiguration(),
+			TimestampSource: decoder.TimestampSourceUDP,
+			Decoder:         "sflow",
+			Config:          udp.DefaultConfiguration(),
 		}},
 	}
 }
@@ -41,6 +44,8 @@ type InputConfiguration struct {
 	// UseSrcAddrForExporterAddr replaces the exporter address by the transport
 	// source address.
 	UseSrcAddrForExporterAddr bool
+	// TimestampSource identify the source to use to timestamp the flows
+	TimestampSource decoder.TimestampSource
 	// Config is the actual configuration of the input.
 	Config input.Configuration
 }

--- a/inlet/flow/config_test.go
+++ b/inlet/flow/config_test.go
@@ -12,6 +12,7 @@ import (
 	"akvorado/common/helpers/yaml"
 
 	"akvorado/common/helpers"
+	"akvorado/inlet/flow/decoder"
 	"akvorado/inlet/flow/input/file"
 	"akvorado/inlet/flow/input/udp"
 )
@@ -190,6 +191,78 @@ func TestDecodeConfiguration(t *testing.T) {
 			},
 			Error: true,
 		},
+		{
+			Description: "netflow timestamp source netflow-packet",
+			Initial: func() interface{} {
+				return Configuration{
+					Inputs: []InputConfiguration{{
+						Decoder: "netflow",
+						Config: &udp.Configuration{
+							Workers:   2,
+							QueueSize: 100,
+							Listen:    "127.0.0.1:2055",
+						},
+					}},
+				}
+			},
+			Configuration: func() interface{} {
+				return gin.H{
+					"inputs": []gin.H{
+						{
+							"timestamp-source": "netflow-packet",
+							"listen": "192.0.2.1:2055",
+						},
+					},
+				}
+			},
+			Expected: Configuration{
+				Inputs: []InputConfiguration{{
+					Decoder: "netflow",
+					TimestampSource: decoder.TimestampSourceNetflowPacket,
+					Config: &udp.Configuration{
+						Workers:   2,
+						QueueSize: 100,
+						Listen:    "192.0.2.1:2055",
+					},
+				}},
+			},
+		},
+		{
+			Description: "netflow timestamp source netflow-first-switched",
+			Initial: func() interface{} {
+				return Configuration{
+					Inputs: []InputConfiguration{{
+						Decoder: "netflow",
+						Config: &udp.Configuration{
+							Workers:   2,
+							QueueSize: 100,
+							Listen:    "127.0.0.1:2055",
+						},
+					}},
+				}
+			},
+			Configuration: func() interface{} {
+				return gin.H{
+					"inputs": []gin.H{
+						{
+							"timestamp-source": "netflow-first-switched",
+							"listen": "192.0.2.1:2055",
+						},
+					},
+				}
+			},
+			Expected: Configuration{
+				Inputs: []InputConfiguration{{
+					Decoder: "netflow",
+					TimestampSource: decoder.TimestampSourceNetflowFirstSwitched,
+					Config: &udp.Configuration{
+						Workers:   2,
+						QueueSize: 100,
+						Listen:    "192.0.2.1:2055",
+					},
+				}},
+			},
+		},
 	})
 }
 
@@ -198,6 +271,7 @@ func TestMarshalYAML(t *testing.T) {
 		Inputs: []InputConfiguration{
 			{
 				Decoder: "netflow",
+				TimestampSource: decoder.TimestampSourceNetflowFirstSwitched,
 				Config: &udp.Configuration{
 					Listen:    "192.0.2.11:2055",
 					QueueSize: 1000,
@@ -223,6 +297,7 @@ func TestMarshalYAML(t *testing.T) {
       listen: 192.0.2.11:2055
       queuesize: 1000
       receivebuffer: 0
+      timestampsource: netflow-first-switched
       type: udp
       usesrcaddrforexporteraddr: false
       workers: 3
@@ -230,6 +305,7 @@ func TestMarshalYAML(t *testing.T) {
       listen: 192.0.2.11:6343
       queuesize: 1000
       receivebuffer: 0
+      timestampsource: udp
       type: udp
       usesrcaddrforexporteraddr: true
       workers: 3

--- a/inlet/flow/decoder/config.go
+++ b/inlet/flow/decoder/config.go
@@ -1,0 +1,59 @@
+package decoder
+
+import (
+	"akvorado/common/helpers/bimap"
+	"errors"
+)
+
+// TimestampSource defines the method to use to extract the TimeReceived for the flows
+type TimestampSource uint
+
+const (
+	// TimestampSourceUDP tells the decoder to use the kernel time at which
+	// the UDP packet was received
+	TimestampSourceUDP TimestampSource = iota
+	// TimestampSourceNetflowPacket tells the decoder to use the timestamp
+	// from the router in the netflow packet
+	TimestampSourceNetflowPacket
+	// TimestampSourceNetflowFirstSwitched tells the decoder to use the timestamp
+	// from each flow "FIRST_SWITCHED" field
+	TimestampSourceNetflowFirstSwitched
+)
+
+var (
+	timestampSourceMap = bimap.New(map[TimestampSource]string{
+		TimestampSourceUDP: "udp",
+		TimestampSourceNetflowPacket: "netflow-packet",
+		TimestampSourceNetflowFirstSwitched:  "netflow-first-switched",
+	})
+	errUnknownTimestampSource = errors.New("unknown TimestampSource")
+)
+
+// MarshalText turns an interface boundary to text
+func (ib TimestampSource) MarshalText() ([]byte, error) {
+	got, ok := timestampSourceMap.LoadValue(ib)
+	if ok {
+		return []byte(got), nil
+	}
+	return nil, errUnknownTimestampSource
+}
+
+// String turns an interface boundary to string
+func (ib TimestampSource) String() string {
+	got, _ := timestampSourceMap.LoadValue(ib)
+	return got
+}
+
+// UnmarshalText provides an interface boundary from text
+func (ib *TimestampSource) UnmarshalText(input []byte) error {
+	if len(input) == 0 {
+		*ib = TimestampSourceUDP
+		return nil
+	}
+	got, ok := timestampSourceMap.LoadKey(string(input))
+	if ok {
+		*ib = got
+		return nil
+	}
+	return errUnknownTimestampSource
+}

--- a/inlet/flow/decoder/root.go
+++ b/inlet/flow/decoder/root.go
@@ -24,6 +24,12 @@ type Decoder interface {
 	Name() string
 }
 
+// Option specifies option to influence the behaviour of the decodr
+type Option struct {
+	// TimestampSource is a selector for how to set the TimeReceived.
+	TimestampSource TimestampSource
+}
+
 // Dependencies are the dependencies for the decoder
 type Dependencies struct {
 	Schema *schema.Component
@@ -37,4 +43,4 @@ type RawFlow struct {
 }
 
 // NewDecoderFunc is the signature of a function to instantiate a decoder.
-type NewDecoderFunc func(*reporter.Reporter, Dependencies) Decoder
+type NewDecoderFunc func(*reporter.Reporter, Dependencies, Option) Decoder

--- a/inlet/flow/decoder/sflow/root.go
+++ b/inlet/flow/decoder/sflow/root.go
@@ -43,7 +43,7 @@ type Decoder struct {
 }
 
 // New instantiates a new sFlow decoder.
-func New(r *reporter.Reporter, dependencies decoder.Dependencies) decoder.Decoder {
+func New(r *reporter.Reporter, dependencies decoder.Dependencies, _ decoder.Option) decoder.Decoder {
 	nd := &Decoder{
 		r:         r,
 		d:         dependencies,

--- a/inlet/flow/decoder/sflow/root_test.go
+++ b/inlet/flow/decoder/sflow/root_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestDecode(t *testing.T) {
 	r := reporter.NewMock(t)
-	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t).EnableAllColumns()})
+	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t).EnableAllColumns()}, decoder.Option{})
 
 	// Send data
 	data := helpers.ReadPcapL4(t, filepath.Join("testdata", "data-1140.pcap"))
@@ -176,7 +176,7 @@ func TestDecode(t *testing.T) {
 
 func TestDecodeInterface(t *testing.T) {
 	r := reporter.NewMock(t)
-	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t)})
+	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t)}, decoder.Option{})
 
 	t.Run("local interface", func(t *testing.T) {
 		// Send data
@@ -284,7 +284,7 @@ func TestDecodeInterface(t *testing.T) {
 
 func TestDecodeSamples(t *testing.T) {
 	r := reporter.NewMock(t)
-	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t).EnableAllColumns()})
+	sdecoder := New(r, decoder.Dependencies{Schema: schema.NewMock(t).EnableAllColumns()}, decoder.Option{})
 
 	t.Run("expanded flow sample", func(t *testing.T) {
 		// Send data

--- a/inlet/flow/decoder_test.go
+++ b/inlet/flow/decoder_test.go
@@ -22,7 +22,7 @@ func BenchmarkDecodeEncodeNetflow(b *testing.B) {
 	schema.DisableDebug(b)
 	r := reporter.NewMock(b)
 	sch := schema.NewMock(b)
-	nfdecoder := netflow.New(r, decoder.Dependencies{Schema: sch})
+	nfdecoder := netflow.New(r, decoder.Dependencies{Schema: sch}, decoder.Option{TimestampSource: decoder.TimestampSourceUDP})
 
 	template := helpers.ReadPcapL4(b, filepath.Join("decoder", "netflow", "testdata", "options-template.pcap"))
 	got := nfdecoder.Decode(decoder.RawFlow{Payload: template, Source: net.ParseIP("127.0.0.1")})
@@ -66,7 +66,7 @@ func BenchmarkDecodeEncodeSflow(b *testing.B) {
 	schema.DisableDebug(b)
 	r := reporter.NewMock(b)
 	sch := schema.NewMock(b)
-	sdecoder := sflow.New(r, decoder.Dependencies{Schema: sch})
+	sdecoder := sflow.New(r, decoder.Dependencies{Schema: sch}, decoder.Option{TimestampSource: decoder.TimestampSourceUDP})
 	data := helpers.ReadPcapL4(b, filepath.Join("decoder", "sflow", "testdata", "data-1140.pcap"))
 
 	for _, withEncoding := range []bool{true, false} {

--- a/inlet/flow/root.go
+++ b/inlet/flow/root.go
@@ -77,7 +77,7 @@ func New(r *reporter.Reporter, configuration Configuration, dependencies Depende
 		if !ok {
 			return nil, fmt.Errorf("unknown decoder %q", input.Decoder)
 		}
-		dec = decoderfunc(r, decoder.Dependencies{Schema: c.d.Schema})
+		dec = decoderfunc(r, decoder.Dependencies{Schema: c.d.Schema}, decoder.Option{TimestampSource: input.TimestampSource})
 		alreadyInitialized[input.Decoder] = dec
 		decs[idx] = c.wrapDecoder(dec, input.UseSrcAddrForExporterAddr)
 	}


### PR DESCRIPTION
Today the timestamp can only be from kernel timetstamp put on the UDP packet by the kernel.

I propose to add 2 alternative methods of getting the timestamp for netflow/IPFix packets:
- TimestampSourceNetflowPacket: use the timestamp field in the netflow packet itself
- TimestampSourceNetflowFirstSwitched: use the FirstSwitched field from each flow (the field is actually in uptime, so we need to shift it according to sysUptime)

Using those fields requires the router to have accurate time (probably NTP), but it allows for architectures where a UDP packet is not immediately received by the collector, eg. if there is a kafka in-between. That in turns allows to do maintenance on the collector, without messing up the statistics