### PR TITLE
feat/console: option to sort by last column

### DIFF
--- a/console/config.go
+++ b/console/config.go
@@ -70,7 +70,7 @@ type VisualizeOptionsConfiguration struct {
 	// Limit is the default limit to use
 	Limit int `json:"limit" validate:"min=5"`
 	// LimitType is the default limitType to use
-	LimitType string `json:"limitType" validate:"oneof=avg max"`
+	LimitType string `json:"limitType" validate:"oneof=avg max last"`
 	// Bidirectional tells if a graph should be bidirectional (all except sankey)
 	Bidirectional bool `json:"bidirectional"`
 	// PreviousPeriod tells if a graph should display the previous period (for stacked)

--- a/console/data/docs/03-usage.md
+++ b/console/data/docs/03-usage.md
@@ -157,6 +157,8 @@ aspect of the graph.
     traffics over the time selection.
   - `max`: the query focuses on getting the traffic bursts over the time
     selection.
+  - `last`: the query focuses on getting the most recent (last) traffic over
+    the time selection.
 
 - The filter box contains an SQL-like expression to limit the data to be
   graphed. It features an auto-completion system that can be triggered manually

--- a/console/frontend/src/components/InputDimensions.vue
+++ b/console/frontend/src/components/InputDimensions.vue
@@ -136,6 +136,7 @@ const limitError = computed(() => {
 const computationModes = {
   avg: "Avg",
   max: "Max",
+  last: "Last",
 } as const;
 
 const computationModeList = Object.entries(computationModes).map(

--- a/console/graph.go
+++ b/console/graph.go
@@ -20,7 +20,7 @@ type graphCommonHandlerInput struct {
 	End            time.Time      `json:"end" binding:"required,gtfield=Start"`
 	Dimensions     []query.Column `json:"dimensions"`            // group by ...
 	Limit          int            `json:"limit" binding:"min=1"` // limit product of dimensions
-	LimitType      string         `json:"limitType" validate:"oneof=avg max"`
+	LimitType      string         `json:"limitType" validate:"oneof=avg max last"`
 	Filter         query.Filter   `json:"filter"`                              // where ...
 	TruncateAddrV4 int            `json:"truncate-v4" binding:"min=0,max=32"`  // 0 or 32 = no truncation
 	TruncateAddrV6 int            `json:"truncate-v6" binding:"min=0,max=128"` // 0 or 128 = no truncation


### PR DESCRIPTION
This is a quick followup on my previous PR #1635, which added the `Last` column to the DataTable.

This PR aims to make the DataTable also sortable by the `Last` column, like it is already possible with `Max`and `Avg`.


### Here is a screenshot:

![Bildschirmfoto vom 2025-02-21 09-25-50](https://github.com/user-attachments/assets/c661b580-a64d-42d9-8aa0-2e4d9ae3f8dd)
