### PR TITLE
inlet/core: rewrite classifiers to use expr.Function for performance

### DIFF
--- a/inlet/core/classifier_test.go
+++ b/inlet/core/classifier_test.go
@@ -46,6 +46,11 @@ func TestExporterClassifier(t *testing.T) {
 			Program:                `ClassifyTenant("mobile")`,
 			ExpectedClassification: exporterClassification{Tenant: "mobile"},
 		}, {
+			Description:            "use format in classifier",
+			Program:                `ClassifyTenant(Format("tenant-%s", Exporter.Name))`,
+			ExporterInfo:           exporterInfo{"127.0.0.1", "roger"},
+			ExpectedClassification: exporterClassification{Tenant: "tenant-roger"},
+		}, {
 			Description:            "access to exporter name",
 			Program:                `Exporter.Name startsWith "expo" && Classify("europe")`,
 			ExporterInfo:           exporterInfo{"127.0.0.1", "exporter"},
@@ -206,6 +211,15 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")
 				Provider:     "telia",
 				Boundary:     schema.InterfaceBoundaryExternal,
 			},
+		}, {
+			Description: "faulty regex",
+			Program:     `ClassifyProviderRegex(Interface.Description, "^(ebp+.r", "europe-$1")`,
+			InterfaceInfo: interfaceInfo{
+				Name:        "Gi0/0/0",
+				Description: "Transit: Telia (GWDM something something)",
+				Speed:       1000,
+			},
+			ExpectedErr: true,
 		}, {
 			Description: "classify with VLANs",
 			Program:     `Interface.VLAN == 100 && ClassifyExternal()`,


### PR DESCRIPTION
Before:
```
goos: linux
goarch: amd64
pkg: akvorado/inlet/core
cpu: AMD Ryzen 5 5600X 6-Core Processor
BenchmarkClassifier-12           1000000              1102 ns/op             645 B/op         20 allocs/op
PASS
ok      akvorado/inlet/core     1.113s
```

After:
```
goos: linux
goarch: amd64
pkg: akvorado/inlet/core
cpu: AMD Ryzen 5 5600X 6-Core Processor
BenchmarkClassifier-12           3194412               375.7 ns/op           480 B/op          8 allocs/op
PASS
ok      akvorado/inlet/core     1.211s
```

It was not a given. See https://github.com/expr-lang/expr/discussions/767.