### PR TITLE
Don't disable DCE

### DIFF
--- a/cmd/akvorado/demo-exporter.go
+++ b/cmd/akvorado/demo-exporter.go
@@ -39,6 +39,11 @@ func (c *DemoExporterConfiguration) Reset() {
 	}
 }
 
+// UnusedButExportedFunction is there to test dead code elimination.
+func (c *DemoExporterConfiguration) UnusedButExportedFunction() {
+	panic("never call me!")
+}
+
 type demoExporterOptions struct {
 	ConfigRelatedOptions
 	CheckMode bool

--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2025 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDeadCodeElimination(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("unsupported OS: %s", runtime.GOOS)
+	}
+	const (
+		code = `
+package main
+
+import "akvorado/cmd"
+
+func main() {
+  cmd.RootCmd.Execute()
+}`
+		dirname    = "test_deadcode"
+		progname   = "test_deadcode_elimination"
+		symbolname = "akvorado/cmd.(*DemoExporterConfiguration).UnusedButExportedFunction"
+	)
+	// Get flags from Makefile
+	makefile, err := os.ReadFile(filepath.Join("..", "Makefile"))
+	if err != nil {
+		t.Fatalf("ReadFile() error:\n%+v", err)
+	}
+	lines := strings.Split(string(makefile), "\n")
+	inAllTarget := false
+	tagsRe := regexp.MustCompile(`^\s+-tags\s+(\S+)\s+\\?\s*$`)
+	var tags string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "all:") {
+			inAllTarget = true
+			continue
+		}
+		if inAllTarget {
+			if len(line) > 0 && line[0] != '\t' && line[0] != ' ' {
+				inAllTarget = false
+				break
+			}
+			if matches := tagsRe.FindStringSubmatch(line); matches != nil {
+				tags = matches[1]
+				break
+			}
+		}
+	}
+	if tags == "" {
+		t.Fatalf("Could not find -tags in Makefile 'all' target")
+	}
+	t.Logf("Compilation tags: %s", tags)
+
+	// Build test program
+	_ = os.Mkdir(dirname, 0770)
+	defer os.RemoveAll(dirname)
+	filename := filepath.Join(dirname, fmt.Sprintf("%s.go", progname))
+	if err := os.WriteFile(filename, []byte(code), 0600); err != nil {
+		t.Fatalf("WriteFile() error:\n%+v", err)
+	}
+	if buf, err := exec.Command("go", "build", "-tags", tags, filename).CombinedOutput(); err != nil {
+		t.Fatalf("go build error:\n%s", buf)
+	}
+	defer os.Remove(progname)
+
+	// Check if symbol is present
+	f, err := elf.Open(progname)
+	if err != nil {
+		t.Fatalf("elf.Open() error:\n%+v", err)
+	}
+	defer f.Close()
+	symbols, err := f.Symbols()
+	if err != nil {
+		t.Fatalf("Symbols() error:\n%+v", err)
+	}
+	for _, sym := range symbols {
+		if sym.Name == symbolname {
+			t.Errorf("Expected %s to be eliminated, but it was found in binary", symbolname)
+			t.Log("Use `make all BUILD_ARGS=\"-ldflags=-dumpdep\" |& go run github.com/aarzilli/whydeadcode@latest`")
+			break
+		}
+	}
+}

--- a/console/authentication/handlers_test.go
+++ b/console/authentication/handlers_test.go
@@ -138,7 +138,7 @@ func TestUserHandlerWithTemplates(t *testing.T) {
 	h := httpserver.NewMock(t, r)
 	config := DefaultConfiguration()
 	config.LogoutURL = "/sso/portals/main/logout"
-	config.AvatarURL = "https://avatars.githubusercontent.com/{{ .Login }}?s=80"
+	config.AvatarURL = "https://avatars.githubusercontent.com/{{Login}}?s=80"
 	c, err := New(r, config)
 	if err != nil {
 		t.Fatalf("New() error:\n%+v", err)

--- a/console/authentication/middleware.go
+++ b/console/authentication/middleware.go
@@ -7,7 +7,8 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"text/template"
+
+	"github.com/valyala/fasttemplate"
 
 	"akvorado/common/helpers"
 	"akvorado/common/httpserver"
@@ -35,15 +36,16 @@ func UserFromContext(ctx context.Context) UserInformation {
 // UserAuthentication is a middleware to fill information about the current
 // user. It does not really perform authentication but relies on HTTP headers.
 func (c *Component) UserAuthentication() httpserver.Middleware {
-	var logoutURLTmpl, avatarURLTmpl *template.Template
+	var logoutURLTmpl, avatarURLTmpl *fasttemplate.Template
 	if c.config.LogoutURL != "" {
-		logoutURLTmpl, _ = template.New("logout").Parse(c.config.LogoutURL)
+		logoutURLTmpl, _ = fasttemplate.NewTemplate(c.config.LogoutURL, "{{", "}}")
 	}
 	if c.config.AvatarURL != "" {
-		avatarURLTmpl, _ = template.New("avatar").Parse(c.config.AvatarURL)
+		avatarURLTmpl, _ = fasttemplate.NewTemplate(c.config.AvatarURL, "{{", "}}")
 	}
 
 	return func(next http.Handler) http.Handler {
+
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			info := c.userFromHeaders(req)
 			if err := helpers.Validate.Struct(info); err != nil {
@@ -54,17 +56,24 @@ func (c *Component) UserAuthentication() httpserver.Middleware {
 				}
 				info = c.config.DefaultUser
 			}
+			data := map[string]any{
+				"Login":     info.Login,
+				"Name":      info.Name,
+				"Email":     info.Email,
+				"LogoutURL": info.LogoutURL,
+				"AvatarURL": info.AvatarURL,
+			}
 
 			// Apply configured templates (they can access header values and choose to keep or override)
 			if logoutURLTmpl != nil {
 				var buf strings.Builder
-				if err := logoutURLTmpl.Execute(&buf, info); err == nil {
+				if _, err := logoutURLTmpl.Execute(&buf, data); err == nil {
 					info.LogoutURL = buf.String()
 				}
 			}
 			if avatarURLTmpl != nil {
 				var buf strings.Builder
-				if err := avatarURLTmpl.Execute(&buf, info); err == nil {
+				if _, err := avatarURLTmpl.Execute(&buf, data); err == nil {
 					info.AvatarURL = buf.String()
 				}
 			}

--- a/console/clickhouse.go
+++ b/console/clickhouse.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"akvorado/console/query"
+
+	"github.com/valyala/fasttemplate"
 )
 
 // flowsTable describe a consolidated or unconsolidated flows table.
@@ -91,17 +93,6 @@ type inputContext struct {
 	Units                  string
 }
 
-// context is the context to finalize the template.
-type context struct {
-	Table             string
-	Timefilter        string
-	TimefilterStart   string
-	TimefilterEnd     string
-	Units             string
-	Interval          uint64
-	ToStartOfInterval string
-}
-
 // templateQuery holds a template string and its associated input context.
 type templateQuery struct {
 	Template string
@@ -111,15 +102,15 @@ type templateQuery struct {
 // templateEscape escapes `{{` and `}}` from a string. In fact, only
 // the opening tag needs to be escaped.
 func templateEscape(input string) string {
-	return strings.ReplaceAll(input, `{{`, `{{"{{"}}`)
+	return strings.ReplaceAll(input, `{{`, `{{Escape}}`)
 }
 
 // templateWhere transforms a filter to a WHERE clause
 func templateWhere(qf query.Filter) string {
 	if qf.Direct() == "" {
-		return `{{ .Timefilter }}`
+		return `{{Timefilter}}`
 	}
-	return fmt.Sprintf(`{{ .Timefilter }} AND (%s)`, templateEscape(qf.Direct()))
+	return fmt.Sprintf(`{{Timefilter}} AND (%s)`, templateEscape(qf.Direct()))
 }
 
 // finalizeTemplateQueries builds the finalized queries from a list of templateQuery.
@@ -185,26 +176,24 @@ func (c *Component) finalizeTemplateQuery(query templateQuery) string {
 
 	c.metrics.clickhouseQueries.WithLabelValues(table).Inc()
 
-	context := context{
-		Table:           table,
-		Timefilter:      timefilter,
-		TimefilterStart: timefilterStart,
-		TimefilterEnd:   timefilterEnd,
-		Units:           units,
-		Interval:        uint64(computedInterval.Seconds()),
-		ToStartOfInterval: fmt.Sprintf(
+	context := map[string]any{
+		"Table":           table,
+		"Timefilter":      timefilter,
+		"TimefilterStart": timefilterStart,
+		"TimefilterEnd":   timefilterEnd,
+		"Units":           units,
+		"Interval":        strconv.FormatUint(uint64(computedInterval.Seconds()), 10),
+		"ToStartOfInterval": fmt.Sprintf(
 			`toStartOfInterval(%s + INTERVAL %d second, INTERVAL %d second) - INTERVAL %d second`,
 			"TimeReceived",
 			diffOffset,
 			uint64(computedInterval.Seconds()),
 			diffOffset),
+		"Escape": "{{",
 	}
 
-	t := template.Must(template.New("query").
-		Option("missingkey=error").
-		Parse(strings.TrimSpace(query.Template)))
 	buf := bytes.NewBufferString("")
-	if err := t.Execute(buf, context); err != nil {
+	if _, err := fasttemplate.Execute(strings.TrimSpace(query.Template), "{{", "}}", buf, context); err != nil {
 		c.r.Err(err).Str("query", query.Template).Msg("invalid query")
 		panic(err)
 	}

--- a/console/clickhouse_test.go
+++ b/console/clickhouse_test.go
@@ -82,7 +82,7 @@ func TestFinalizeQuery(t *testing.T) {
 	}{
 		{
 			Description: "simple query without additional tables",
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query:       "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -91,7 +91,7 @@ func TestFinalizeQuery(t *testing.T) {
 			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
 		}, {
 			Description: "query with source port",
-			Query:       "SELECT TimeReceived, SrcPort FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query:       "SELECT TimeReceived, SrcPort FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:             time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:               time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -102,7 +102,7 @@ func TestFinalizeQuery(t *testing.T) {
 		}, {
 			Description: "only flows table available",
 			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query:       "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -112,7 +112,7 @@ func TestFinalizeQuery(t *testing.T) {
 		}, {
 			Description: "timefilter.Start and timefilter.Stop",
 			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT {{ .TimefilterStart }}, {{ .TimefilterEnd }}",
+			Query:       "SELECT {{TimefilterStart}}, {{TimefilterEnd}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -122,7 +122,7 @@ func TestFinalizeQuery(t *testing.T) {
 		}, {
 			Description: "only flows table and out of range request",
 			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query:       "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -135,7 +135,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 3, 10, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}} // {{Interval}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -148,7 +148,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -161,7 +161,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 4, 10, 16, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -174,7 +174,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 4, 10, 10, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 10, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}} // {{Interval}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -187,7 +187,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 4, 10, 10, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 10, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}} // {{Interval}}",
 			Context: inputContext{
 				Start: time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC),
 				End:   time.Date(2022, 3, 11, 15, 45, 10, 0, time.UTC),
@@ -204,7 +204,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows", 0, time.Date(2022, 3, 10, 16, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}} // {{Interval}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -218,7 +218,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_5m0s", 5 * time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}} // {{Interval}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -232,7 +232,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_5m0s", 5 * time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 46, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 46, 10, 0, time.UTC),
@@ -246,7 +246,7 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 22, 40, 0, 0, time.UTC)},
 				{"flows_1h0m0s", time.Hour, time.Date(2022, 4, 10, 22, 0, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Query: "SELECT 1 FROM {{Table}} WHERE {{Timefilter}}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 46, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 46, 10, 0, time.UTC),
@@ -255,7 +255,7 @@ func TestFinalizeQuery(t *testing.T) {
 			Expected: "SELECT 1 FROM flows_1m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:46:00', 'UTC') AND toDateTime('2022-04-11 15:46:00', 'UTC')",
 		}, {
 			Description: "query with escaped template",
-			Query:       `SELECT TimeReceived, SrcPort WHERE InIfDescription = '{{"{{"}} hello }}'`,
+			Query:       `SELECT TimeReceived, SrcPort WHERE InIfDescription = '{{Escape}} hello }}'`,
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -264,7 +264,7 @@ func TestFinalizeQuery(t *testing.T) {
 			Expected: `SELECT TimeReceived, SrcPort WHERE InIfDescription = '{{ hello }}'`,
 		}, {
 			Description: "use of ToStartOfInterval",
-			Query:       `{{ .ToStartOfInterval }}`,
+			Query:       `{{ToStartOfInterval}}`,
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
@@ -293,7 +293,7 @@ func TestFinalizeQuery(t *testing.T) {
 			Expected: "SELECT SUM(Packets*SamplingRate) FROM flows",
 		}, {
 			Description: "Small interval outside main table expiration",
-			Query:       "SELECT InIfProvider FROM {{ .Table }}",
+			Query:       "SELECT InIfProvider FROM {{Table}}",
 			Tables: []flowsTable{
 				{"flows", time.Duration(0), time.Date(2022, 11, 6, 12, 0, 0, 0, time.UTC)},
 				{"flows_1h0m0s", time.Hour, time.Date(2022, 4, 25, 18, 0, 0, 0, time.UTC)},

--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -1185,8 +1185,8 @@ providing a different mapping under the `headers` key. It is also possible to
 modify the default user (when no header is present) by tweaking the
 `default-user` key. If logout URL or avatar URL is not provided in the headers,
 it is possible to provide them as `logout-url` and `avatar-url`. In this case,
-they can be templated with `.Login`, `.Name`, `.Email`, `.LogoutURL`, and
-`.AvatarURL`.
+they can be templated with `Login`, `Name`, `Email`, `LogoutURL`, and
+`AvatarURL`. Only simple substitutions is allowed!
 
 ```yaml
 auth:
@@ -1198,8 +1198,8 @@ auth:
   default-user:
     login: default
     name: Default User
-  avatar-url: "https://avatars.githubusercontent.com/{{ .Login }}?s=80"
-  logout-url: "{{ if .LogoutURL }}{{ .LogoutURL }}{{ else }}/logout{{ end }}"
+  avatar-url: "https://avatars.githubusercontent.com/{{Login}}?s=80"
+  logout-url: "/logout"
 ```
 
 To prevent access when not authenticated, the `login` field for the

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -61,6 +61,7 @@ ClickHouse.
 
 ## 2.1.0 - 2026-01-10
 
+- 💥 *console*: `auth`→`avatar-url` and `auth`→`logout-url` only allows simple substitutions instead of full Go templates
 - 💥 *docker*: remove conntrack-fixer service (this requires Docker Engine v23 or more recent)
 - ✨ *inlet*: add a configuration option to decapsulate received flows (IPIP, GRE, VXLAN, and SRv6 are supported)
 - ✨ *outlet*: add `FlowDirection` as a new IPFIX field (can be `undefined`, `ingress`, or `egress`)

--- a/console/graph.go
+++ b/console/graph.go
@@ -56,7 +56,7 @@ func (input graphCommonHandlerInput) sourceSelect() string {
 		}
 	}
 	if len(truncated) == 0 {
-		return "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1"
+		return "SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1"
 	}
-	return fmt.Sprintf("SELECT * REPLACE (%s) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1", strings.Join(truncated, ", "))
+	return fmt.Sprintf("SELECT * REPLACE (%s) FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1", strings.Join(truncated, ", "))
 }

--- a/console/graph_test.go
+++ b/console/graph_test.go
@@ -23,7 +23,7 @@ func TestSourceSelect(t *testing.T) {
 			Input: graphCommonHandlerInput{
 				Dimensions: []query.Column{},
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "no truncatable dimensions",
 			Input: graphCommonHandlerInput{
@@ -31,13 +31,13 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 16,
 				TruncateAddrV6: 40,
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "no truncatation",
 			Input: graphCommonHandlerInput{
 				Dimensions: []query.Column{query.NewColumn("SrcAddr")},
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "IPv4/IPv6 same prefix length",
 			Input: graphCommonHandlerInput{
@@ -45,7 +45,7 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 16,
 				TruncateAddrV6: 112,
 			},
-			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, 112), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, 112), 1) AS SrcAddr) FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "IPv4/IPv6 different prefix length",
 			Input: graphCommonHandlerInput{
@@ -53,7 +53,7 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 24,
 				TruncateAddrV6: 40,
 			},
-			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 40)), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 40)), 1) AS SrcAddr) FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1",
 		},
 	}
 	for _, tc := range cases {

--- a/console/line.go
+++ b/console/line.go
@@ -113,8 +113,8 @@ func (input graphLineHandlerInput) toSQL1(axis int, options toSQL1Options) templ
 
 	// Select
 	fields := []string{
-		fmt.Sprintf(`{{ .ToStartOfInterval }}%s AS time`, offsetShift),
-		`{{ .Units }}/{{ .Interval }} AS xps`,
+		fmt.Sprintf(`{{ToStartOfInterval}}%s AS time`, offsetShift),
+		`{{Units}}/{{Interval}} AS xps`,
 	}
 	selectFields := []string{}
 	dimensions := []string{}
@@ -168,9 +168,9 @@ FROM source
 WHERE %s
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}%s
- TO {{ .TimefilterEnd }} + INTERVAL 1 second%s
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}%s
+ TO {{TimefilterEnd}} + INTERVAL 1 second%s
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS %s))`,
 		withStr, axis, strings.Join(fields, ",\n "), where, offsetShift, offsetShift,
 		dimensionsInterpolate,

--- a/console/line_test.go
+++ b/console/line_test.go
@@ -187,19 +187,19 @@ func TestGraphQuerySQL(t *testing.T) {
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -225,19 +225,19 @@ ORDER BY time WITH FILL
 						Units:  "l2bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -263,19 +263,19 @@ ORDER BY time WITH FILL
 						Units:  "pps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -342,20 +342,20 @@ ORDER BY time WITH FILL
 						MainTableRequired: true,
 					},
 					Template: `WITH
- source AS (SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 48)), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr FROM source WHERE {{ .Timefilter }} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')) GROUP BY SrcAddr ORDER BY {{ .Units }} DESC LIMIT 0)
+ source AS (SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 48)), 1) AS SrcAddr) FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT SrcAddr FROM source WHERE {{Timefilter}} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')) GROUP BY SrcAddr ORDER BY {{Units}} DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((SrcAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', '')], ['Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255'))
+WHERE {{Timefilter}} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255'))
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other']))`,
 				},
 			},
@@ -381,19 +381,19 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE {{Timefilter}} AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -419,19 +419,19 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfDescription = '{{"{{"}} hello }}' AND SrcCountry = 'US')
+WHERE {{Timefilter}} AND (InIfDescription = '{{Escape}} hello }}' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -458,19 +458,19 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE {{Timefilter}} AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				}, {
 					Context: inputContext{
@@ -481,16 +481,16 @@ ORDER BY time WITH FILL
 					},
 					Template: `SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE {{Timefilter}} AND (SrcCountry = 'FR' AND DstCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -517,19 +517,19 @@ ORDER BY time WITH FILL
 						Units:  "inl2%",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE {{Timefilter}} AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				}, {
 					Context: inputContext{
@@ -540,16 +540,16 @@ ORDER BY time WITH FILL
 					},
 					Template: `SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE {{Timefilter}} AND (SrcCountry = 'FR' AND DstCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -579,20 +579,20 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{Timefilter}} GROUP BY ExporterName, InIfProvider ORDER BY {{Units}} DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				},
 			},
@@ -623,20 +623,20 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM ( SELECT ExporterName, InIfProvider, {{ .Units }} AS sum_at_time FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ) GROUP BY ExporterName, InIfProvider ORDER BY MAX(sum_at_time) DESC LIMIT 20)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM ( SELECT ExporterName, InIfProvider, {{Units}} AS sum_at_time FROM source WHERE {{Timefilter}} GROUP BY ExporterName, InIfProvider ) GROUP BY ExporterName, InIfProvider ORDER BY MAX(sum_at_time) DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				},
 			},
@@ -667,20 +667,20 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{Timefilter}} GROUP BY ExporterName, InIfProvider ORDER BY {{Units}} DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				}, {
 					Context: inputContext{
@@ -691,16 +691,16 @@ ORDER BY time WITH FILL
 					},
 					Template: `SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((ExporterName, OutIfProvider) IN rows, [ExporterName, OutIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				},
 			},
@@ -731,20 +731,20 @@ ORDER BY time WITH FILL
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{Timefilter}} GROUP BY ExporterName, InIfProvider ORDER BY {{Units}} DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				}, {
 					Context: inputContext{
@@ -759,16 +759,16 @@ ORDER BY time WITH FILL
 					},
 					Template: `SELECT 3 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} + INTERVAL 86400 second AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} + INTERVAL 86400 second AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }} + INTERVAL 86400 second
- TO {{ .TimefilterEnd }} + INTERVAL 1 second + INTERVAL 86400 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}} + INTERVAL 86400 second
+ TO {{TimefilterEnd}} + INTERVAL 1 second + INTERVAL 86400 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},
@@ -799,20 +799,20 @@ ORDER BY time WITH FILL
 						Units:             "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr, DstAddr FROM source WHERE {{ .Timefilter }} AND (InIfBoundary = 'external') GROUP BY SrcAddr, DstAddr ORDER BY {{ .Units }} DESC LIMIT 0)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT SrcAddr, DstAddr FROM source WHERE {{Timefilter}} AND (InIfBoundary = 'external') GROUP BY SrcAddr, DstAddr ORDER BY {{Units}} DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} AS time,
+ {{Units}}/{{Interval}} AS xps,
  if((SrcAddr, DstAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', ''), replaceRegexpOne(IPv6NumToString(DstAddr), '^::ffff:', '')], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfBoundary = 'external')
+WHERE {{Timefilter}} AND (InIfBoundary = 'external')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
 				}, {
 					Context: inputContext{
@@ -828,16 +828,16 @@ ORDER BY time WITH FILL
 					},
 					Template: `SELECT 3 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} + INTERVAL 86400 second AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ {{ToStartOfInterval}} + INTERVAL 86400 second AS time,
+ {{Units}}/{{Interval}} AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfBoundary = 'external')
+WHERE {{Timefilter}} AND (InIfBoundary = 'external')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }} + INTERVAL 86400 second
- TO {{ .TimefilterEnd }} + INTERVAL 1 second + INTERVAL 86400 second
- STEP {{ .Interval }}
+ FROM {{TimefilterStart}} + INTERVAL 86400 second
+ TO {{TimefilterEnd}} + INTERVAL 1 second + INTERVAL 86400 second
+ STEP {{Interval}}
  INTERPOLATE (dimensions AS emptyArrayString()))`,
 				},
 			},

--- a/console/query.go
+++ b/console/query.go
@@ -48,14 +48,14 @@ func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []string, w
 	var orderBy string
 	if input.LimitType == "max" {
 		source = fmt.Sprintf("( SELECT %s AS sum_at_time FROM source WHERE %s GROUP BY %s )",
-			strings.Join(append(dimensions, "{{ .Units }}"), ", "),
+			strings.Join(append(dimensions, "{{Units}}"), ", "),
 			where,
 			strings.Join(dimensions, ", "),
 		)
 		orderBy = "MAX(sum_at_time)"
 	} else {
 		source = fmt.Sprintf("source WHERE %s", where)
-		orderBy = "{{ .Units }}"
+		orderBy = "{{Units}}"
 	}
 	rowsType = fmt.Sprintf(
 		"rows AS (SELECT %s FROM %s GROUP BY %s ORDER BY %s DESC LIMIT %d)",

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -49,7 +49,7 @@ func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
 		dimensions = append(dimensions, column.String())
 	}
 	fields := []string{
-		`{{ .Units }}/range AS xps`,
+		`{{Units}}/range AS xps`,
 		fmt.Sprintf("[%s] AS dimensions", strings.Join(arrayFields, ",\n  ")),
 	}
 

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -46,15 +46,15 @@ func TestSankeyQuerySQL(t *testing.T) {
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{Timefilter}}) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{Timefilter}} GROUP BY SrcAS, ExporterName ORDER BY {{Units}} DESC LIMIT 5)
 SELECT
- {{ .Units }}/range AS xps,
+ {{Units}}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY dimensions
 ORDER BY xps DESC`,
 				},
@@ -85,15 +85,15 @@ ORDER BY xps DESC`,
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM ( SELECT SrcAS, ExporterName, {{ .Units }} AS sum_at_time FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ) GROUP BY SrcAS, ExporterName ORDER BY MAX(sum_at_time) DESC LIMIT 5)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{Timefilter}}) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM ( SELECT SrcAS, ExporterName, {{Units}} AS sum_at_time FROM source WHERE {{Timefilter}} GROUP BY SrcAS, ExporterName ) GROUP BY SrcAS, ExporterName ORDER BY MAX(sum_at_time) DESC LIMIT 5)
 SELECT
- {{ .Units }}/range AS xps,
+ {{Units}}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY dimensions
 ORDER BY xps DESC`,
 				},
@@ -123,15 +123,15 @@ ORDER BY xps DESC`,
 						Units:  "l2bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{Timefilter}}) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{Timefilter}} GROUP BY SrcAS, ExporterName ORDER BY {{Units}} DESC LIMIT 5)
 SELECT
- {{ .Units }}/range AS xps,
+ {{Units}}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY dimensions
 ORDER BY xps DESC`,
 				},
@@ -161,15 +161,15 @@ ORDER BY xps DESC`,
 						Units:  "pps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{Timefilter}}) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{Timefilter}} GROUP BY SrcAS, ExporterName ORDER BY {{Units}} DESC LIMIT 5)
 SELECT
- {{ .Units }}/range AS xps,
+ {{Units}}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE {{Timefilter}}
 GROUP BY dimensions
 ORDER BY xps DESC`,
 				},
@@ -199,15 +199,15 @@ ORDER BY xps DESC`,
 						Units:  "l3bps",
 					},
 					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR')) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 10)
+ source AS (SELECT * FROM {{Table}} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{Timefilter}} AND (DstCountry = 'FR')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{Timefilter}} AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY {{Units}} DESC LIMIT 10)
 SELECT
- {{ .Units }}/range AS xps,
+ {{Units}}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR')
+WHERE {{Timefilter}} AND (DstCountry = 'FR')
 GROUP BY dimensions
 ORDER BY xps DESC`,
 				},

--- a/console/widgets.go
+++ b/console/widgets.go
@@ -184,12 +184,12 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 	now := c.d.Clock.Now()
 	template := fmt.Sprintf(`
 WITH
- (SELECT SUM(Bytes*SamplingRate) FROM {{ .Table }} WHERE {{ .Timefilter }} %s) AS Total
+ (SELECT SUM(Bytes*SamplingRate) FROM {{Table}} WHERE {{Timefilter}} %s) AS Total
 SELECT
  if(empty(%s),'Unknown',%s) AS Name,
  SUM(Bytes*SamplingRate) / Total * 100 AS Percent
-FROM {{ .Table }}
-WHERE {{ .Timefilter }}
+FROM {{Table}}
+WHERE {{Timefilter}}
 %s
 GROUP BY %s
 ORDER BY Percent DESC
@@ -225,16 +225,16 @@ func (c *Component) widgetGraphHandlerFunc(w http.ResponseWriter, req *http.Requ
 	now := c.d.Clock.Now()
 	template := fmt.Sprintf(`
 SELECT
- {{ .ToStartOfInterval }} AS Time,
- SUM(Bytes*SamplingRate*8/{{ .Interval }})/1000/1000/1000 AS Gbps
-FROM {{ .Table }}
-WHERE {{ .Timefilter }}
+ {{ToStartOfInterval}} AS Time,
+ SUM(Bytes*SamplingRate*8/{{Interval}})/1000/1000/1000 AS Gbps
+FROM {{Table}}
+WHERE {{Timefilter}}
 %s
 GROUP BY Time
 ORDER BY Time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}`,
+ FROM {{TimefilterStart}}
+ TO {{TimefilterEnd}} + INTERVAL 1 second
+ STEP {{Interval}}`,
 		filter)
 
 	query := c.finalizeTemplateQuery(templateQuery{

--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,8 @@ require (
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,12 @@ github.com/uptrace/bun/dialect/pgdialect v1.2.18/go.mod h1:Tqdf4QP1okrGYpXfodXvC
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18 h1:Z33SY/U++XK9uGWqS4h8OZVxfCXguIG+sU9cYq2PGFQ=
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18/go.mod h1:1MVOS/Ncy4FZbkJcgUFH6OqYoQinYNjkEwsmNQEXz2A=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
+github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
+github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/orchestrator/clickhouse/migrations_helpers.go
+++ b/orchestrator/clickhouse/migrations_helpers.go
@@ -11,11 +11,12 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/valyala/fasttemplate"
 
 	"akvorado/common/clickhousedb"
 	"akvorado/common/helpers"
@@ -80,20 +81,14 @@ func (c *Component) wrapMigrations(ctx context.Context, fns ...func(context.Cont
 	return nil
 }
 
-// stemplate is a simple wrapper around text/template.
-func stemplate(t string, data any) (string, error) {
-	tpl, err := template.New("tpl").
-		Option("missingkey=error").
-		Funcs(template.FuncMap{
-			"qi": clickhousedb.QuoteIdentifier, // identifier: `name`
-			"qs": quoteString,                  // string: 'value'
-		}).
-		Parse(t)
-	if err != nil {
-		return "", err
-	}
+// stemplate is a simple wrapper around fasttemplate.
+func stemplate(t string, data map[string]string) (string, error) {
 	var result strings.Builder
-	if err := tpl.Execute(&result, data); err != nil {
+	m := make(map[string]any, len(data))
+	for k, v := range data {
+		m[k] = v
+	}
+	if _, err := fasttemplate.Execute(t, "{{", "}}", &result, m); err != nil {
 		return "", err
 	}
 	return result.String(), nil
@@ -196,15 +191,15 @@ func (c *Component) createDictionary(ctx context.Context, name, layout, schema, 
 	source := fmt.Sprintf(`SOURCE(HTTP(%s))`, strings.Join(sourceParams, " "))
 	settings := `SETTINGS(format_csv_allow_single_quotes = 0)`
 	createQuery, err := stemplate(`
-CREATE DICTIONARY {{ qi .Database }}.{{ qi .Name }} ({{ .Schema }})
-PRIMARY KEY {{ .PrimaryKey}}
-{{ .Source }}
+CREATE DICTIONARY {{Database}}.{{Name}} ({{Schema}})
+PRIMARY KEY {{PrimaryKey}}
+{{Source}}
 LIFETIME(MIN 0 MAX 3600)
-LAYOUT({{ .Layout }}())
-{{ .Settings }}
-`, helpers.M{
-		"Database":   c.d.ClickHouse.DatabaseName(),
-		"Name":       name,
+LAYOUT({{Layout}}())
+{{Settings}}
+`, map[string]string{
+		"Database":   clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
+		"Name":       clickhousedb.QuoteIdentifier(name),
 		"Schema":     schema,
 		"PrimaryKey": primary,
 		"Layout":     strings.ToUpper(layout),
@@ -248,14 +243,14 @@ func (c *Component) createExportersTable(ctx context.Context) error {
 	// Build CREATE TABLE
 	name := "exporters"
 	createQuery, err := stemplate(
-		`CREATE TABLE {{ qi .Database }}.{{ qi .Table }}
-({{ .Schema }})
-ENGINE = {{ .Engine }}
+		`CREATE TABLE {{Database}}.{{Table}}
+({{Schema}})
+ENGINE = {{Engine}}
 ORDER BY (ExporterAddress, IfName)
 TTL TimeReceived + toIntervalDay(1)`,
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    name,
+		map[string]string{
+			"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
+			"Table":    clickhousedb.QuoteIdentifier(name),
 			"Schema":   strings.Join(cols, ", "),
 			"Engine":   c.mergeTreeEngine(name, "Replacing", "TimeReceived"),
 		})
@@ -301,10 +296,10 @@ func (c *Component) createExportersConsumerView(ctx context.Context) error {
 
 	// Build SELECT query
 	selectQuery, err := stemplate(
-		`SELECT {{ .Columns }} FROM {{ qi .Database }}.{{ qi .Table }} ARRAY JOIN arrayEnumerate([1, 2]) AS num`,
-		helpers.M{
-			"Table":    c.distributedTable("flows"),
-			"Database": c.d.ClickHouse.DatabaseName(),
+		`SELECT {{Columns}} FROM {{Database}}.{{Table}} ARRAY JOIN arrayEnumerate([1, 2]) AS num`,
+		map[string]string{
+			"Table":    clickhousedb.QuoteIdentifier(c.distributedTable("flows")),
+			"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
 			"Columns":  strings.Join(cols, ", "),
 		})
 	if err != nil {
@@ -342,10 +337,10 @@ func (c *Component) createRawFlowsTable(ctx context.Context) error {
 
 	// Build CREATE query
 	createQuery, err := stemplate(
-		"CREATE TABLE {{ qi .Database }}.{{ qi .Table }} ({{ .Schema }}) ENGINE = `Null`",
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    tableName,
+		"CREATE TABLE {{Database}}.{{Table}} ({{Schema}}) ENGINE = `Null`",
+		map[string]string{
+			"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
+			"Table":    clickhousedb.QuoteIdentifier(tableName),
 			"Schema": c.d.Schema.ClickHouseCreateTable(
 				schema.ClickHouseSkipGeneratedColumns,
 				schema.ClickHouseSkipAliasedColumns),
@@ -390,13 +385,13 @@ func (c *Component) createRawFlowsConsumerView(ctx context.Context) error {
 
 	// Build SELECT query
 	selectQuery, err := stemplate(
-		`SELECT {{ .Columns }} FROM {{ qi .Database }}.{{ qi .Table }}`,
-		helpers.M{
+		`SELECT {{Columns}} FROM {{Database}}.{{Table}}`,
+		map[string]string{
 			"Columns": strings.Join(c.d.Schema.ClickHouseSelectColumns(
 				schema.ClickHouseSubstituteGenerates,
 				schema.ClickHouseSkipAliasedColumns), ", "),
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    tableName,
+			"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
+			"Table":    clickhousedb.QuoteIdentifier(tableName),
 		})
 	if err != nil {
 		return fmt.Errorf("cannot build select statement for raw flows consumer view: %w", err)
@@ -503,37 +498,37 @@ func (c *Component) createOrUpdateFlowsTable(ctx context.Context, resolution Res
 		var err error
 		if resolution.Interval == 0 {
 			createQuery, err = stemplate(`
-CREATE TABLE {{ .Table }} ({{ .Schema }})
-ENGINE = {{ .Engine }}
-PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{ .PartitionInterval }} second))
+CREATE TABLE {{Table}} ({{Schema}})
+ENGINE = {{Engine}}
+PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{PartitionInterval}} second))
 PRIMARY KEY toStartOfFiveMinutes(TimeReceived)
 ORDER BY (toStartOfFiveMinutes(TimeReceived), ExporterAddress, InIfName, OutIfName)
-TTL TimeReceived + toIntervalSecond({{ .TTL }})
-SETTINGS {{ .Settings }}
-`, helpers.M{
+TTL TimeReceived + toIntervalSecond({{TTL}})
+SETTINGS {{Settings}}
+`, map[string]string{
 				"Table":             tableName,
 				"Schema":            c.d.Schema.ClickHouseCreateTable(),
-				"PartitionInterval": partitionInterval,
-				"TTL":               ttl,
+				"PartitionInterval": strconv.FormatUint(partitionInterval, 10),
+				"TTL":               strconv.FormatUint(ttl, 10),
 				"Engine":            c.mergeTreeEngine(tableName, ""),
 				"Settings":          settings,
 			})
 		} else {
 			createQuery, err = stemplate(`
-CREATE TABLE {{ .Table }} ({{ .Schema }})
-ENGINE = {{ .Engine }}
-PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{ .PartitionInterval }} second))
-PRIMARY KEY ({{ .PrimaryKey }})
-ORDER BY ({{ .SortingKey }})
-TTL TimeReceived + toIntervalSecond({{ .TTL }})
-SETTINGS {{ .Settings }}
-`, helpers.M{
+CREATE TABLE {{Table}} ({{Schema}})
+ENGINE = {{Engine}}
+PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{PartitionInterval}} second))
+PRIMARY KEY ({{PrimaryKey}})
+ORDER BY ({{SortingKey}})
+TTL TimeReceived + toIntervalSecond({{TTL}})
+SETTINGS {{Settings}}
+`, map[string]string{
 				"Table":             tableName,
 				"Schema":            c.d.Schema.ClickHouseCreateTable(schema.ClickHouseSkipMainOnlyColumns),
-				"PartitionInterval": partitionInterval,
+				"PartitionInterval": strconv.FormatUint(partitionInterval, 10),
 				"PrimaryKey":        strings.Join(c.d.Schema.ClickHousePrimaryKeys(), ", "),
 				"SortingKey":        strings.Join(c.d.Schema.ClickHouseSortingKeys(), ", "),
-				"TTL":               ttl,
+				"TTL":               strconv.FormatUint(ttl, 10),
 				"Engine":            c.mergeTreeEngine(tableName, "Summing", "(Bytes, Packets)"),
 				"Settings":          settings,
 			})
@@ -809,12 +804,12 @@ func (c *Component) createFlowsConsumerView(ctx context.Context, resolution Reso
 	// Build SELECT query
 	selectQuery, err := stemplate(`
 SELECT
- toStartOfInterval(TimeReceived, toIntervalSecond({{ .Seconds }})) AS TimeReceived,
- {{ .Columns }}
-FROM {{ .Database }}.{{ .Table }}`, helpers.M{
+ toStartOfInterval(TimeReceived, toIntervalSecond({{Seconds}})) AS TimeReceived,
+ {{Columns}}
+FROM {{Database}}.{{Table}}`, map[string]string{
 		"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
 		"Table":    c.localTable("flows"),
-		"Seconds":  uint64(resolution.Interval.Seconds()),
+		"Seconds":  strconv.FormatUint(uint64(resolution.Interval.Seconds()), 10),
 		"Columns": strings.Join(c.d.Schema.ClickHouseSelectColumns(
 			schema.ClickHouseSkipTimeReceived,
 			schema.ClickHouseSkipMainOnlyColumns,
@@ -881,16 +876,18 @@ ORDER BY position ASC
 	}
 
 	// Build the CREATE TABLE
+	databaseName := c.d.ClickHouse.DatabaseName()
 	createQuery, err := stemplate(
-		`CREATE TABLE {{ qi .Database }}.{{ qi .Target }}
-({{ .Schema }})
-ENGINE = Distributed({{ qs .Cluster }}, {{ qs .Database }}, {{ qs .Source }}, rand())`,
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Cluster":  c.d.ClickHouse.ClusterName(),
-			"Source":   c.localTable(source),
-			"Target":   c.distributedTable(source),
-			"Schema":   strings.Join(cols, ", "),
+		`CREATE TABLE {{Database}}.{{Target}}
+({{Schema}})
+ENGINE = Distributed({{ClusterQ}}, {{DatabaseQ}}, {{SourceQ}}, rand())`,
+		map[string]string{
+			"Database":  clickhousedb.QuoteIdentifier(databaseName),
+			"Target":    clickhousedb.QuoteIdentifier(c.distributedTable(source)),
+			"ClusterQ":  quoteString(c.d.ClickHouse.ClusterName()),
+			"DatabaseQ": quoteString(databaseName),
+			"SourceQ":   quoteString(c.localTable(source)),
+			"Schema":    strings.Join(cols, ", "),
 		})
 	if err != nil {
 		return fmt.Errorf("cannot build query to create exporters view: %w", err)


### PR DESCRIPTION
Akvorado binaries are larger than they should be because dead code elimination is disabled because of using `reflect.MethodByName` or `reflect.Method`. This needs to be fixed everywhere.

- [x] disable tracing support in gRPC (5ae5d966437964e2224b4b973451f07d05ae815a)
- [x] replace static usage of `reflect.MethodByName()` with an interface check (756d0a958012d4e5390aaefc0e17cd56cc352b33) 
- [x] fix [go-playground/validator/v10](https://github.com/go-playground/validator/issues/1496): 00a9ecd36635
- [x] don't use `text/template`
- [ ] fix [expr-lang/expr](https://github.com/expr-lang/expr/pull/956)
- [x] fix [gorm.io/gorm](https://github.com/go-gorm/gorm/pull/7643), removed in 8e2b97aa0257f87f91b489d0a3fbb57feae58041
- [x] add a non-regression test