### PR TITLE
Fix system reload request to include db name

### DIFF
--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -210,5 +210,5 @@ func (c *Component) getHTTPBaseURL(address string) (string, error) {
 
 // ReloadDictionary will reload the specified dictionnary.
 func (c *Component) ReloadDictionary(ctx context.Context, dictName string) error {
-	return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s", dictName))
+	return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s.%s", c.config.Database, dictName))
 }


### PR DESCRIPTION
Depending on (I guess) database configuration,
it is required to specify the full dict name (include database), or else we get "BAD_ARGUMENTS" error.

It seems like a good idea to always send the full table/dict name regardless, because it makes sure there is no conflict in case of duplicate table names (eg. multiple akvorados running on the same clickhous cluster).