### PR TITLE
console/filter: add autocomplete for the SrcPort and DstPort filters

### DIFF
--- a/console/filter_test.go
+++ b/console/filter_test.go
@@ -132,6 +132,50 @@ LIMIT 20`, "6540").
 			{"65402:200:100", "large community"},
 		}).
 		Return(nil)
+	mockConn.EXPECT().
+		Select(gomock.Any(), gomock.Any(), `
+SELECT label, detail FROM (
+ SELECT toString(SrcPort) AS label, dictGet('tcp', 'name', SrcPort) AS detail, 1 AS rank, count(*) AS c
+ FROM flows
+ WHERE TimeReceived > date_sub(minute, 1, now())
+ AND detail != ''
+ AND positionCaseInsensitive(detail, $1) >= 1
+ AND Proto = 6
+ GROUP BY SrcPort
+ ORDER BY COUNT(*) DESC
+ LIMIT 20
+UNION DISTINCT
+ SELECT toString(SrcPort) AS label, dictGet(udp, 'name', SrcPort) AS detail, 1 AS rank, count(*) AS c
+ FROM flows
+ WHERE TimeReceived > date_sub(minute, 1, now())
+ AND detail != ''
+ AND positionCaseInsensitive(detail, $1) >= 1
+ AND Proto = 17
+ GROUP BY SrcPort
+ ORDER BY COUNT(*) DESC
+ LIMIT 20
+UNION DISTINCT
+ SELECT toString(port) AS label, name AS detail, 2 AS rank, 0 AS c
+ FROM tcp
+ WHERE positionCaseInsensitive(name, $1) >= 1
+ ORDER BY positionCaseInsensitive(name, $1) ASC, port ASC
+ LIMIT 20
+UNION DISTINCT
+ SELECT toString(port) AS label, name AS detail, 2 AS rank, 0 AS c
+ FROM udp
+ WHERE positionCaseInsensitive(name, $1) >= 1
+ ORDER BY positionCaseInsensitive(name, $1) ASC, port ASC
+ LIMIT 20
+) GROUP BY rank, label, detail ORDER BY rank ASC, MAX(c) DESC, MIN(rowNumberInBlock()) ASC LIMIT 20`, "http").
+		SetArg(1, []struct {
+			Label  string `ch:"label"`
+			Detail string `ch:"detail"`
+		}{
+			{"443", "https"},
+			{"80", "http"},
+			{"8080", "http-alt"},
+		}).
+		Return(nil)
 
 	helpers.TestHTTPEndpoints(t, h.LocalAddr(), helpers.HTTPEndpointCases{
 		{
@@ -267,6 +311,16 @@ LIMIT 20`, "6540").
 				{"label": "AS36492", "detail": "Google", "quoted": false},
 				{"label": "AS36987", "detail": "Google Kenya", "quoted": false},
 				{"label": "AS41264", "detail": "Google Switzerland", "quoted": false},
+			}},
+		},
+		{
+			URL:        "/api/v0/console/filter/complete",
+			StatusCode: 200,
+			JSONInput:  gin.H{"what": "value", "column": "srcport", "prefix": "http"},
+			JSONOutput: gin.H{"completions": []gin.H{
+				{"label": "443", "detail": "https", "quoted": false},
+				{"label": "80", "detail": "http", "quoted": false},
+				{"label": "8080", "detail": "http-alt", "quoted": false},
 			}},
 		},
 		{


### PR DESCRIPTION
Hello

This PR adds autocomplete functionality for the ```SrcPort``` and ```DstPort``` filters. 
Example: if we enter ```SrcPort = http``` , it will display a list of all ports whose protocol name begins with ```http```.

<img width="301" height="190" alt="image" src="https://github.com/user-attachments/assets/b142a9ce-ea89-4b33-bd9c-b4180faf82a8" />


This follows on from my first PR #1257 