### PR TITLE
routing: include routeAttributes.plen in .Equal() and .Hash()

### DIFF
--- a/inlet/routing/provider/bmp/rib.go
+++ b/inlet/routing/provider/bmp/rib.go
@@ -94,6 +94,7 @@ func (rta routeAttributes) Hash() uint64 {
 	if len(rta.communities) > 0 {
 		state.Add((*byte)(unsafe.Pointer(&rta.communities[0])), len(rta.communities)*int(unsafe.Sizeof(rta.communities[0])))
 	}
+	state.Add((*byte)(unsafe.Pointer(&rta.plen)), 1)
 	if len(rta.largeCommunities) > 0 {
 		// There is a test to check that this computation is
 		// correct (the struct is 12-byte aligned, not
@@ -112,6 +113,9 @@ func (rta routeAttributes) Equal(orta routeAttributes) bool {
 		return false
 	}
 	if len(rta.communities) != len(orta.communities) {
+		return false
+	}
+	if rta.plen != orta.plen {
 		return false
 	}
 	if len(rta.largeCommunities) != len(orta.largeCommunities) {

--- a/inlet/routing/provider/bmp/rib_test.go
+++ b/inlet/routing/provider/bmp/rib_test.go
@@ -166,6 +166,18 @@ func TestRTAEqual(t *testing.T) {
 			routeAttributes{asn: 2038, largeCommunities: []bgp.LargeCommunity{{ASN: 1, LocalData1: 2, LocalData2: 3}, {ASN: 3, LocalData1: 4, LocalData2: 5}, {ASN: 5, LocalData1: 6, LocalData2: 7}}},
 			false,
 		},
+		{
+			helpers.Mark(),
+			routeAttributes{plen: 48},
+			routeAttributes{plen: 48},
+			true,
+		},
+		{
+			helpers.Mark(),
+			routeAttributes{plen: 48},
+			routeAttributes{plen: 49},
+			false,
+		},
 	}
 outer:
 	for try := 3; try >= 0; try-- {

--- a/inlet/routing/provider/bmp/tests.go
+++ b/inlet/routing/provider/bmp/tests.go
@@ -119,6 +119,16 @@ func (p *Provider) PopulateRIB(t *testing.T) {
 			plen:   96 + 22,
 		}),
 	})
+	p.rib.addPrefix(netip.MustParseAddr("::ffff:192.168.148.1"), 96+32, route{
+		peer:    pinfo.reference,
+		nlri:    p.rib.nlris.Put(nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0}),
+		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:203.0.113.14"))),
+		attributes: p.rib.rtas.Put(routeAttributes{
+			asn:    1234,
+			asPath: []uint32{1234},
+			plen:   96 + 32,
+		}),
+	})
 }
 
 // LocalAddr returns the address the BMP collector is listening to.

--- a/inlet/routing/root_test.go
+++ b/inlet/routing/root_test.go
@@ -30,4 +30,11 @@ func TestRoutingComponent(t *testing.T) {
 	if lookup.ASN != 0 {
 		t.Errorf("Lookup() == %d, expected 0", lookup.ASN)
 	}
+
+	lookup = c.Lookup(context.Background(),
+		netip.MustParseAddr("::ffff:192.168.148.1"),
+		netip.MustParseAddr("::ffff:203.0.113.14"), netip.Addr{})
+	if lookup.NetMask != 32 {
+		t.Errorf("Lookup() == NetMask %d, expected 32", lookup.NetMask)
+	}
 }


### PR DESCRIPTION
We noticed invalid DstNetMask and SrcNetMask values from routers with only a default route, where the value from flows is zero and replaced with information from the BMP provider.

We were able to confirm that the correct routes were advertised via BMP, and further discovered that the `plen` set in [`inlet/routing/provider/bmp/events.go` line 397](https://github.com/akvorado/akvorado/blob/98922dda9ff05d6d4b4c30781393250c2b353296/inlet/routing/provider/bmp/events.go#L397) did not always match the value when read in [`addPrefix()`](https://github.com/akvorado/akvorado/blob/98922dda9ff05d6d4b4c30781393250c2b353296/inlet/routing/provider/bmp/rib.go#L139).

We believe the cause might be that the `plen` attribute in is not considered in the `Equals()` and `Hash()` functions for the `routeAttribute` struct. This PR includes a fix for that, which seems to solve our issues. 