### PR TITLE
compare bart.Table and bart.Fast lookup

### DIFF
--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -184,7 +184,7 @@ func TestRTAEqual(t *testing.T) {
 }
 
 func TestRemoveRoutes(t *testing.T) {
-	nr := func(r *rib, peer uint32) route {
+	nr := func(r *ribFast, peer uint32) route {
 		return route{
 			peer:    peer,
 			nlri:    r.nlris.Put(nlri{family: bgp.RF_IPv4_UC, path: 1}),
@@ -196,7 +196,7 @@ func TestRemoveRoutes(t *testing.T) {
 		}
 	}
 	t.Run("only route", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r.AddPrefix(netip.MustParsePrefix("::ffff:192.168.144.0/120"), nr(r, 10))
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
 		count, empty := r.removeRoutes(idx, func(route) bool { return true }, true)
@@ -212,7 +212,7 @@ func TestRemoveRoutes(t *testing.T) {
 	})
 
 	t.Run("first route", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r1 := nr(r, 10)
 		r2 := nr(r, 11)
 		r.AddPrefix(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
@@ -233,7 +233,7 @@ func TestRemoveRoutes(t *testing.T) {
 	})
 
 	t.Run("second route", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r1 := nr(r, 10)
 		r2 := nr(r, 11)
 		r.AddPrefix(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
@@ -253,7 +253,7 @@ func TestRemoveRoutes(t *testing.T) {
 		}
 	})
 	t.Run("middle route", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r1 := nr(r, 10)
 		r2 := nr(r, 11)
 		r3 := nr(r, 12)
@@ -276,7 +276,7 @@ func TestRemoveRoutes(t *testing.T) {
 		}
 	})
 	t.Run("one route out of two", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r1 := nr(r, 10)
 		r2 := nr(r, 11)
 		r3 := nr(r, 12)
@@ -304,7 +304,7 @@ func TestRemoveRoutes(t *testing.T) {
 	})
 
 	t.Run("all routes", func(t *testing.T) {
-		r := newRIB()
+		r := newFastRIB()
 		r1 := nr(r, 10)
 		r2 := nr(r, 11)
 		r3 := nr(r, 12)
@@ -344,7 +344,7 @@ func TestRIBHarness(t *testing.T) {
 			run, totalExporters, peerPerExporter,
 			maxInitialRoutePerPeer, maxRemovedRoutePerPeer, maxReaddedRoutePerPeer)
 
-		r := newRIB()
+		r := newFastRIB()
 		type lookup struct {
 			peer    uint32
 			addr    netip.Addr

--- a/outlet/routing/provider/bmp/root.go
+++ b/outlet/routing/provider/bmp/root.go
@@ -34,7 +34,7 @@ type Provider struct {
 	metrics metrics
 
 	// RIB management with peers
-	rib               *rib
+	rib               *ribFast
 	peers             map[peerKey]*peerInfo
 	lastPeerReference uint32
 	staleTimer        *clock.Timer
@@ -59,7 +59,7 @@ func (configuration Configuration) New(r *reporter.Reporter, dependencies Depend
 		d:      &dependencies,
 		config: configuration,
 
-		rib:   newRIB(),
+		rib:   newFastRIB(),
 		peers: make(map[peerKey]*peerInfo),
 	}
 	if len(p.config.RDs) > 0 {


### PR DESCRIPTION
I fixed (maybe) your lookup benchmark (ipv4-mapped addrs in lookup) and removed the inner range over prefixes in b.Loop() and divided by b.N, here are my results:
```text
$ go test -run=xxx -bench=BenchmarkRIBLookup
goos: linux
goarch: amd64
pkg: akvorado/outlet/routing/provider/bmp
cpu: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
BenchmarkRIBLookupFAST/1000_routes,_1_peers-8         	59207290	        20.18 ns/op
BenchmarkRIBLookupFAST/1000_routes,_2_peers-8         	58501526	        20.17 ns/op
BenchmarkRIBLookupFAST/1000_routes,_5_peers-8         	54101719	        20.23 ns/op
BenchmarkRIBLookupFAST/10000_routes,_1_peers-8        	59427116	        20.15 ns/op
BenchmarkRIBLookupFAST/10000_routes,_2_peers-8        	59365204	        20.11 ns/op
BenchmarkRIBLookupFAST/10000_routes,_5_peers-8        	59485538	        20.15 ns/op
BenchmarkRIBLookupFAST/100000_routes,_1_peers-8       	58626580	        20.14 ns/op
BenchmarkRIBLookupFAST/100000_routes,_2_peers-8       	59028798	        20.17 ns/op
BenchmarkRIBLookupFAST/100000_routes,_5_peers-8       	59120834	        20.15 ns/op
BenchmarkRIBLookupBART/1000_routes,_1_peers-8         	39616549	        29.58 ns/op
BenchmarkRIBLookupBART/1000_routes,_2_peers-8         	40250928	        29.52 ns/op
BenchmarkRIBLookupBART/1000_routes,_5_peers-8         	40028767	        29.55 ns/op
BenchmarkRIBLookupBART/10000_routes,_1_peers-8        	40388374	        29.49 ns/op
BenchmarkRIBLookupBART/10000_routes,_2_peers-8        	40667470	        29.48 ns/op
BenchmarkRIBLookupBART/10000_routes,_5_peers-8        	40750194	        29.49 ns/op
BenchmarkRIBLookupBART/100000_routes,_1_peers-8       	40722726	        29.68 ns/op
BenchmarkRIBLookupBART/100000_routes,_2_peers-8       	40652895	        29.47 ns/op
BenchmarkRIBLookupBART/100000_routes,_5_peers-8       	40145362	        30.15 ns/op
PASS
ok  	akvorado/outlet/routing/provider/bmp	24.486s
```
for me it's like expected, 20ns versus 30ns

Please check my version and correct me if I'm wrong.