### PR TITLE
outlet/flow: handle discard on Juniper devices

### DIFF
--- a/console/data/docs/04-operations.md
+++ b/console/data/docs/04-operations.md
@@ -286,6 +286,7 @@ chassis {
     sampling-instance sample-ins;
     inline-services {
       flex-flow-sizing;
+      report-zero-oif-gw-on-discard;
     }
   }
 }

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -13,6 +13,7 @@ identified with a specific icon:
 ## 2.1.1 - 2026-01-17
 
 - 🩹 *outlet*: fix crash on malformed flow packets
+- 🌱 *outlet*: handle discard on Juniper devices with `report-zero-oif-gw-on-discard` set
 
 ## 2.1.0 - 2026-01-10
 

--- a/outlet/flow/decoder/netflow/root_test.go
+++ b/outlet/flow/decoder/netflow/root_test.go
@@ -309,6 +309,9 @@ func TestDecodeSamplingRate(t *testing.T) {
 				schema.ColumnDstPort:       uint16(10907),
 				schema.ColumnEType:         uint32(constants.ETypeIPv4),
 				schema.ColumnFlowDirection: uint8(schema.DirectionIngress),
+				// Is that correct? This would match if device is Juniper, but
+				// this packet is from a Huawei router.
+				schema.ColumnForwardingStatus: uint32(128),
 			},
 		},
 	}


### PR DESCRIPTION
See https://pavel.network/quirks-of-juniper-netflow-and-ipfix-implementations/

This looks like a fragile workaround. Notably, one of the test that has to be modified is from a Huawei. Is the packet really discarded in this case?

```
Flow 1
    SrcAddr: 232.131.215.65
    DstAddr: 142.183.180.65
    NextHop: 0.0.0.0
    Packets: 1
    Octets: 160
    [Duration: 0.000000000 seconds (switched)]
    BGPNextHop: 0.0.0.0
    InputInt: 13
    OutputInt: 0
    SrcPort: 13245
    DstPort: 10907
    SrcAS: 0
    DstAS: 0
    Vlan Id: 701
    Post Vlan Id: 0
    TCP Flags: 0x00
    Protocol: TCP (6)
    IP ToS: 0x00
    Direction: Ingress (0)
    Sampling interval: 2048
    Sampling algorithm: Random sampling (2)
    SrcMask: 0
    DstMask: 0
```

Fix #2222