### PR TITLE
Add depends_on: kafka to avoid crash loop on startup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       file: versions.yml
       service: akvorado
     restart: unless-stopped
+    depends_on:
+      kafka:
+        condition: service_healthy
     command: orchestrator /etc/akvorado/akvorado.yaml
     volumes:
       - ../config:/etc/akvorado:ro


### PR DESCRIPTION
Wait for kafka to be healthy to start akvorado-orchestrator to avoid a crash loop and service unhealthy when kafka takes too long to start.