### PR TITLE
Enable load-balancing for clickhouse

### DIFF
--- a/common/clickhousedb/root.go
+++ b/common/clickhousedb/root.go
@@ -43,6 +43,7 @@ func New(r *reporter.Reporter, config Configuration, dependencies Dependencies) 
 	}
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: config.Servers,
+		ConnOpenStrategy: clickhouse.ConnOpenRoundRobin,
 		Auth: clickhouse.Auth{
 			Database: config.Database,
 			Username: config.Username,


### PR DESCRIPTION
By defaut, the clickhouse-client does only failover (ConnOpenInOrder) the first instance that replies is used.

This enabled round-robin so that servers can all be used in parallel.