### PR TITLE
inlet/metadata: handle multiple keys in gNMI events

### DIFF
--- a/inlet/metadata/provider/gnmi/collector.go
+++ b/inlet/metadata/provider/gnmi/collector.go
@@ -106,13 +106,13 @@ outer2:
 		iface := state.Interfaces[index]
 		// Set name
 		if iface.Name == "" && len(model.IfNameKeys) > 0 {
-			// We assume we only have one key
-			if !strings.Contains(keys, ",") {
+inner3:
+			for _, key := range strings.Split(keys, ",") {
 				for _, name := range model.IfNameKeys {
 					pfx := fmt.Sprintf("%s=", name)
-					if strings.HasPrefix(keys, pfx) {
-						iface.Name = keys[len(pfx):]
-						break
+					if strings.HasPrefix(key, pfx) {
+						iface.Name = key[len(pfx):]
+						break inner3
 					}
 				}
 			}


### PR DESCRIPTION
Currently, for discovering interfaces' name, description and speed, the gNMI metadata provider assumes that all entries returned by the device always contain a single key.

However, this is not always the case. For example, on Nokia SR OS, sampling is enabled on logical interfaces that are defined inside router instances or VPRN services, rather than physical ports.

To give an example:
```
$ gnmic get -u akvorado ... \
    --path 'state/service/vprn/interface/system-if-index'
[
  {
...
    "updates": [
      {
        "Path": "state/service/vprn[service-name=WAN_VRF]/interface[interface-name=primary_transit]/system-if-index",
        "values": {
          "state/service/vprn/interface/system-if-index": 264
        }
      },
...
```

Adding this path to if-index-paths, with interface-name as a if-name-keys, would not allow primary_transit to be successfully discovered as the name for interface index 264.

The proposed change aims at adding support for this type of situation.