### PR TITLE
inlet/flow: make some of the socket options not fatal

### DIFF
--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -10,6 +10,10 @@ identified with a specific icon:
 - 🩹: bug fix
 - 🌱: miscellaneous change
 
+## Unreleased
+
+- 🩹 *inlet*: disable kernel timestamping on Linux kernel older than 5.1
+
 ## 2.0.0 - 2025-09-22
 
 This release introduces a new component: the outlet. Previously, ClickHouse was

--- a/inlet/flow/input/udp/root.go
+++ b/inlet/flow/input/udp/root.go
@@ -120,7 +120,8 @@ func (in *Input) Start() error {
 				return fmt.Errorf("unable to resolve %v: %w", in.config.Listen, err)
 			}
 		}
-		pconn, err := listenConfig.ListenPacket(in.t.Context(context.Background()), "udp", listenAddr.String())
+		pconn, err := listenConfig(in.r, udpSocketOptions).
+			ListenPacket(in.t.Context(context.Background()), "udp", listenAddr.String())
 		if err != nil {
 			return fmt.Errorf("unable to listen to %v: %w", listenAddr, err)
 		}

--- a/inlet/flow/input/udp/socket_linux.go
+++ b/inlet/flow/input/udp/socket_linux.go
@@ -15,13 +15,30 @@ import (
 
 var (
 	oobLength        = syscall.CmsgLen(4) + syscall.CmsgLen(16) // uint32 + 2*int64
-	udpSocketOptions = []int{
-		// Allow multiple listeners to bind to the same IP/port
-		unix.SO_REUSEADDR, unix.SO_REUSEPORT,
-		// Get the number of dropped packets
-		unix.SO_RXQ_OVFL,
-		// Ask the kernel to timestamp incoming packets
-		unix.SO_TIMESTAMP_NEW | unix.SOF_TIMESTAMPING_RX_SOFTWARE,
+	udpSocketOptions = []socketOption{
+		{
+			// Allow multiple listeners to bind to the same IP
+			Name:      "SO_REUSEADDR",
+			Level:     unix.SOL_SOCKET,
+			Option:    unix.SO_REUSEADDR,
+			Mandatory: true,
+		}, {
+			// Allow multiple listeners to bind to the same port
+			Name:      "SO_REUSEPORT",
+			Level:     unix.SOL_SOCKET,
+			Option:    unix.SO_REUSEPORT,
+			Mandatory: true,
+		}, {
+			// Get the number of dropped packets
+			Name:   "SO_RXQ_OVFL",
+			Level:  unix.SOL_SOCKET,
+			Option: unix.SO_RXQ_OVFL,
+		}, {
+			// Ask the kernel to timestamp incoming packets
+			Name:   "SO_TIMESTAMP_NEW",
+			Level:  unix.SOL_SOCKET,
+			Option: unix.SO_TIMESTAMP_NEW | unix.SOF_TIMESTAMPING_RX_SOFTWARE,
+		},
 	}
 )
 

--- a/inlet/flow/input/udp/socket_others.go
+++ b/inlet/flow/input/udp/socket_others.go
@@ -9,7 +9,21 @@ import "golang.org/x/sys/unix"
 
 var (
 	oobLength        = 0
-	udpSocketOptions = []int{unix.SO_REUSEADDR, unix.SO_REUSEPORT}
+	udpSocketOptions = []socketOption{
+		{
+			// Allow multiple listeners to bind to the same IP
+			Name:      "SO_REUSEADDR",
+			Level:     unix.SOL_SOCKET,
+			Option:    unix.SO_REUSEADDR,
+			Mandatory: true,
+		}, {
+			// Allow multiple listeners to bind to the same port
+			Name:      "SO_REUSEPORT",
+			Level:     unix.SOL_SOCKET,
+			Option:    unix.SO_REUSEPORT,
+			Mandatory: true,
+		},
+	}
 )
 
 // parseSocketControlMessage always returns 0.


### PR DESCRIPTION
If the kernel is too old for timestamping, it should not be fatal. I prefer to not accept SO_TIMESTAMP_OLD as the size of the timestamp is arch-dependent.

Fix #1978