### PR TITLE
outlet/kafka: expose consumer lag as a prometheus metric

### DIFF
--- a/outlet/kafka/metrics.go
+++ b/outlet/kafka/metrics.go
@@ -4,6 +4,11 @@
 package kafka
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"akvorado/common/pb"
 	"akvorado/common/reporter"
 )
 
@@ -15,6 +20,7 @@ type metrics struct {
 	workers          reporter.GaugeFunc
 	workerIncrease   reporter.Counter
 	workerDecrease   reporter.Counter
+	consumerLag      reporter.GaugeFunc
 }
 
 func (c *realComponent) initMetrics() {
@@ -69,4 +75,73 @@ func (c *realComponent) initMetrics() {
 			Help: "Number of times a new worker was stopped.",
 		},
 	)
+	c.metrics.consumerLag = c.r.GaugeFunc(
+		reporter.GaugeOpts{
+			Name: "consumergroup_lag_messages",
+			Help: "Current consumer lag across all partitions. A value of -1 indicates an issue with Kafka and/or consumers",
+		},
+		func() float64 {
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			c.kadmClientMu.Lock()
+			defer c.kadmClientMu.Unlock()
+			if c.kadmClient == nil {
+				return -1
+			}
+
+			lag, err := c.computeLagMetric(ctx)
+			if err != nil {
+				c.r.Err(err).Msg("lag metric refresh failed, setting to -1")
+				return -1
+			}
+			return lag
+		},
+	)
+}
+
+func (c *realComponent) computeLagMetric(ctx context.Context) (float64, error) {
+	lag, err := c.kadmClient.Lag(ctx, c.config.ConsumerGroup)
+	if err != nil {
+		return -1, fmt.Errorf("unable to compute Kafka group lag: %w", err)
+	}
+
+	// The map entry should exist, but let's check anyway to be safe
+	perGroupLag, ok := lag[c.config.ConsumerGroup]
+	if !ok {
+		return -1, fmt.Errorf("unable to find Kafka consumer group %q", c.config.ConsumerGroup)
+	}
+	if perGroupLag.FetchErr != nil {
+		return -1, fmt.Errorf("unable to fetch Kafka consumer group offsets %q: %w", c.config.ConsumerGroup, perGroupLag.FetchErr)
+	}
+	if perGroupLag.DescribeErr != nil {
+		return -1, fmt.Errorf("unable to describe Kafka consumer group %q: %w", c.config.ConsumerGroup, perGroupLag.DescribeErr)
+	}
+
+	// Retrieve only the current topic as there may be several
+	topic := fmt.Sprintf("%s-v%d", c.config.Topic, pb.Version)
+	perPartitionGroupLag, ok := perGroupLag.Lag[topic]
+	if !ok {
+		return -1, fmt.Errorf("unable to find Kafka consumer group lag for topic %q", topic)
+	}
+
+	// Finally, sum the lag across all partitions
+	var lagTotal int64
+	for _, partitionLag := range perPartitionGroupLag {
+		// Skip possibly unassigned partitions in case of rebalancing
+		if partitionLag.IsEmpty() {
+			continue
+		}
+
+		if partitionLag.Err != nil {
+			memberOrInstanceID := partitionLag.Member.MemberID
+			if partitionLag.Member.InstanceID != nil {
+				memberOrInstanceID = *partitionLag.Member.InstanceID
+			}
+			return -1, fmt.Errorf("unable to compute Kafka consumer lag because of a commit error on group %q, member %q, partition %q: %w", c.config.ConsumerGroup, memberOrInstanceID, partitionLag.Partition, partitionLag.Err)
+		}
+		lagTotal += partitionLag.Lag
+	}
+
+	return float64(lagTotal), nil
 }


### PR DESCRIPTION
# Summary

Monitoring consumer lag is useful to troubleshoot performance/scaling issues. It can currenctly be seen through kafka-ui, but a proper metric is more practical.

Unfortunately, JMX metrics on the broker don't expose this. It seems that people usually resort to monitoring from the consumer side, or through other external exporters like [Burrow](https://github.com/linkedin/Burrow) or [kafka_exporter](https://github.com/danielqsj/kafka_exporter).

franz-go/kadm provides a function to compute the consumer lag!

# Testing

```
curl -s http://localhost:8080/api/v0/outlet/metrics | grep akvorado_outlet_kafka_consumergroup_lag_messages
```

This should return a somewhat stable and low number. The average value most likely depends on the configured ClickHouse batch size / max wait time, but monitoring for sudden increases is probably better than hardcoded thresholds. 

1. `docker compose stop akvorado-outlet; sleep 60; docker compose start akvorado-outlet`: the outlet stops processing flows, they'll accumulate in Kafka. Checking the metric right after restarting it after a while should show a higher consumer lag (sleeping for longer or sending more flows per second might be necessary)
2. `docker compose stop akvorado-inlet`: the inlet stops ingesting flows, consumer lag drops to 0

In case Kafka is unreachable / slow, the lag computation has a context deadline to make sure it doesn't block for more than half the ticker frequency.

# Implementation

- The metric is computed only when polled
- This implementation (as far as I can tell/test) correctly survives Kafka restarts

# Remaining questions/work

1. Is that ok? Should the implementation be done in a completely different way?
   - if ok: I'll update the troubleshooting / scaling documentation to mention this
3. I haven't written Go since a long time, there might be non-idiomatic stuff 
