### PR TITLE
console/clickhouse: Expose API route to get best table and interval from time range

### DIFF
--- a/console/root.go
+++ b/console/root.go
@@ -94,6 +94,7 @@ func (c *Component) Start() error {
 	endpoint.GET("/widget/graph", c.d.HTTP.CacheByRequestPath(5*time.Minute), c.widgetGraphHandlerFunc)
 	endpoint.POST("/graph/line", c.d.HTTP.CacheByRequestBody(c.config.CacheTTL), c.graphLineHandlerFunc)
 	endpoint.POST("/graph/sankey", c.d.HTTP.CacheByRequestBody(c.config.CacheTTL), c.graphSankeyHandlerFunc)
+	endpoint.POST("/graph/table-interval", c.getTableAndIntervalHandlerFunc)
 	endpoint.POST("/filter/validate", c.filterValidateHandlerFunc)
 	endpoint.POST("/filter/complete", c.d.HTTP.CacheByRequestBody(time.Minute), c.filterCompleteHandlerFunc)
 	endpoint.GET("/filter/saved", c.filterSavedListHandlerFunc)

--- a/console/tests.go
+++ b/console/tests.go
@@ -21,7 +21,7 @@ import (
 	"akvorado/console/database"
 )
 
-// NewMock instantiantes a new authentication component
+// NewMock instantiates a new authentication component
 func NewMock(t *testing.T, config Configuration) (*Component, *httpserver.Component, *mocks.MockConn, *clock.Mock) {
 	t.Helper()
 	r := reporter.NewMock(t)


### PR DESCRIPTION
This PR aims to expose as an API route, the internal logic to compute the appropriate `table` and `interval` (in seconds) to use.
This is very useful for third party apps like Grafana dashboards, running Akvorado-like SQL queries, to adapt perfectly with current Akvorado configuration.