### PR TITLE
move viewers_can_edit to users section in grafana.ini

### DIFF
--- a/docker/grafana/grafana.ini
+++ b/docker/grafana/grafana.ini
@@ -2,13 +2,13 @@
 
 [security]
 disable_initial_admin_creation = false
-viewers_can_edit = true
 
 [users]
 allow_sign_up = false
 allow_org_create = false
 auto_assign_org = true
 auto_assign_org_role = Viewer # Viewer, Admin, Editor, or None
+viewers_can_edit = true
 
 [auth]
 disable_signout_menu = true


### PR DESCRIPTION
Needs to be in section [users] instead of [security]

see:
https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#viewers_can_edit
