### PR TITLE
feat: Add ASN provider that ignores flow ASN when its the default route

### DIFF
--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -511,9 +511,10 @@ The following configuration keys are accepted:
   would also accept a single value).
 - `asn-providers` defines the source list for AS numbers. The available sources
   are `flow`, `flow-except-private` (use information from flow except if the ASN
-  is private), `routing`, `routing-except-private`, and `geo-ip`. The default
-  value is `flow`, `routing`, `geo-ip`. `geo-ip` should only be used at the end as
-  there is no fallback possible.
+  is private), `flow-except-default-route` (use information from flow except if
+  the NetMask is the default route), `routing`, `routing-except-private`, and
+  `geo-ip`. The default value is `flow`, `routing`, `geo-ip`. `geo-ip` should
+  only be used at the end as there is no fallback possible.
 - `net-providers` defines the sources for prefix lengths and nexthop. `flow` uses the value
   provided by the flow message (if any), while `routing` looks it up using the BMP
   component. If multiple sources are provided, the value of the first source

--- a/outlet/core/config.go
+++ b/outlet/core/config.go
@@ -55,6 +55,8 @@ const (
 	ASNProviderFlow ASNProvider = iota
 	// ASNProviderFlowExceptPrivate uses the AS number embedded in flows, except if this is a private AS.
 	ASNProviderFlowExceptPrivate
+	// ASNProviderFlowExceptDefaultRoute uses the AS number embedded in flows, except if the netmask is zero.
+	ASNProviderFlowExceptDefaultRoute
 	// ASNProviderGeoIP pulls the AS number from a GeoIP database.
 	ASNProviderGeoIP
 	// ASNProviderRouting uses the AS number from BMP

--- a/outlet/core/enricher_test.go
+++ b/outlet/core/enricher_test.go
@@ -727,27 +727,29 @@ ClassifyProviderRegex(Interface.Description, "^Transit: ([^ ]+)", "$1")`,
 
 func TestGetASNumber(t *testing.T) {
 	cases := []struct {
-		Pos       helpers.Pos
-		Addr      string
-		FlowAS    uint32
-		BMPAS     uint32
-		Providers []ASNProvider
-		Expected  uint32
+		Pos         helpers.Pos
+		Addr        string
+		FlowAS      uint32
+		BMPAS       uint32
+		FlowNetMask uint8
+		Providers   []ASNProvider
+		Expected    uint32
 	}{
 		// 1
-		{helpers.Mark(), "1.0.0.1", 12322, 0, []ASNProvider{ASNProviderFlow}, 12322},
-		{helpers.Mark(), "::ffff:1.0.0.1", 12322, 0, []ASNProvider{ASNProviderFlow}, 12322},
-		{helpers.Mark(), "1.0.0.1", 65536, 0, []ASNProvider{ASNProviderFlow}, 65536},
-		{helpers.Mark(), "1.0.0.1", 65536, 0, []ASNProvider{ASNProviderFlowExceptPrivate}, 0},
-		{helpers.Mark(), "1.0.0.1", 4_200_000_121, 0, []ASNProvider{ASNProviderFlowExceptPrivate}, 0},
-		{helpers.Mark(), "1.0.0.1", 65536, 0, []ASNProvider{ASNProviderFlowExceptPrivate, ASNProviderFlow}, 65536},
-		{helpers.Mark(), "1.0.0.1", 12322, 0, []ASNProvider{ASNProviderFlowExceptPrivate}, 12322},
+		{helpers.Mark(), "1.0.0.1", 12322, 0, 24, []ASNProvider{ASNProviderFlow}, 12322},
+		{helpers.Mark(), "::ffff:1.0.0.1", 12322, 0, 24, []ASNProvider{ASNProviderFlow}, 12322},
+		{helpers.Mark(), "1.0.0.1", 65536, 0, 24, []ASNProvider{ASNProviderFlow}, 65536},
+		{helpers.Mark(), "1.0.0.1", 65536, 0, 24, []ASNProvider{ASNProviderFlowExceptPrivate}, 0},
+		{helpers.Mark(), "1.0.0.1", 4_200_000_121, 0, 24, []ASNProvider{ASNProviderFlowExceptPrivate}, 0},
+		{helpers.Mark(), "1.0.0.1", 65536, 0, 24, []ASNProvider{ASNProviderFlowExceptPrivate, ASNProviderFlow}, 65536},
+		{helpers.Mark(), "1.0.0.1", 12322, 0, 24, []ASNProvider{ASNProviderFlowExceptPrivate}, 12322},
+		{helpers.Mark(), "1.0.0.1", 12322, 0, 0, []ASNProvider{ASNProviderFlowExceptDefaultRoute}, 0},
 		// 10
-		{helpers.Mark(), "192.0.2.2", 12322, 174, []ASNProvider{ASNProviderRouting}, 174},
-		{helpers.Mark(), "192.0.2.129", 12322, 1299, []ASNProvider{ASNProviderRouting}, 1299},
-		{helpers.Mark(), "192.0.2.254", 12322, 0, []ASNProvider{ASNProviderRouting}, 0},
-		{helpers.Mark(), "1.0.0.1", 12322, 65300, []ASNProvider{ASNProviderRouting}, 65300},
-		{helpers.Mark(), "1.0.0.1", 12322, 65300, []ASNProvider{ASNProviderGeoIP, ASNProviderRouting}, 0},
+		{helpers.Mark(), "192.0.2.2", 12322, 174, 24, []ASNProvider{ASNProviderRouting}, 174},
+		{helpers.Mark(), "192.0.2.129", 12322, 1299, 24, []ASNProvider{ASNProviderRouting}, 1299},
+		{helpers.Mark(), "192.0.2.254", 12322, 0, 24, []ASNProvider{ASNProviderRouting}, 0},
+		{helpers.Mark(), "1.0.0.1", 12322, 65300, 24, []ASNProvider{ASNProviderRouting}, 65300},
+		{helpers.Mark(), "1.0.0.1", 12322, 65300, 24, []ASNProvider{ASNProviderGeoIP, ASNProviderRouting}, 0},
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("case %s", tc.Pos), func(t *testing.T) {
@@ -767,7 +769,7 @@ func TestGetASNumber(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%sNew() error:\n%+v", tc.Pos, err)
 			}
-			got := c.getASNumber(tc.FlowAS, tc.BMPAS)
+			got := c.getASNumber(tc.FlowAS, tc.BMPAS, tc.FlowNetMask)
 			if diff := helpers.Diff(got, tc.Expected); diff != "" {
 				t.Fatalf("%sgetASNumber() (-got, +want):\n%s", tc.Pos, diff)
 			}


### PR DESCRIPTION
Our Juniper routers label traffic that originates from its default-route with the NTT ASN. This pull request adds another ASNProvider option that ignores the given ASN when the `NetMask==0`. 