### PR TITLE
docker: update kafka data volume mount path

### DIFF
--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -10,6 +10,10 @@ identified with a specific icon:
 - 🩹: bug fix
 - 🌱: miscellaneous change
 
+## Unreleased
+
+- 💥 *docker*: update kafka data volume mount path
+
 ## 2.0.0-beta.4 - 2025-08-18
 
 > [!CAUTION]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
     restart: unless-stopped
     volumes:
-      - akvorado-kafka:/var/lib/kafka
+      - akvorado-kafka:/var/lib/kafka/data
     healthcheck:
       interval: 20s
       test: ["CMD",


### PR DESCRIPTION
# Summary

The migration from `bitnami/kafka` to `apache/kafka` in 1eb3822 introduces a change in the data volume used by the Kakfa container: [`apache/kafka` defines an anonymous volume under `/var/lib/kafka/data`](https://hub.docker.com/layers/apache/kafka/4.0.0/images/sha256-01b9a4030e54c6068e66eb3ba4cb82c0d89238629ef1c30d79b86036bf89b1b7), not `/var/lib/kafka`.

The current compose file therefore no longer uses the named volume: since the mount path does not match, the anonymous volume takes precedence.

Unfortunately, this is a breaking change, this PR suggests one implementation, there are other possibilities but this one was (imo) the best compromise.

# Why this implementation

Let's only change the mount path. This has the following implications:
1. previous Kafka data is lost
2. it's technically still kept in the volume of course, but unusable (which means it takes up disk space)

This was motivated by the fact that:
1. the changelogs for `v2.0.0-beta.1` already suggest removing the Kafka volume and starting from scratch, so this would be in line with it
2. changing the volume name would remove leftover data, but people might have volume overrides defined in their `docker-compose-local`, so that could be more significant breaking change

I think that's the best compromise.

# Why not specifying the mount subpath

Another possibility would be to use the `subpath` volume mount option:
```yaml
services:
  kafka:
    volumes:
      - type: volume
        source: akvorado-kafka
        target: /var/lib/kafka/data
        volume:
          subpath: data
```

I believe this would make the change fully transparent, however this option is only supported in compose >= 2.26 and I'm not sure such a hard requirement would be acceptable.