### PR TITLE
outlet/metadata: fix gNMI metadata provider exiting too early

### DIFF
--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -13,6 +13,7 @@ identified with a specific icon:
 ## Unreleased
 
 - 🩹 *inlet*: disable kernel timestamping on Linux kernel older than 5.1
+- 🩹 *outlet*: fix gNMI metadata provider exiting too early
 - 🩹 *doc*: fix documentation for SNMPv3 configuration
 - 🌱 *inlet*: add support for RFC 5103 (bidirectional flows)
 

--- a/outlet/metadata/provider/gnmi/srlinux_test.go
+++ b/outlet/metadata/provider/gnmi/srlinux_test.go
@@ -728,7 +728,7 @@ commit now
 				iface, answer.Interface.Name, answer.Interface.Description, answer.Interface.Speed)
 		}
 		r := reporter.NewMock(t)
-		p, err := configP.New(r)
+		p, err := configP.New(t.Context(), r)
 		if err != nil {
 			t.Fatalf("New() error:\n%+v", err)
 		}

--- a/outlet/metadata/provider/root.go
+++ b/outlet/metadata/provider/root.go
@@ -67,6 +67,7 @@ type Provider interface {
 
 // Configuration defines an interface to configure a provider.
 type Configuration interface {
-	// New instantiates a new provider from its configuration.
-	New(r *reporter.Reporter) (Provider, error)
+	// New instantiates a new provider from its configuration. The provided
+	// context is to stop any long-running goroutine.
+	New(context.Context, *reporter.Reporter) (Provider, error)
 }

--- a/outlet/metadata/provider/snmp/poller_test.go
+++ b/outlet/metadata/provider/snmp/poller_test.go
@@ -278,7 +278,7 @@ func TestPoller(t *testing.T) {
 			config.Ports = helpers.MustNewSubnetMap(map[string]uint16{
 				"::/0": uint16(port),
 			})
-			p, err := config.New(r)
+			p, err := config.New(t.Context(), r)
 			if err != nil {
 				t.Fatalf("New() error:\n%+v", err)
 			}

--- a/outlet/metadata/provider/snmp/root.go
+++ b/outlet/metadata/provider/snmp/root.go
@@ -34,7 +34,7 @@ var (
 )
 
 // New creates a new SNMP provider from configuration
-func (configuration Configuration) New(r *reporter.Reporter) (provider.Provider, error) {
+func (configuration Configuration) New(_ context.Context, r *reporter.Reporter) (provider.Provider, error) {
 	for exporterIP, agentIP := range configuration.Agents {
 		if exporterIP.Is4() || agentIP.Is4() {
 			delete(configuration.Agents, exporterIP)

--- a/outlet/metadata/provider/static/root.go
+++ b/outlet/metadata/provider/static/root.go
@@ -41,7 +41,7 @@ var (
 )
 
 // New creates a new static provider from configuration
-func (configuration Configuration) New(r *reporter.Reporter) (provider.Provider, error) {
+func (configuration Configuration) New(_ context.Context, r *reporter.Reporter) (provider.Provider, error) {
 	p := &Provider{
 		r:            r,
 		exportersMap: map[string][]exporterInfo{},

--- a/outlet/metadata/provider/static/root_test.go
+++ b/outlet/metadata/provider/static/root_test.go
@@ -97,7 +97,7 @@ func TestStaticProvider(t *testing.T) {
 
 	var got []provider.Answer
 	r := reporter.NewMock(t)
-	p, _ := config.New(r)
+	p, _ := config.New(t.Context(), r)
 
 	answer, _ := p.Query(context.Background(), provider.Query{
 		ExporterIP: netip.MustParseAddr("2001:db8:1::10"),

--- a/outlet/metadata/provider/static/source_test.go
+++ b/outlet/metadata/provider/static/source_test.go
@@ -186,7 +186,7 @@ func TestRemoteExporterSources(t *testing.T) {
 			},
 		},
 	}
-	p, _ := config.New(r)
+	p, _ := config.New(t.Context(), r)
 
 	// Query when json is not ready yet, we should get a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)

--- a/outlet/metadata/root.go
+++ b/outlet/metadata/root.go
@@ -80,7 +80,7 @@ func New(r *reporter.Reporter, configuration Configuration, dependencies Depende
 
 	// Initialize providers
 	for _, p := range c.config.Providers {
-		selectedProvider, err := p.Config.New(r)
+		selectedProvider, err := p.Config.New(c.t.Context(nil), r)
 		if err != nil {
 			return nil, err
 		}

--- a/outlet/metadata/root_test.go
+++ b/outlet/metadata/root_test.go
@@ -230,7 +230,7 @@ func (ep errorProvider) Query(_ context.Context, _ provider.Query) (provider.Ans
 
 type errorProviderConfiguration struct{}
 
-func (epc errorProviderConfiguration) New(_ *reporter.Reporter) (provider.Provider, error) {
+func (epc errorProviderConfiguration) New(context.Context, *reporter.Reporter) (provider.Provider, error) {
 	return errorProvider{}, nil
 }
 

--- a/outlet/metadata/tests.go
+++ b/outlet/metadata/tests.go
@@ -73,7 +73,7 @@ func (mp mockProvider) Query(_ context.Context, query provider.Query) (provider.
 type mockProviderConfiguration struct{}
 
 // New returns a new mock provider.
-func (mpc mockProviderConfiguration) New(_ *reporter.Reporter) (provider.Provider, error) {
+func (mpc mockProviderConfiguration) New(context.Context, *reporter.Reporter) (provider.Provider, error) {
 	return mockProvider{}, nil
 }
 
@@ -103,6 +103,6 @@ func (mp emptyProvider) Query(_ context.Context, _ provider.Query) (provider.Ans
 type emptyProviderConfiguration struct{}
 
 // New returns a new empty provider.
-func (mpc emptyProviderConfiguration) New(_ *reporter.Reporter) (provider.Provider, error) {
+func (mpc emptyProviderConfiguration) New(context.Context, *reporter.Reporter) (provider.Provider, error) {
 	return emptyProvider{}, nil
 }


### PR DESCRIPTION
We have to manage two contexts:

- one associated to a query because the queries are now synchronous
- one associated to the component because some providers need a goroutine (like gNMI)

Fix #1991.