### PR TITLE
build: don't use fetchurl to get IANA service names for Nix

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,6 +67,6 @@ runs:
         path: |
           orchestrator/clickhouse/data/udp.csv
           orchestrator/clickhouse/data/tcp.csv
-        key: iana-cache-${{ hashFiles('Makefile', 'nix/ianaServiceNamesHash.txt') }}-${{ github.run_id }}
+        key: iana-cache-${{ hashFiles('Makefile', 'flake.lock') }}-${{ github.run_id }}
         restore-keys: |
-          iana-cache-${{ hashFiles('Makefile', 'nix/ianaServiceNamesHash.txt') }}-
+          iana-cache-${{ hashFiles('Makefile', 'flake.lock') }}-

--- a/.github/workflows/update-nix-flake-lock.yml
+++ b/.github/workflows/update-nix-flake-lock.yml
@@ -15,6 +15,7 @@ jobs:
         source:
           - nixpkgs
           - asn2org
+          - iana-assignments
     steps:
       - uses: actions/checkout@v5
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -35,6 +35,22 @@
         "type": "github"
       }
     },
+    "iana-assignments": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761359241,
+        "narHash": "sha256-Q/bkxeQJFELXd+4Ma50PliUimIPiMBeGhC6nFUUDOzc=",
+        "owner": "larseggert",
+        "repo": "iana-assignments",
+        "rev": "597006e11311b3ebee998d86ab862955c5e7d6ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "larseggert",
+        "repo": "iana-assignments",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1760164275,
@@ -53,6 +69,7 @@
       "inputs": {
         "asn2org": "asn2org",
         "flake-utils": "flake-utils",
+        "iana-assignments": "iana-assignments",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/nix/ianaServiceNamesHash.txt
+++ b/nix/ianaServiceNamesHash.txt
@@ -1,1 +1,0 @@
-sha256-MMTJRwpFEvXDHxp+OXbpwTa6aUNd0JXvR6KMwymKiTo=


### PR DESCRIPTION
As the file may change, even the latest tagged version of flake.nix won't work to build Akvorado. Instead, rely on an unofficial Git repository.

Fix #2043
