### PR TITLE
outlet/metadata: ignore sync response message on gNMI subscription

### DIFF
--- a/outlet/metadata/provider/gnmi/collector.go
+++ b/outlet/metadata/provider/gnmi/collector.go
@@ -246,7 +246,7 @@ retryDetect:
 	for {
 		l.Debug().Msg("polling")
 		start := time.Now()
-		subscribeResp, err := tg.SubscribeOnce(p.ctx, subscribeReq)
+		subscribeResp, err := subscribeOnce(p.ctx, tg, subscribeReq)
 		p.metrics.times.WithLabelValues(exporterStr).Observe(time.Since(start).Seconds())
 		if err == nil {
 			events := subscribeResponsesToEvents(subscribeResp)
@@ -326,7 +326,7 @@ func (p *Provider) detectModelAndEncoding(ctx context.Context, tg *target.Target
 			if err != nil {
 				panic(fmt.Errorf("NewSubscribeRequest() error: %w", err))
 			}
-			_, err = tg.SubscribeOnce(ctx, subscribeReq)
+			_, err = subscribeOnce(ctx, tg, subscribeReq)
 			if err != nil && ctx.Err() != nil {
 				return Model{}, "", err
 			} else if err != nil {

--- a/outlet/metadata/provider/gnmi/srlinux_test.go
+++ b/outlet/metadata/provider/gnmi/srlinux_test.go
@@ -246,9 +246,9 @@ commit now
 			if err != nil {
 				t.Fatalf("NewSubscribeRequest() error:\n%+v", err)
 			}
-			subscribeResp, err := tg.SubscribeOnce(ctx, subscribeReq)
+			subscribeResp, err := subscribeOnce(ctx, tg, subscribeReq)
 			if err != nil {
-				t.Fatalf("SubscribeOnce() error:\n%+v", err)
+				t.Fatalf("subscribeOnce() error:\n%+v", err)
 			}
 			got := subscribeResponsesToEvents(subscribeResp)
 			sort.Slice(got, func(i, j int) bool {
@@ -745,9 +745,9 @@ commit now
 		if err != nil {
 			t.Fatalf("NewSubscribeRequest() error:\n%+v", err)
 		}
-		subscribeResp, err := tg.SubscribeOnce(ctx, subscribeReq)
+		subscribeResp, err := subscribeOnce(ctx, tg, subscribeReq)
 		if err != nil {
-			t.Fatalf("SubscribeOnce() error:\n%+v", err)
+			t.Fatalf("subscribeOnce() error:\n%+v", err)
 		}
 		indexes := map[string]uint{}
 		for _, event := range subscribeResponsesToEvents(subscribeResp) {

--- a/outlet/metadata/provider/gnmi/subscribe.go
+++ b/outlet/metadata/provider/gnmi/subscribe.go
@@ -4,12 +4,15 @@
 package gnmi
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"path"
 	"strconv"
 	"strings"
 
 	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmic/pkg/api/target"
 )
 
 // event describes an event received in a subscription. No deletion is handled
@@ -87,6 +90,32 @@ func subscribeResponsesToEvents(responses []*gnmi.SubscribeResponse) []event {
 		events = append(events, subscribeResponseToEvents(response)...)
 	}
 	return events
+}
+
+// subscribeOnce performs a SubscribeOnce RPC, collecting all update responses
+// until the server closes the stream. Unlike target.SubscribeOnce, it does not
+// stop on SyncResponse, ensuring all updates are received. See
+// https://github.com/akvorado/akvorado/issues/2249.
+func subscribeOnce(ctx context.Context, tg *target.Target, req *gnmi.SubscribeRequest) ([]*gnmi.SubscribeResponse, error) {
+	rspChan, errChan := tg.SubscribeOnceChan(ctx, req)
+	var responses []*gnmi.SubscribeResponse
+	for {
+		select {
+		case r := <-rspChan:
+			switch r.Response.(type) {
+			case *gnmi.SubscribeResponse_Update:
+				responses = append(responses, r)
+			case *gnmi.SubscribeResponse_SyncResponse:
+				// We choose to ignore it as some implementations may send it
+				// while not all paths have been updated.
+			}
+		case err := <-errChan:
+			if err == io.EOF {
+				return responses, nil
+			}
+			return nil, err
+		}
+	}
 }
 
 // jsonAppendToEvents appends the events derived from the provided event plus


### PR DESCRIPTION
Some implementations may send a sync response when subscribing once, while some data is still missing. Mimic gnmic behavior by waiting until EOF to get all data.

Fix #2249