### PR TITLE
Use unit for sorting topX instead of always using bytes

### DIFF
--- a/console/line.go
+++ b/console/line.go
@@ -134,16 +134,18 @@ func (input graphLineHandlerInput) toSQL1(axis int, options toSQL1Options) strin
 		dimensionsInterpolate = "emptyArrayString()"
 	}
 
+	
 	// With
 	withStr := ""
 	if !options.skipWithClause {
 		with := []string{fmt.Sprintf("source AS (%s)", input.sourceSelect())}
 		if len(dimensions) > 0 {
 			with = append(with, fmt.Sprintf(
-				"rows AS (SELECT %s FROM source WHERE %s GROUP BY %s ORDER BY SUM(Bytes) DESC LIMIT %d)",
+				"rows AS (SELECT %s FROM source WHERE %s GROUP BY %s ORDER BY SUM(%s) DESC LIMIT %d)",
 				strings.Join(dimensions, ", "),
 				where,
 				strings.Join(dimensions, ", "),
+				metricForTopSort(input.Units),
 				input.Limit))
 		}
 		if len(with) > 0 {

--- a/console/query.go
+++ b/console/query.go
@@ -32,3 +32,13 @@ func (c *Component) fixQueryColumnName(name string) string {
 	}
 	return ""
 }
+
+
+func metricForTopSort(inputUnit string) string {
+	switch inputUnit {
+	case "pps":
+		return "Packets"
+	default:
+		return "Bytes"
+	}
+}

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -59,10 +59,11 @@ func (input graphSankeyHandlerInput) toSQL() (string, error) {
 		fmt.Sprintf("source AS (%s)", input.sourceSelect()),
 		fmt.Sprintf(`(SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE %s) AS range`, where),
 		fmt.Sprintf(
-			"rows AS (SELECT %s FROM source WHERE %s GROUP BY %s ORDER BY SUM(Bytes) DESC LIMIT %d)",
+			"rows AS (SELECT %s FROM source WHERE %s GROUP BY %s ORDER BY SUM(%s) DESC LIMIT %d)",
 			strings.Join(dimensions, ", "),
 			where,
 			strings.Join(dimensions, ", "),
+			metricForTopSort(input.Units),
 			input.Limit),
 	}
 

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -107,7 +107,7 @@ ORDER BY xps DESC
 WITH
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY SUM(Bytes) DESC LIMIT 5)
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY SUM(Packets) DESC LIMIT 5)
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),


### PR DESCRIPTION
We noticed that we had inconsistencies on the TOPN pps query between the returned top IPs,
and we found that the sort was always using the Bytes instead of using the unit we have on the graph.

When we have a DOS for example, the packets are small, so the background noise in bytes is hiding the IP of interest in PPS.

I added a function to select the appropriate column based on the unit selected by the user.