### PR TITLE
console/frontend: switch to Node 20+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/console/data/docs/01-install.md
+++ b/console/data/docs/01-install.md
@@ -33,7 +33,7 @@ Currently, only a pre-built binary for Linux x86-64 is provided.
 ## Compilation from source
 
 You need a proper installation of [Go](https://go.dev/doc/install) (1.24+), and
-[NodeJS](https://nodejs.org/en/download/) (18+) with NPM (6+). For example, on
+[NodeJS](https://nodejs.org/en/download/) (20+) with NPM (6+). For example, on
 Debian:
 
 ```console
@@ -41,7 +41,7 @@ Debian:
 # go version
 go version go1.24.1 linux/amd64
 # node --version
-v20.18.1
+v20.19.2
 # npm --version
 9.2.0
 ```

--- a/console/frontend/package-lock.json
+++ b/console/frontend/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.15.0",
-        "@tsconfig/node18": "^18.2.0",
+        "@tsconfig/node20": "^20.1.6",
         "@types/jsdom": "^21.1.0",
         "@types/lodash-es": "^4.17.6",
         "@types/lz-string": "^1.3.34",
@@ -1715,10 +1715,10 @@
         "vue": "^2.7.0 || ^3.0.0"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
+      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
       "dev": true
     },
     "node_modules/@types/estree": {

--- a/console/frontend/package.json
+++ b/console/frontend/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.15.0",
-    "@tsconfig/node18": "^18.2.0",
+    "@tsconfig/node20": "^20.1.6",
     "@types/jsdom": "^21.1.0",
     "@types/lodash-es": "^4.17.6",
     "@types/lz-string": "^1.3.34",

--- a/console/frontend/tsconfig.node.json
+++ b/console/frontend/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "include": [
     "vite.config.*",
     "vitest.config.*",


### PR DESCRIPTION
Node 18 has been deprecated on 30 April 2025