### PR TITLE
Nix: replace deprecated pnpm.* package attributes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,12 @@
           src = ./console/frontend;
           nativeBuildInputs = [
             nodejs
-            pnpm.configHook
+            pnpm
+            pkgs.pnpmConfigHook
           ];
 
-          pnpmDeps = pnpm.fetchDeps {
-            inherit src;
+          pnpmDeps = pkgs.fetchPnpmDeps {
+            inherit src pnpm;
             pname = name;
             buildInputs = [ nodejs ];
             fetcherVersion = 2;


### PR DESCRIPTION
Fixes the following evaluation warnings on NixOS 25.11 and above:

trace: evaluation warning: pnpm.configHook: The package attribute is deprecated. Use the top-level pnpmConfigHook attribute instead
trace: evaluation warning: pnpm.fetchDeps: The package attribute is deprecated. Use the top-level fetchPnpmDeps attribute instead