### PR TITLE
Remove Bitnami images

### DIFF
--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -21,6 +21,7 @@ identified with a specific icon:
 - 🌱 *build*: minimal Go version to build is now 1.24
 - 🌱 *build*: use PGO for better performance of the inlet
 - 🌱 *orchestrator*: ability to override ClickHouse or Kafka configuration in some components
+- 🌱 *docker*: update Kafka to 3.8 (not mandatory)
 - 🌱 *docker*: switch from `bitnami/valkey` to `valkey/valkey`
 
 ## 1.11.3 - 2025-02-04

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -21,6 +21,7 @@ identified with a specific icon:
 - 🌱 *build*: minimal Go version to build is now 1.24
 - 🌱 *build*: use PGO for better performance of the inlet
 - 🌱 *orchestrator*: ability to override ClickHouse or Kafka configuration in some components
+- 🌱 *docker*: switch from `bitnami/valkey` to `valkey/valkey`
 
 ## 1.11.3 - 2025-02-04
 

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -27,8 +27,6 @@ services:
     extends:
       file: versions.yml
       service: redis
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - 127.0.0.1:6379:6379/tcp
 

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -35,9 +35,9 @@ services:
       file: versions.yml
       service: postgres
     environment:
-      POSTGRESQL_USERNAME: akvorado
-      POSTGRESQL_PASSWORD: akpass
-      POSTGRESQL_DATABASE: akvorado
+      POSTGRES_USER: akvorado
+      POSTGRES_PASSWORD: akpass
+      POSTGRES_DB: akvorado
     ports:
       - 127.0.0.1:5432:5432/tcp
     healthcheck:

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -51,14 +51,14 @@ services:
       file: versions.yml
       service: mysql
     environment:
-      ALLOW_EMPTY_PASSWORD: "yes"
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
       MARIADB_USER: akvorado
       MARIADB_PASSWORD: akpass
       MARIADB_DATABASE: akvorado
     ports:
       - 127.0.0.1:3306:3306/tcp
     healthcheck:
-      test: ['CMD', '/opt/bitnami/scripts/mariadb/healthcheck.sh']
+      test: ['CMD', 'healthcheck.sh', '--connect', '--innodb_initialized']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,8 +58,6 @@ services:
     extends:
       file: versions.yml
       service: redis
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
     restart: unless-stopped
     healthcheck:
       interval: 20s

--- a/docker/versions.yml
+++ b/docker/versions.yml
@@ -6,7 +6,7 @@ services:
   kafka:
     image: bitnami/kafka:3.7 # \d+\.\d+
   redis:
-    image: bitnami/valkey:7.2 # \d+\.\d+
+    image: valkey/valkey:7.2 # \d+\.\d+
   clickhouse:
     image: clickhouse/clickhouse-server:24.8 # \d+\.[38]
   traefik:

--- a/docker/versions.yml
+++ b/docker/versions.yml
@@ -37,6 +37,6 @@ services:
   srlinux:
     image: ghcr.io/nokia/srlinux:23.10.6
   postgres:
-    image: bitnami/postgresql:16.3.0 # \d+\.\d+\.0
+    image: postgres:16 # \d+
   mysql:
     image: bitnami/mariadb:11.3 # \d+\.\d+

--- a/docker/versions.yml
+++ b/docker/versions.yml
@@ -39,4 +39,4 @@ services:
   postgres:
     image: postgres:16 # \d+
   mysql:
-    image: bitnami/mariadb:11.3 # \d+\.\d+
+    image: mariadb:11.4 # \d+\.\d+

--- a/docker/versions.yml
+++ b/docker/versions.yml
@@ -4,7 +4,7 @@ services:
   zookeeper:
     image: bitnami/zookeeper:3.8 # \d+\.\d+
   kafka:
-    image: bitnami/kafka:3.7 # \d+\.\d+
+    image: bitnami/kafka:3.8 # \d+\.\d+
   redis:
     image: valkey/valkey:7.2 # \d+\.\d+
   clickhouse:


### PR DESCRIPTION
Bitnami only maintain the latest version available (which may not be the LTS one) since a few months. See their [announcement](https://community.broadcom.com/tanzu/blogs/carlos-rodriguez-hernandez/2025/01/14/announcing-general-availability-of-bitnami-premium). Moreover, their images now have pull limits.

The main issue when migrating away is volumes. The replacement images may not use the same layout. Docker got the recent ability to use subvolumes.

For Zookeeper, we will remove its use at some point, so it does not matter. Kafka needs to be investigated more.