### PR TITLE
docker: switch away from Nix to build Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,25 @@ jobs:
         if: always()
         run: docker compose -f docker/docker-compose-dev.yml down --remove-orphans --timeout 60
 
+  build-nix:
+    name: ❄️ Build on Nix
+    runs-on: ubuntu-latest
+    needs:
+      - dependabot
+    if: needs.dependabot.outputs.package-ecosystem != 'npm_and_yarn'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: cachix/install-nix-action@v31
+      - name: Update dependency hashes
+        run: nix run .#update
+      - name: Build
+        run: nix build && ./result/bin/akvorado version
+
   build-macos:
     name: 🍏 Build and test on macOS
     runs-on: macos-14
@@ -241,12 +260,11 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: >-
-            ${{
-              github.ref_type == 'tag' &&
-              'linux/amd64,linux/amd64/v3,linux/arm64' ||
-              'linux/amd64,linux/amd64/v3'
-            }}
+          platforms: |
+            linux/amd64
+            linux/amd64/v3
+            linux/arm64
+            linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -260,6 +278,8 @@ jobs:
     needs:
       - build-go
       - build-js
+      - build-nix
+      - build-macos
       - docker
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=max
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:main
-          cache-to: type=inline
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
   release:
     name: 🚀 Publish release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Get version
+        id: version
+        run: |
+          echo version=$(make version) >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/metadata-action@v5
@@ -256,9 +260,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - name: Build image
+        uses: docker/build-push-action@v6
         with:
-          context: .
           file: docker/Dockerfile
           platforms: |
             linux/amd64
@@ -266,6 +270,8 @@ jobs:
             linux/arm64
             linux/arm/v7
           push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ GENERATED = \
 
 .PHONY: all
 all: fmt lint $(GENERATED) ; $(info $(M) building executable…) @ ## Build program binary
-	$Q $(GO) build \
+	$Q env GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
+         $(if $(filter amd64,$(TARGETARCH)),GOAMD64=$(TARGETVARIANT),\
+         $(if $(filter arm64,$(TARGETARCH)),GOARM64=$(TARGETVARIANT).0,\
+         $(if $(filter arm,$(TARGETARCH)),GOARM=$(TARGETVARIANT:v%=%)))) \
+	   $(GO) build \
 		-tags release \
 		-ldflags '-X $(MODULE)/common/helpers.AkvoradoVersion=$(VERSION)' \
 		-o bin/$(basename $(MODULE)) main.go

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,9 @@ package cmd
 import (
 	"net/http"
 	"runtime"
+	runtimedebug "runtime/debug"
 	"slices"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
@@ -27,6 +29,13 @@ var versionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.Printf("akvorado %s\n", helpers.AkvoradoVersion)
 		cmd.Printf("  Built with: %s\n", runtime.Version())
+		if info, ok := runtimedebug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if strings.HasPrefix(setting.Key, "GO") {
+					cmd.Printf("  Build setting %s=%s\n", setting.Key, setting.Value)
+				}
+			}
+		}
 		cmd.Println()
 
 		sch, err := schema.New(schema.DefaultConfiguration())

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -26,10 +27,18 @@ func TestVersion(t *testing.T) {
 	want := []string{
 		"akvorado dev",
 		fmt.Sprintf("  Built with: %s", runtime.Version()),
+		fmt.Sprintf("  Build setting GOARCH=%s", runtime.GOARCH),
+		fmt.Sprintf("  Build setting GOOS=%s", runtime.GOOS),
 		"",
 	}
-	got := strings.Split(buf.String(), "\n")[:len(want)]
-	if diff := helpers.Diff(got, want); diff != "" {
+	got := strings.Split(buf.String(), "\n")
+	got = slices.DeleteFunc(got, func(s string) bool {
+		return strings.HasPrefix(s, "  Build setting") &&
+			!strings.HasPrefix(s, "  Build setting GOOS") &&
+			!strings.HasPrefix(s, "  Build setting GOARCH")
+	})
+
+	if diff := helpers.Diff(got[:len(want)], want); diff != "" {
 		t.Errorf("`version` (-got, +want):\n%s", diff)
 	}
 }

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -15,6 +15,7 @@ identified with a specific icon:
 - 💥 *common*: be stricter on results returned from remote sources
 - 🌱 *outlet*: commit records from Kafka after queuing them to ClickHouse
 - 🌱 *docker*: build a linux/amd64/v3 image to enable some optimizations
+- 🌱 *docker*: build a linux/arm/v7 image
 - 🌱 *docker*: change default log level for ClickHouse from trace to information
 - 🌱 *docker*: switch from Provectus Kafka UI (unmaintained) to Kafbat UI
 - 🌱 *docker*: expose metrics and Kafka UI (read-only) to the public endpoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN touch console/frontend/node_modules console/data/frontend .fmt-js~ .fmt.go~ 
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG VERSION
 RUN make
 
 FROM gcr.io/distroless/static:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,31 @@
-FROM nixpkgs/nix-flakes:latest AS build
-ARG TARGETPLATFORM
-RUN echo filter-syscalls = false >> /etc/nix/nix.conf
-WORKDIR /app
+FROM --platform=$BUILDPLATFORM node:20-alpine AS build-js
+RUN apk add --no-cache make
+WORKDIR /build
+COPY console/frontend console/frontend
+COPY Makefile .
+RUN make console/data/frontend
+
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build-go
+RUN apk add --no-cache make mailcap
+WORKDIR /build
+# Cache for modules
+COPY go.mod go.sum .
+RUN go mod download
+# Build
 COPY . .
-RUN mkdir -p /output/store
-RUN git describe --tags --always --dirty --match=v* > .version && git add -f .version
-RUN nix run ".#update" \
- && nix run ".#build" \
- && cp -va $(nix-store -qR result) /output/store \
- && rm -rf /output/store/*-akvorado
+COPY --from=build-js /build/console/data/frontend console/data/frontend
+RUN touch console/frontend/node_modules console/data/frontend .fmt-js~ .fmt.go~ .lint-js~ .lint-go~
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN make
 
 FROM gcr.io/distroless/static:latest
 LABEL org.opencontainers.image.source=https://github.com/akvorado/akvorado
 LABEL org.opencontainers.image.description="Akvorado: flow collector, enricher and visualizer"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
-COPY --from=build /output/store /nix/store
-COPY --from=build /app/result/  /usr/local/
+COPY --from=build-go /etc/mime.types /etc/mime.types
+COPY --from=build-go /build/bin/akvorado /usr/local/bin/akvorado
 EXPOSE 8080
 HEALTHCHECK --interval=20s CMD [ "/usr/local/bin/akvorado", "healthcheck" ]
 ENTRYPOINT [ "/usr/local/bin/akvorado" ]

--- a/docker/Dockerfile.nix
+++ b/docker/Dockerfile.nix
@@ -1,0 +1,21 @@
+FROM nixpkgs/nix-flakes:latest AS build
+ARG TARGETPLATFORM
+RUN echo filter-syscalls = false >> /etc/nix/nix.conf
+WORKDIR /app
+COPY . .
+RUN mkdir -p /output/store
+RUN git describe --tags --always --dirty --match=v* > .version && git add -f .version
+RUN nix run ".#update" \
+ && nix run ".#build" \
+ && cp -va $(nix-store -qR result) /output/store \
+ && rm -rf /output/store/*-akvorado
+
+FROM gcr.io/distroless/static:latest
+LABEL org.opencontainers.image.source=https://github.com/akvorado/akvorado
+LABEL org.opencontainers.image.description="Akvorado: flow collector, enricher and visualizer"
+LABEL org.opencontainers.image.licenses=AGPL-3.0-only
+COPY --from=build /output/store /nix/store
+COPY --from=build /app/result/  /usr/local/
+EXPOSE 8080
+HEALTHCHECK --interval=20s CMD [ "/usr/local/bin/akvorado", "healthcheck" ]
+ENTRYPOINT [ "/usr/local/bin/akvorado" ]

--- a/docker/Dockerfile.nix
+++ b/docker/Dockerfile.nix
@@ -4,7 +4,7 @@ RUN echo filter-syscalls = false >> /etc/nix/nix.conf
 WORKDIR /app
 COPY . .
 RUN mkdir -p /output/store
-RUN git describe --tags --always --dirty --match=v* > .version && git add -f .version
+RUN make version > .version && git add -f .version
 RUN nix run ".#update" \
  && nix run ".#build" \
  && cp -va $(nix-store -qR result) /output/store \


### PR DESCRIPTION
This should be faster to build multiarch images, as Nix requires emulation, while we can build everything natively using builtin Go cross-compilation support. Moreover, caching should be better.

Also, add Nix build to CI.

Also, build more architectures (linux/arm/v7).