### PR TITLE
static metadata provider: add option skip missing interfaces

### DIFF
--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -492,6 +492,9 @@ an exporter configuration. An exporter configuration is map:
 - `name` is the name of the exporter
 - `default` is the default interface when no match is found
 - `ifindexes` is a map from interface indexes to interface
+- `skip_missing_interfaces` defines whether the exporter should process only
+  interfaces defined in the configuration and leave the remainder to the next
+  provider.
 
 An interface is a `name`, a `description` and a `speed`.
 

--- a/inlet/metadata/provider/gnmi/root.go
+++ b/inlet/metadata/provider/gnmi/root.go
@@ -40,7 +40,7 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 }
 
 // Query queries exporter to get information through gNMI.
-func (p *Provider) Query(ctx context.Context, q provider.BatchQuery) error {
+func (p *Provider) Query(ctx context.Context, q *provider.BatchQuery) error {
 	p.stateLock.Lock()
 	defer p.stateLock.Unlock()
 	state, ok := p.state[q.ExporterIP]

--- a/inlet/metadata/provider/gnmi/srlinux_test.go
+++ b/inlet/metadata/provider/gnmi/srlinux_test.go
@@ -713,7 +713,7 @@ commit now
 			t.Fatalf("New() error:\n%+v", err)
 		}
 		// Let's trigger a request now
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{641}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{641}})
 
 		// We need the indexes
 		subscribeReq, err := api.NewSubscribeRequest(
@@ -741,12 +741,12 @@ commit now
 
 		// Wait a bit
 		time.Sleep(500 * time.Millisecond)
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/2"]}})
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo,
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/2"]}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo,
 			IfIndexes: []uint{indexes["name=lag1"], indexes["name=ethernet-1/3"]}})
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{5}})
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo,
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{5}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo,
 			IfIndexes: []uint{indexes["name=ethernet-1/4,index=1"]}})
 
 		time.Sleep(50 * time.Millisecond)
@@ -793,10 +793,10 @@ commit now
 			t.Fatalf("SendConfig() error:\n%+v", resp.Failed)
 		}
 		time.Sleep(500 * time.Millisecond) // We should exceed the second now and next request will trigger a refresh
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
 		time.Sleep(300 * time.Millisecond) // Do it again to get the fresh value
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
-		p.Query(context.Background(), provider.BatchQuery{ExporterIP: lo,
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo, IfIndexes: []uint{indexes["name=ethernet-1/1"]}})
+		p.Query(context.Background(), &provider.BatchQuery{ExporterIP: lo,
 			IfIndexes: []uint{indexes["name=ethernet-1/4,index=1"]}})
 		time.Sleep(50 * time.Millisecond)
 		if diff := helpers.Diff(got, []string{

--- a/inlet/metadata/provider/root.go
+++ b/inlet/metadata/provider/root.go
@@ -70,7 +70,7 @@ type Update struct {
 // Provider is the interface a provider should implement.
 type Provider interface {
 	// Query asks the provider to query metadata for several requests.
-	Query(ctx context.Context, query BatchQuery) error
+	Query(ctx context.Context, query *BatchQuery) error
 }
 
 // Configuration defines an interface to configure a provider.

--- a/inlet/metadata/provider/snmp/poller_test.go
+++ b/inlet/metadata/provider/snmp/poller_test.go
@@ -279,10 +279,10 @@ func TestPoller(t *testing.T) {
 				t.Fatalf("New() error:\n%+v", err)
 			}
 
-			p.Query(context.Background(), provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{641}})
-			p.Query(context.Background(), provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{642}})
-			p.Query(context.Background(), provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{643, 644, 645}})
-			p.Query(context.Background(), provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{0}})
+			p.Query(context.Background(), &provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{641}})
+			p.Query(context.Background(), &provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{642}})
+			p.Query(context.Background(), &provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{643, 644, 645}})
+			p.Query(context.Background(), &provider.BatchQuery{ExporterIP: tc.ExporterIP, IfIndexes: []uint{0}})
 			exporterStr := tc.ExporterIP.Unmap().String()
 			time.Sleep(50 * time.Millisecond)
 			if diff := helpers.Diff(got, []string{

--- a/inlet/metadata/provider/snmp/root.go
+++ b/inlet/metadata/provider/snmp/root.go
@@ -91,7 +91,7 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 }
 
 // Query queries exporter to get information through SNMP.
-func (p *Provider) Query(ctx context.Context, query provider.BatchQuery) error {
+func (p *Provider) Query(ctx context.Context, query *provider.BatchQuery) error {
 	// Avoid querying too much exporters with errors
 	agentIP, ok := p.config.Agents[query.ExporterIP]
 	if !ok {

--- a/inlet/metadata/provider/static/config.go
+++ b/inlet/metadata/provider/static/config.go
@@ -31,6 +31,8 @@ type ExporterConfiguration struct {
 	Default provider.Interface `validate:"omitempty"`
 	// IfIndexes is a map from interface indexes to interfaces
 	IfIndexes map[uint]provider.Interface `validate:"omitempty,dive"`
+	// Use next provider for interfaces without static config
+	SkipMissingInterfaces bool `mapstructure:"skip_missing_interfaces" validate:"omitempty"`
 }
 
 // DefaultConfiguration represents the default configuration for the static provider

--- a/inlet/metadata/provider/static/config_test.go
+++ b/inlet/metadata/provider/static/config_test.go
@@ -71,4 +71,17 @@ func TestValidation(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("validate.Struct() error:\n%+v", err)
 	}
+
+	if err := helpers.Validate.Struct(Configuration{
+		Exporters: helpers.MustNewSubnetMap(map[string]ExporterConfiguration{
+			"::ffff:203.0.113.0/120": {
+				Exporter: provider.Exporter{
+					Name: "something",
+				},
+				SkipMissingInterfaces: true,
+			},
+		}),
+	}); err != nil {
+		t.Fatalf("validate.Struct() error:\n%+v", err)
+	}
 }

--- a/inlet/metadata/provider/static/root.go
+++ b/inlet/metadata/provider/static/root.go
@@ -57,7 +57,7 @@ func (p *Provider) Query(_ context.Context, query *provider.BatchQuery) error {
 	for _, ifIndex := range query.IfIndexes {
 		iface, ok := exporter.IfIndexes[ifIndex]
 		if !ok {
-			if exporter.Default.Name == "" {
+			if exporter.SkipMissingInterfaces {
 				query.IfIndexes[skippedIfIndexes] = ifIndex
 				skippedIfIndexes++
 				continue

--- a/inlet/metadata/provider/static/root.go
+++ b/inlet/metadata/provider/static/root.go
@@ -48,14 +48,20 @@ func (configuration Configuration) New(r *reporter.Reporter, put func(provider.U
 }
 
 // Query queries static configuration.
-func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
+func (p *Provider) Query(_ context.Context, query *provider.BatchQuery) error {
 	exporter, ok := p.exporters.Load().Lookup(query.ExporterIP)
 	if !ok {
 		return provider.ErrSkipProvider
 	}
+	var skippedIfIndexes uint
 	for _, ifIndex := range query.IfIndexes {
 		iface, ok := exporter.IfIndexes[ifIndex]
 		if !ok {
+			if exporter.Default.Name == "" {
+				query.IfIndexes[skippedIfIndexes] = ifIndex
+				skippedIfIndexes++
+				continue
+			}
 			iface = exporter.Default
 		}
 		p.put(provider.Update{
@@ -68,6 +74,10 @@ func (p *Provider) Query(_ context.Context, query provider.BatchQuery) error {
 				Interface: iface,
 			},
 		})
+	}
+	if skippedIfIndexes > 0 {
+		query.IfIndexes = query.IfIndexes[:skippedIfIndexes]
+		return provider.ErrSkipProvider
 	}
 	return nil
 }

--- a/inlet/metadata/provider/static/source_test.go
+++ b/inlet/metadata/provider/static/source_test.go
@@ -193,13 +193,13 @@ func TestRemoteExporterSources(t *testing.T) {
 	})
 
 	// Query when json is not ready yet, only static configured data available
-	p.Query(context.Background(), provider.BatchQuery{
+	p.Query(context.Background(), &provider.BatchQuery{
 		ExporterIP: netip.MustParseAddr("2001:db8:1::10"),
 		IfIndexes:  []uint{9},
 	})
 
 	// Unknown Exporter at this moment
-	p.Query(context.Background(), provider.BatchQuery{
+	p.Query(context.Background(), &provider.BatchQuery{
 		ExporterIP: netip.MustParseAddr("2001:db8:2::10"),
 		IfIndexes:  []uint{1},
 	})
@@ -232,7 +232,7 @@ func TestRemoteExporterSources(t *testing.T) {
 	}
 
 	// We now should be able to resolve our new exporter from remote source
-	p.Query(context.Background(), provider.BatchQuery{
+	p.Query(context.Background(), &provider.BatchQuery{
 		ExporterIP: netip.MustParseAddr("2001:db8:2::10"),
 		IfIndexes:  []uint{1},
 	})

--- a/inlet/metadata/root.go
+++ b/inlet/metadata/root.go
@@ -298,7 +298,7 @@ func (c *Component) providerIncomingRequest(request provider.BatchQuery) {
 		for _, p := range c.providers {
 			// Query providers in the order they are defined and stop on the
 			// first provider accepting to handle the query.
-			if err := p.Query(ctx, request); err != nil && err != provider.ErrSkipProvider {
+			if err := p.Query(ctx, &request); err != nil && err != provider.ErrSkipProvider {
 				return err
 			} else if err == provider.ErrSkipProvider {
 				continue

--- a/inlet/metadata/root_test.go
+++ b/inlet/metadata/root_test.go
@@ -193,7 +193,7 @@ func TestStartStopWithMultipleWorkers(t *testing.T) {
 
 type errorProvider struct{}
 
-func (ep errorProvider) Query(_ context.Context, _ provider.BatchQuery) error {
+func (ep errorProvider) Query(_ context.Context, _ *provider.BatchQuery) error {
 	return errors.New("noooo")
 }
 
@@ -244,8 +244,8 @@ type batchProvider struct {
 	config *batchProviderConfiguration
 }
 
-func (bp *batchProvider) Query(_ context.Context, query provider.BatchQuery) error {
-	bp.config.received = append(bp.config.received, query)
+func (bp *batchProvider) Query(_ context.Context, query *provider.BatchQuery) error {
+	bp.config.received = append(bp.config.received, *query)
 	return nil
 }
 

--- a/inlet/metadata/tests.go
+++ b/inlet/metadata/tests.go
@@ -23,7 +23,7 @@ type mockProvider struct {
 }
 
 // Query query the mock provider for a value.
-func (mp mockProvider) Query(_ context.Context, query provider.BatchQuery) error {
+func (mp mockProvider) Query(_ context.Context, query *provider.BatchQuery) error {
 	for _, ifIndex := range query.IfIndexes {
 		answer := provider.Answer{
 			Exporter: provider.Exporter{


### PR DESCRIPTION
As briefly discussed in https://github.com/akvorado/akvorado/discussions/1572 we've implemented a PR for processing only the configured interfaces in the static metadata provider and skip to the next provider for the rest. This behaviour can be enabled per exporter by setting `skip_missing_interfaces` to `true` in the static metadata provider configuration.

For this the `Provider` interface's `Query()` function is updated to use a pointer to the `query` parameter, so that the `ifIndexes` attribute can be updated. The static provider removes interfaces from this slice as it processes them, and returns `ErrSkipProvider` if interfaces were skipped.