### PR TITLE
orchestrator/clickhouse: do not embed clickhouse database settings

### DIFF
--- a/cmd/testdata/configurations/orchestrator-clickhousedb/expected.yaml
+++ b/cmd/testdata/configurations/orchestrator-clickhousedb/expected.yaml
@@ -1,0 +1,18 @@
+---
+paths:
+  clickhouse.orchestratorurl: http://akvorado-orchestrator:8080
+  clickhousedb:
+    servers:
+      - clickhouse:9000
+    cluster: ""
+    username: alfred
+    password: "IsBaT!Man"
+    database: default
+    maxopenconns: 10
+    dialtimeout: 5s
+    tls:
+      enable: true
+      verify: true
+      cafile: ""
+      certfile: ""
+      keyfile: ""

--- a/cmd/testdata/configurations/orchestrator-clickhousedb/in.yaml
+++ b/cmd/testdata/configurations/orchestrator-clickhousedb/in.yaml
@@ -1,0 +1,14 @@
+---
+clickhouse:
+  orchestrator-url: http://akvorado-orchestrator:8080
+  kafka:
+    consumers: 4
+  servers:
+    - clickhouse:9000
+  username: alfred
+  password: "IsBaT!Man"
+  tls:
+    enable: true
+  prometheus-endpoint: /metrics
+  asns:
+    64501: ACME Corporation

--- a/common/clickhousedb/config.go
+++ b/common/clickhousedb/config.go
@@ -45,3 +45,13 @@ func DefaultConfiguration() Configuration {
 		},
 	}
 }
+
+// ClusterName returns the cluster we operate on.
+func (c *Component) ClusterName() string {
+	return c.config.Cluster
+}
+
+// DatabaseName returns the database we operate on.
+func (c *Component) DatabaseName() string {
+	return c.config.Database
+}

--- a/common/clickhousedb/tests.go
+++ b/common/clickhousedb/tests.go
@@ -39,11 +39,6 @@ func SetupClickHouse(t *testing.T, r *reporter.Reporter, cluster bool) *Componen
 	return c
 }
 
-// ClusterName returns the name of the cluster (for testing only)
-func (c *Component) ClusterName() string {
-	return c.config.Cluster
-}
-
 // NewMock creates a new component using a mock driver. It returns
 // both the component and the mock driver.
 func NewMock(t *testing.T, r *reporter.Reporter) (*Component, *mocks.MockConn) {

--- a/config/akvorado.yaml
+++ b/config/akvorado.yaml
@@ -35,12 +35,14 @@ geoip:
   #geo-database:
   # - /usr/share/GeoIP/GeoLite2-Country.mmdb
 
+clickhousedb:
+  servers:
+    - clickhouse:9000
+
 clickhouse:
   orchestrator-url: http://akvorado-orchestrator:8080
   kafka:
     consumers: 4
-  servers:
-    - clickhouse:9000
   prometheus-endpoint: /metrics
   asns:
     64501: ACME Corporation

--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -786,18 +786,25 @@ By default, the configuration entries are kept in sync with the content of
 the configuration file, except if you disable the `config-entries-strict-sync`,
 the existing non-listed overrides won't be removed from topic configuration entries.
 
-### ClickHouse
+### ClickHouse database
 
-The ClickHouse component exposes some useful HTTP endpoints to
-configure a ClickHouse database. It also provisions and keep
-up-to-date a ClickHouse database. The following keys should be
-provided:
+The ClickHouse database component contains the settings to connect to the
+ClickHouse database. The following keys should be provided inside
+`clickhousedb`:
 
 - `servers` defines the list of ClickHouse servers to connect to
 - `username` is the username to use for authentication
 - `password` is the password to use for authentication
 - `database` defines the database to use to create tables
-- `cluster` defines the cluster for replicated and distributed tables, see below for more information
+- `cluster` defines the cluster for replicated and distributed tables, see the next section for more information
+
+### ClickHouse
+
+The ClickHouse component exposes some useful HTTP endpoints to
+configure a ClickHouse database. It also provisions and keep
+up-to-date a ClickHouse database. The following keys can be
+provided inside `clickhouse`:
+
 - `kafka` defines the configuration for the Kafka consumer. The accepted keys are:
   - `consumers` defines the number of consumers to use to consume messages from
     the Kafka topic. It is silently bound by the maximum number of threads

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -18,6 +18,7 @@ identified with a specific icon:
   "unhealthy" state on non-updated installation
 - 🌱 *docker*: enable access log for Traefik
 - 🌱 *docker*: update Traefik to 3.4 (not mandatory)
+- 🌱 *orchestrator*: move ClickHouse database settings from `clickhouse` to `clickhousedb`
 - 🌱 *inlet*: improve performance of classifiers
 
 ## 1.11.5 - 2025-05-11

--- a/orchestrator/clickhouse/config.go
+++ b/orchestrator/clickhouse/config.go
@@ -9,7 +9,6 @@ import (
 
 	"akvorado/common/remotedatasourcefetcher"
 
-	"akvorado/common/clickhousedb"
 	"akvorado/common/helpers"
 	"akvorado/common/kafka"
 
@@ -18,7 +17,6 @@ import (
 
 // Configuration describes the configuration for the ClickHouse configurator.
 type Configuration struct {
-	clickhousedb.Configuration `mapstructure:",squash" yaml:"-,inline"`
 	// SkipMigrations tell if we should skip migrations.
 	SkipMigrations bool
 	// Kafka describes Kafka-specific configuration
@@ -90,7 +88,6 @@ type KafkaConfiguration struct {
 // DefaultConfiguration represents the default configuration for the ClickHouse configurator.
 func DefaultConfiguration() Configuration {
 	return Configuration{
-		Configuration: clickhousedb.DefaultConfiguration(),
 		Kafka: KafkaConfiguration{
 			Consumers: 1,
 			GroupName: "clickhouse",

--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -60,11 +60,11 @@ func (c *Component) migrateDatabase() error {
 		return fmt.Errorf("incorrect ClickHouse version: %w", err)
 	}
 
-	if c.config.Cluster != "" {
+	if c.d.ClickHouse.ClusterName() != "" {
 		var shardNum uint64
 		row = c.d.ClickHouse.QueryRow(ctx,
 			`SELECT countDistinct(shard_num) AS num FROM system.clusters WHERE cluster = $1`,
-			c.config.Cluster,
+			c.d.ClickHouse.ClusterName(),
 		)
 		if err := row.Scan(&shardNum); err != nil {
 			c.r.Err(err).Msg("unable to parse cluster settings")
@@ -210,5 +210,5 @@ func (c *Component) getHTTPBaseURL(address string) (string, error) {
 
 // ReloadDictionary will reload the specified dictionnary.
 func (c *Component) ReloadDictionary(ctx context.Context, dictName string) error {
-	return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s.%s", c.config.Database, dictName))
+	return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s.%s", c.d.ClickHouse.DatabaseName(), dictName))
 }

--- a/orchestrator/clickhouse/migrations_test.go
+++ b/orchestrator/clickhouse/migrations_test.go
@@ -137,9 +137,6 @@ func startTestComponent(t *testing.T, r *reporter.Reporter, chComponent *clickho
 	configuration := DefaultConfiguration()
 	configuration.OrchestratorURL = "http://127.0.0.1:0"
 	configuration.Kafka.Configuration = kafka.DefaultConfiguration()
-	// This is a bit hacky, in real setup, the same configuration block is
-	// used for both clickhousedb.Component and clickhouse.Component.
-	configuration.Cluster = chComponent.ClusterName()
 	ch, err := New(r, configuration, Dependencies{
 		Daemon:     daemon.NewMock(t),
 		HTTP:       httpserver.NewMock(t, r),
@@ -432,7 +429,7 @@ SELECT toString(groupArray(tuple(name, type, default_expression)))
 FROM system.columns
 WHERE table = $1
 AND database = $2
-AND name LIKE $3`, "flows", ch.config.Database, "%DimensionAttribute")
+AND name LIKE $3`, "flows", ch.d.ClickHouse.DatabaseName(), "%DimensionAttribute")
 		var existing string
 		if err := row.Scan(&existing); err != nil {
 			t.Fatalf("Scan() error:\n%+v", err)
@@ -507,7 +504,7 @@ SELECT toString(groupArray(tuple(name, type, default_expression)))
 FROM system.columns
 WHERE table = $1
 AND database = $2
-AND name LIKE $3`, "flows", ch.config.Database, "%DimensionAttribute")
+AND name LIKE $3`, "flows", ch.d.ClickHouse.DatabaseName(), "%DimensionAttribute")
 		var existing string
 		if err := row.Scan(&existing); err != nil {
 			t.Fatalf("Scan() error:\n%+v", err)

--- a/orchestrator/clickhouse/root.go
+++ b/orchestrator/clickhouse/root.go
@@ -46,7 +46,7 @@ type Component struct {
 	networksCSVLock       sync.Mutex
 }
 
-// Dependencies define the dependencies of the ClickHouse configurator.
+// Dependencies define the dependencies of the orchestrator.
 type Dependencies struct {
 	Daemon     daemon.Component
 	HTTP       *httpserver.Component


### PR DESCRIPTION
Instead, properly use them from the clickhousedb component. Also provide some automatic migration.