### PR TITLE
outlet/routing: implement RIB sharding for BMP

### DIFF
--- a/cmd/akvorado/testdata/configurations/bmp-to-routing/expected.yaml
+++ b/cmd/akvorado/testdata/configurations/bmp-to-routing/expected.yaml
@@ -11,6 +11,7 @@ paths:
       keep: 1h0m0s
       rds: []
       receivebuffer: 0
+      ribshards: 16
   outlet.0.core.asnproviders:
     - flow
     - routing

--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -222,6 +222,10 @@ For the BMP provider, the following keys are accepted:
   full, the reader blocks, relying on TCP backpressure. This decouples IO from
   processing and prevents the sender from declaring the session stuck during
   slow operations.
+- `rib-shards` is the number of shards for the RIB (default: 16, max: 256). The
+  RIB is split across independent shards to reduce lock contention when
+  processing routes from multiple BMP connections concurrently. Increasing the
+  number of shards increase the memory usage.
 
 If you do not need AS paths and communities, you can disable them to save memory
 and disk space in ClickHouse.

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -14,6 +14,8 @@ identified with a specific icon:
 
 - 🩹 *outlet*: fix OpenConfig model handling in gNMI provider
 - 🩹 *outlet*: fix detection of gNMI model for equipments not triggering an error on nonexistent paths
+- 🩹 *outlet*: fix BMP RIB corruption due to sharing of route attribute references
+- 🌱 *outlet*: shard BMP RIB to reduce lock contention
 - 🌱 *outlet*: map sFlow drop codes to IPFIX ForwardingStatus
 - 🌱 *orchestrator*: do not materialize TTLs in ClickHouse when updating them
 - 🌱 *orchestrator*: reduce overhead of the exporters view to improve ClickHouse ingest performance

--- a/outlet/routing/provider/bmp/config.go
+++ b/outlet/routing/provider/bmp/config.go
@@ -33,6 +33,10 @@ type Configuration struct {
 	// MessageBuffer is the maximum number of BMP messages buffered between the
 	// TCP reader and the message processor.
 	MessageBuffer uint `validate:"min=1"`
+	// RIBShards is the number of shards for the RIB. Each shard has its own
+	// lock, enabling concurrent route operations on different shards. The
+	// maximum value matches shardBits constant in rib.go.
+	RIBShards uint `validate:"min=1,max=256"`
 }
 
 // DefaultConfiguration represents the default configuration for the BMP server
@@ -44,6 +48,7 @@ func DefaultConfiguration() provider.Configuration {
 		CollectCommunities: true,
 		Keep:               5 * time.Minute,
 		MessageBuffer:      10000,
+		RIBShards:          16,
 	}
 }
 

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -281,15 +281,7 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 		rta.asPath = nil
 	}
 
-	// Acquire the lock for shared mutable state: peers and RIB.
-	lockStart := p.d.Clock.Now()
 	p.mu.Lock()
-	defer func() {
-		p.mu.Unlock()
-		p.metrics.locked.WithLabelValues("route-monitoring").Observe(
-			float64(p.d.Clock.Now().Sub(lockStart).Nanoseconds()) / 1000 / 1000 / 1000)
-	}()
-
 	pinfo, ok := p.peers[pkey]
 	if !ok {
 		// We may have missed the peer down notification?
@@ -298,9 +290,8 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 		p.metrics.peers.WithLabelValues(exporterStr).Inc()
 		pinfo = p.addPeer(pkey)
 	}
-
-	nhRef := p.rib.nextHops.Put(nextHop(nh))
-	rtaRef := p.rib.rtas.Put(rta)
+	peerRef := pinfo.reference
+	p.mu.Unlock()
 
 	routesAdded := 0
 	routesRemoved := 0
@@ -317,15 +308,15 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 				continue
 			}
 			pfx := helpers.PrefixTo6(v4UCPrefix.Prefix)
-			added, isNew := p.rib.AddRoute(pfx, route{
-				peer: pinfo.reference,
-				nlri: p.rib.nlris.Put(nlri{
+			added, isNew := p.rib.AddRoute(pfx, rawRoute{
+				peer: peerRef,
+				nlri: nlri{
 					family: bgp.RF_IPv4_UC,
 					path:   path.ID,
 					rd:     pkey.distinguisher,
-				}),
-				nextHop:    nhRef,
-				attributes: rtaRef,
+				},
+				nextHop:    nextHop(nh),
+				attributes: rta,
 				prefixLen:  uint8(pfx.Bits()),
 			})
 			routesAdded += added
@@ -341,19 +332,17 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 				continue
 			}
 			pfx := helpers.PrefixTo6(v4UCPrefix.Prefix)
-			if nlriRef, ok := p.rib.nlris.Ref(nlri{
-				family: bgp.RF_IPv4_UC,
-				path:   path.ID,
-				rd:     pkey.distinguisher,
-			}); ok {
-				removed, prefixRemoved := p.rib.RemoveRoute(pfx, route{
-					peer: pinfo.reference,
-					nlri: nlriRef,
-				})
-				routesRemoved += removed
-				if prefixRemoved {
-					prefixesRemoved++
-				}
+			removed, prefixRemoved := p.rib.RemoveRoute(pfx, rawRoute{
+				peer: peerRef,
+				nlri: nlri{
+					family: bgp.RF_IPv4_UC,
+					path:   path.ID,
+					rd:     pkey.distinguisher,
+				},
+			})
+			routesRemoved += removed
+			if prefixRemoved {
+				prefixesRemoved++
 			}
 		}
 	}
@@ -365,7 +354,6 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 		switch attr := attr.(type) {
 		case *bgp.PathAttributeMpReachNLRI:
 			nh = helpers.AddrTo6(attr.Nexthop)
-			nhRef = p.rib.nextHops.Put(nextHop(nh))
 			paths = attr.Value
 			family = bgp.NewFamily(attr.AFI, attr.SAFI)
 		case *bgp.PathAttributeMpUnreachNLRI:
@@ -400,15 +388,15 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 			}
 			switch attr.(type) {
 			case *bgp.PathAttributeMpReachNLRI:
-				added, isNew := p.rib.AddRoute(pfx, route{
-					peer: pinfo.reference,
-					nlri: p.rib.nlris.Put(nlri{
+				added, isNew := p.rib.AddRoute(pfx, rawRoute{
+					peer: peerRef,
+					nlri: nlri{
 						family: family,
 						rd:     rd,
 						path:   path.ID,
-					}),
-					nextHop:    nhRef,
-					attributes: rtaRef,
+					},
+					nextHop:    nextHop(nh),
+					attributes: rta,
 					prefixLen:  uint8(pfx.Bits()),
 				})
 				routesAdded += added
@@ -418,19 +406,17 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 					prefixesUpdated++
 				}
 			case *bgp.PathAttributeMpUnreachNLRI:
-				if nlriRef, ok := p.rib.nlris.Ref(nlri{
-					family: family,
-					rd:     rd,
-					path:   path.ID,
-				}); ok {
-					removed, prefixRemoved := p.rib.RemoveRoute(pfx, route{
-						peer: pinfo.reference,
-						nlri: nlriRef,
-					})
-					routesRemoved += removed
-					if prefixRemoved {
-						prefixesRemoved++
-					}
+				removed, prefixRemoved := p.rib.RemoveRoute(pfx, rawRoute{
+					peer: peerRef,
+					nlri: nlri{
+						family: family,
+						rd:     rd,
+						path:   path.ID,
+					},
+				})
+				routesRemoved += removed
+				if prefixRemoved {
+					prefixesRemoved++
 				}
 			}
 		}

--- a/outlet/routing/provider/bmp/lookup.go
+++ b/outlet/routing/provider/bmp/lookup.go
@@ -28,35 +28,15 @@ func (p *Provider) Lookup(_ context.Context, ip, nh, _ netip.Addr) (LookupResult
 	if !p.active.Load() {
 		return LookupResult{}, nil
 	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
 
-	// Find the best route, preferring exact next hop match
-	var selectedRoute route
-	routeFound := false
-	for route := range p.rib.IterateRoutes(ip) {
-		if !routeFound {
-			selectedRoute = route
-			routeFound = true
-		}
-		if p.rib.nextHops.Get(route.nextHop) == nextHop(nh) {
-			// Exact match found, use it and don't search further
-			selectedRoute = route
-			break
-		}
-	}
-
-	if !routeFound {
+	attributes, nhResult, plen, found := p.rib.LookupRoute(ip, nh)
+	if !found {
 		return LookupResult{}, errNoRouteFound
 	}
 
-	attributes := p.rib.rtas.Get(selectedRoute.attributes)
-	// The next hop is updated from the rib in every case, because the user
-	// "opted in" for bmp as source if the lookup result is evaluated
-	nh = netip.Addr(p.rib.nextHops.Get(selectedRoute.nextHop))
+	nh = netip.Addr(nhResult)
 
 	// Prefix length is for IPv4-mapped IPv6 address.
-	plen := selectedRoute.prefixLen
 	if ip.Is4In6() {
 		plen = plen - 96
 	}

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -218,7 +218,7 @@ func BenchmarkRIBInsertion(b *testing.B) {
 				inserted := 0
 				tentative := 0
 				for b.Loop() {
-					rib = newRIB()
+					rib = newRIB(16)
 					nh := netip.MustParseAddr("::ffff:198.51.100.0")
 					prng1 := rand.New(rand.NewPCG(10, 10))
 					prng2 := make([]*rand.Rand, peers)
@@ -235,24 +235,22 @@ func BenchmarkRIBInsertion(b *testing.B) {
 						}
 						b.StartTimer()
 
-						nlriRef := rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC})
-						nhRef := rib.nextHops.Put(nextHop(nh))
 						for _, r := range randomPrefixes {
 							if prng2[p].IntN(10) == 0 {
 								continue
 							}
 							pfx := helpers.PrefixTo6(r.Prefix)
 							tentative++
-							routesAdded, _ := rib.AddRoute(pfx, route{
+							routesAdded, _ := rib.AddRoute(pfx, rawRoute{
 								peer:    uint32(p),
-								nlri:    nlriRef,
-								nextHop: nhRef,
-								attributes: rib.rtas.Put(routeAttributes{
+								nlri:    nlri{family: bgp.RF_IPv4_UC},
+								nextHop: nextHop(nh),
+								attributes: routeAttributes{
 									asn:              r.ASPath[len(r.ASPath)-1],
 									asPath:           r.ASPath,
 									communities:      r.Communities,
 									largeCommunities: r.LargeCommunities,
-								}),
+								},
 								prefixLen: uint8(pfx.Bits()),
 							})
 							inserted += routesAdded
@@ -285,7 +283,7 @@ func BenchmarkRIBLookup(b *testing.B) {
 			name := fmt.Sprintf("%d routes, %d peers", routes, peers)
 
 			b.Run(name, func(b *testing.B) {
-				rib := newRIB()
+				rib := newRIB(16)
 				nh := netip.MustParseAddr("::ffff:198.51.100.0")
 				prng1 := rand.New(rand.NewPCG(10, 10))
 				prng2 := make([]*rand.Rand, peers)
@@ -294,23 +292,21 @@ func BenchmarkRIBLookup(b *testing.B) {
 				}
 				for p := range peers {
 					nh = nh.Next()
-					nlriRef := rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC})
-					nhRef := rib.nextHops.Put(nextHop(nh))
 					for r := range randomRealWorldRoutes4(prng1, prng2[p], routes) {
 						if prng2[p].IntN(10) == 0 {
 							continue
 						}
 						pfx := helpers.PrefixTo6(r.Prefix)
-						rib.AddRoute(pfx, route{
+						rib.AddRoute(pfx, rawRoute{
 							peer:    uint32(p),
-							nlri:    nlriRef,
-							nextHop: nhRef,
-							attributes: rib.rtas.Put(routeAttributes{
+							nlri:    nlri{family: bgp.RF_IPv4_UC},
+							nextHop: nextHop(nh),
+							attributes: routeAttributes{
 								asn:              r.ASPath[len(r.ASPath)-1],
 								asPath:           r.ASPath,
 								communities:      r.Communities,
 								largeCommunities: r.LargeCommunities,
-							}),
+							},
 							prefixLen: uint8(pfx.Bits()),
 						})
 					}
@@ -324,6 +320,7 @@ func BenchmarkRIBLookup(b *testing.B) {
 					count++
 					ip4 := randomPrefixes[count%len(randomPrefixes)].Prefix.Addr()
 					p.Lookup(b.Context(), ip4, netip.Addr{}, netip.Addr{})
+					rib.LookupRoute(ip4, netip.Addr{})
 				}
 				b.ReportMetric(float64(b.Elapsed())/float64(count), "ns/op")
 			})
@@ -339,7 +336,7 @@ func BenchmarkRIBFlush(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				for b.Loop() {
 					b.StopTimer()
-					rib := newRIB()
+					rib := newRIB(16)
 					nh := netip.MustParseAddr("::ffff:198.51.100.0")
 					prng1 := rand.New(rand.NewPCG(10, 10))
 					prng2 := make([]*rand.Rand, peers)
@@ -348,23 +345,21 @@ func BenchmarkRIBFlush(b *testing.B) {
 					}
 					for p := range peers {
 						nh = nh.Next()
-						nlriRef := rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC})
-						nhRef := rib.nextHops.Put(nextHop(nh))
 						for r := range randomRealWorldRoutes4(prng1, prng2[p], routes) {
 							if prng2[p].IntN(10) == 0 {
 								continue
 							}
 							pfx := helpers.PrefixTo6(r.Prefix)
-							rib.AddRoute(pfx, route{
+							rib.AddRoute(pfx, rawRoute{
 								peer:    uint32(p),
-								nlri:    nlriRef,
-								nextHop: nhRef,
-								attributes: rib.rtas.Put(routeAttributes{
+								nlri:    nlri{family: bgp.RF_IPv4_UC},
+								nextHop: nextHop(nh),
+								attributes: routeAttributes{
 									asn:              r.ASPath[len(r.ASPath)-1],
 									asPath:           r.ASPath,
 									communities:      r.Communities,
 									largeCommunities: r.LargeCommunities,
-								}),
+								},
 								prefixLen: uint8(pfx.Bits()),
 							})
 						}

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -6,6 +6,7 @@ package bmp
 import (
 	"iter"
 	"net/netip"
+	"sync"
 	"unsafe"
 
 	"akvorado/common/helpers"
@@ -15,7 +16,11 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-// prefixIndex is a typed index for prefixes in the RIB
+// shardBits is the number of high bits used to encode the shard number.
+const shardBits = 8
+
+// prefixIndex is a typed index for prefixes in the RIB.
+// The high shardBits encode the shard index, the remaining bits are the local ID.
 type prefixIndex uint32
 
 // routeIndex is a typed index for routes within a prefix
@@ -24,10 +29,21 @@ type routeIndex uint32
 // routeKey is a typed key for route map entries
 type routeKey uint64
 
-// rib represents the RIB.
-type rib struct {
-	tree          *bart.Table[prefixIndex] // stores prefix indices
-	routes        map[routeKey]route       // map[routeKey]route where routeKey = (prefixIdx << 32) | routeIdx
+// makePrefixIndex creates a global prefixIndex from shard index and local ID.
+func makePrefixIndex(shardIdx int, localID prefixIndex) prefixIndex {
+	return prefixIndex(uint32(shardIdx)<<(32-shardBits)) | localID
+}
+
+// shardIdx extracts the shard index from a global prefixIndex.
+func (idx prefixIndex) shardIdx() int {
+	return int(idx >> (32 - shardBits))
+}
+
+// ribShard holds the per-shard state for a RIB shard.
+type ribShard struct {
+	mu            sync.RWMutex
+	idx           int
+	routes        map[routeKey]route
 	nlris         *intern.Pool[nlri]
 	nextHops      *intern.Pool[nextHop]
 	rtas          *intern.Pool[routeAttributes]
@@ -35,14 +51,30 @@ type rib struct {
 	freePrefixIDs []prefixIndex // free list for reused prefix indices
 }
 
+// rib represents the RIB.
+type rib struct {
+	mu     sync.RWMutex             // protects tree
+	tree   *bart.Table[prefixIndex] // stores global prefix indices
+	shards []*ribShard
+}
+
 // route contains the peer (external opaque value), the NLRI, the next
 // hop and route attributes. The primary key is prefix (implied), peer
-// and nlri.
+// and nlri. References are interned within a shard.
 type route struct {
 	peer       uint32
 	nlri       intern.Reference[nlri]
 	nextHop    intern.Reference[nextHop]
 	attributes intern.Reference[routeAttributes]
+	prefixLen  uint8
+}
+
+// rawRoute contains raw (non-interned) values for adding a route.
+type rawRoute struct {
+	peer       uint32
+	nlri       nlri
+	nextHop    nextHop
+	attributes routeAttributes
 	prefixLen  uint8
 }
 
@@ -145,26 +177,38 @@ func (rta routeAttributes) Equal(orta routeAttributes) bool {
 	return true
 }
 
-// newPrefixIndex allocates a new prefix index, reusing from free list if available
-func (r *rib) newPrefixIndex() prefixIndex {
-	if len(r.freePrefixIDs) > 0 {
-		id := r.freePrefixIDs[len(r.freePrefixIDs)-1]
-		r.freePrefixIDs = r.freePrefixIDs[:len(r.freePrefixIDs)-1]
-		return id
+// shardForPrefix determines which shard a prefix belongs to using FNV-1a hash.
+func (r *rib) shardForPrefix(prefix netip.Prefix) int {
+	a := prefix.Addr().As16()
+	h := uint32(2166136261)
+	for _, b := range a {
+		h ^= uint32(b)
+		h *= 16777619
 	}
-	id := r.nextPrefixID
-	r.nextPrefixID++
-	return id
+	return int(h % uint32(len(r.shards)))
 }
 
-// freePrefixIndex returns a prefix ID to the free list
-func (r *rib) freePrefixIndex(id prefixIndex) {
+// newPrefixIndex allocates a new prefix index for this shard.
+func (rs *ribShard) newPrefixIndex() prefixIndex {
+	if len(rs.freePrefixIDs) > 0 {
+		localID := rs.freePrefixIDs[len(rs.freePrefixIDs)-1]
+		rs.freePrefixIDs = rs.freePrefixIDs[:len(rs.freePrefixIDs)-1]
+		return makePrefixIndex(rs.idx, localID)
+	}
+	localID := rs.nextPrefixID
+	rs.nextPrefixID++
+	return makePrefixIndex(rs.idx, localID)
+}
+
+// freePrefixIndex returns a prefix ID to the shard's free list.
+func (rs *ribShard) freePrefixIndex(globalID prefixIndex) {
+	localID := globalID & ((1 << (32 - shardBits)) - 1)
 	if helpers.Testing() {
-		if id == 0 {
+		if localID == 0 {
 			panic("cannot free index 0")
 		}
 	}
-	r.freePrefixIDs = append(r.freePrefixIDs, id)
+	rs.freePrefixIDs = append(rs.freePrefixIDs, localID)
 }
 
 // makeRouteKey creates a route key from prefix and route indices
@@ -172,12 +216,12 @@ func makeRouteKey(prefixIdx prefixIndex, routeIdx routeIndex) routeKey {
 	return routeKey((uint64(prefixIdx) << 32) | uint64(routeIdx))
 }
 
-// iterateRoutesForPrefix returns an iterator over all routes for a given prefix index
-func (r *rib) iterateRoutesForPrefixIndex(prefixIdx prefixIndex) iter.Seq[route] {
+// iterateRoutesForPrefixIndex returns an iterator over all routes for a given prefix index
+func (rs *ribShard) iterateRoutesForPrefixIndex(prefixIdx prefixIndex) iter.Seq[route] {
 	return func(yield func(route) bool) {
 		key := makeRouteKey(prefixIdx, 0)
 		for {
-			route, exists := r.routes[key]
+			route, exists := rs.routes[key]
 			if !exists {
 				break
 			}
@@ -194,24 +238,24 @@ func (r *rib) iterateRoutesForPrefixIndex(prefixIdx prefixIndex) iter.Seq[route]
 // prefix becomes empty, removes it from the tree and frees the prefix ID. It
 // returns the number of routes removed and a boolean to say if the prefix
 // should be removed from the tree.
-func (r *rib) removeRoutes(prefixIdx prefixIndex, shouldRemove func(route) bool, once bool) (int, bool) {
+func (rs *ribShard) removeRoutes(prefixIdx prefixIndex, shouldRemove func(route) bool, once bool) (int, bool) {
 	removed := 0
 	checkKey := makeRouteKey(prefixIdx, 0)
 	nextKey := checkKey
 	skip := false // skip remaining routes if once is true
 
 	for {
-		existingRoute, exists := r.routes[checkKey]
+		existingRoute, exists := rs.routes[checkKey]
 		if !exists {
 			break
 		}
 
 		if !skip && shouldRemove(existingRoute) {
 			// Remove this route
-			r.nlris.Take(existingRoute.nlri)
-			r.nextHops.Take(existingRoute.nextHop)
-			r.rtas.Take(existingRoute.attributes)
-			delete(r.routes, checkKey)
+			rs.nlris.Take(existingRoute.nlri)
+			rs.nextHops.Take(existingRoute.nextHop)
+			rs.rtas.Take(existingRoute.attributes)
+			delete(rs.routes, checkKey)
 			removed++
 			if once {
 				skip = true
@@ -219,8 +263,8 @@ func (r *rib) removeRoutes(prefixIdx prefixIndex, shouldRemove func(route) bool,
 		} else {
 			// Keep this route, move it to nextKey if needed
 			if checkKey != nextKey {
-				r.routes[nextKey] = existingRoute
-				delete(r.routes, checkKey)
+				rs.routes[nextKey] = existingRoute
+				delete(rs.routes, checkKey)
 			}
 			nextKey++ // advance to next position for kept routes
 		}
@@ -230,47 +274,56 @@ func (r *rib) removeRoutes(prefixIdx prefixIndex, shouldRemove func(route) bool,
 	return removed, nextKey == makeRouteKey(prefixIdx, 0)
 }
 
-// IterateRoutes will iterate on all the routes matching the provided IP address.
-func (r *rib) IterateRoutes(ip netip.Addr) iter.Seq[route] {
-	return func(yield func(route) bool) {
-		prefixIdx, found := r.tree.Lookup(ip.Unmap())
-		if found {
-			r.iterateRoutesForPrefixIndex(prefixIdx)(yield)
-		}
-	}
-}
-
-// AddRoute add a new route to the RIB. It returns the number of routes
+// AddRoute adds a new route to the RIB. It returns the number of routes
 // really added and whether the prefix is new in the tree.
-func (r *rib) AddRoute(prefix netip.Prefix, newRoute route) (int, bool) {
+func (r *rib) AddRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
+	prefix = helpers.UnmapPrefix(prefix)
+	shardIdx := r.shardForPrefix(prefix)
+	rs := r.shards[shardIdx]
+
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	nlriRef := rs.nlris.Put(rr.nlri)
+	nhRef := rs.nextHops.Put(rr.nextHop)
+	rtaRef := rs.rtas.Put(rr.attributes)
+	newRoute := route{
+		peer:       rr.peer,
+		nlri:       nlriRef,
+		nextHop:    nhRef,
+		attributes: rtaRef,
+		prefixLen:  rr.prefixLen,
+	}
+
 	var prefixIdx prefixIndex
 	var isNew bool
-	prefix = helpers.UnmapPrefix(prefix)
+	r.mu.Lock()
 	r.tree.Modify(prefix, func(existing prefixIndex, found bool) (prefixIndex, bool) {
 		if found {
 			prefixIdx = existing
 		} else {
 			isNew = true
-			prefixIdx = r.newPrefixIndex()
+			prefixIdx = rs.newPrefixIndex()
 		}
 		return prefixIdx, false
 	})
+	r.mu.Unlock()
 
 	// Check if route already exists (same peer and nlri)
 	key := makeRouteKey(prefixIdx, 0)
 	for {
-		existingRoute, exists := r.routes[key]
+		existingRoute, exists := rs.routes[key]
 		if !exists {
 			// Found empty slot, add new route
-			r.routes[key] = newRoute
+			rs.routes[key] = newRoute
 			return 1, isNew
 		}
 		if existingRoute.peer == newRoute.peer && existingRoute.nlri == newRoute.nlri {
 			// Found existing route, update it
-			r.nlris.Take(existingRoute.nlri)
-			r.nextHops.Take(existingRoute.nextHop)
-			r.rtas.Take(existingRoute.attributes)
-			r.routes[key] = newRoute
+			rs.nlris.Take(existingRoute.nlri)
+			rs.nextHops.Take(existingRoute.nextHop)
+			rs.rtas.Take(existingRoute.attributes)
+			rs.routes[key] = newRoute
 			return 0, false // Not really added, just updated
 		}
 		key++
@@ -279,19 +332,31 @@ func (r *rib) AddRoute(prefix netip.Prefix, newRoute route) (int, bool) {
 
 // RemoveRoute removes a route from the RIB. It returns the number of routes
 // really removed and whether the prefix was removed from the tree.
-func (r *rib) RemoveRoute(prefix netip.Prefix, oldRoute route) (int, bool) {
+func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
+	prefix = helpers.UnmapPrefix(prefix)
+	shardIdx := r.shardForPrefix(prefix)
+	rs := r.shards[shardIdx]
+
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	nlriRef, ok := rs.nlris.Ref(rr.nlri)
+	if !ok {
+		return 0, false
+	}
+
 	removedCount := 0
 	prefixRemoved := false
-	prefix = helpers.UnmapPrefix(prefix)
 
+	r.mu.Lock()
 	r.tree.Modify(prefix, func(existing prefixIndex, found bool) (prefixIndex, bool) {
 		if found {
 			var empty bool
-			removedCount, empty = r.removeRoutes(existing, func(route route) bool {
-				return route.peer == oldRoute.peer && route.nlri == oldRoute.nlri
+			removedCount, empty = rs.removeRoutes(existing, func(route route) bool {
+				return route.peer == rr.peer && route.nlri == nlriRef
 			}, true)
 			if empty {
-				r.freePrefixIndex(existing)
+				rs.freePrefixIndex(existing)
 				prefixRemoved = true
 				return 0, true
 			}
@@ -299,6 +364,7 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, oldRoute route) (int, bool) {
 		}
 		return 0, true
 	})
+	r.mu.Unlock()
 
 	return removedCount, prefixRemoved
 }
@@ -310,42 +376,100 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	prefixesRemoved := 0
 	anyEmpty := false
 
+	// Lock all shards in order, then tree
+	for _, rs := range r.shards {
+		rs.mu.Lock()
+	}
+	r.mu.Lock()
+
 	// Iterate through all prefixes and remove peer routes.
 	for _, prefixIdx := range r.tree.All() {
-		removed, empty := r.removeRoutes(prefixIdx, func(route route) bool {
+		rs := r.shards[prefixIdx.shardIdx()]
+		removed, empty := rs.removeRoutes(prefixIdx, func(route route) bool {
 			return route.peer == peer
 		}, false)
 		routesRemoved += removed
 		if empty {
+			rs.freePrefixIndex(prefixIdx)
 			prefixesRemoved++
 		}
 		anyEmpty = anyEmpty || empty
 	}
 
 	if anyEmpty {
-		// We need to rebuild the tree. A typical tree is 1M routes, this should
-		// be pretty fast. Moreover, loosing a peer is not a condition happening
-		// often.
+		// Rebuild the tree excluding empty prefixes.
 		newTree := &bart.Table[prefixIndex]{}
 		for prefix, prefixIdx := range r.tree.All() {
-			if prefixIdx != 0 {
+			if _, hasRoutes := r.shards[prefixIdx.shardIdx()].routes[makeRouteKey(prefixIdx, 0)]; hasRoutes {
 				newTree.Insert(prefix, prefixIdx)
 			}
 		}
 		r.tree = newTree
 	}
+
+	r.mu.Unlock()
+	for i := len(r.shards) - 1; i >= 0; i-- {
+		r.shards[i].mu.Unlock()
+	}
+
 	return routesRemoved, prefixesRemoved
 }
 
-// newRIB initializes a new RIB.
-func newRIB() *rib {
+// LookupRoute looks up the best matching route for an IP address,
+// preferring routes with the given next hop. It returns route attributes,
+// next hop, prefix length, and whether a route was found.
+func (r *rib) LookupRoute(ip, preferredNH netip.Addr) (routeAttributes, nextHop, uint8, bool) {
+	r.mu.RLock()
+	prefixIdx, found := r.tree.Lookup(ip.Unmap())
+	r.mu.RUnlock()
+
+	if !found {
+		return routeAttributes{}, nextHop{}, 0, false
+	}
+
+	rs := r.shards[prefixIdx.shardIdx()]
+
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+
+	var selectedRoute route
+	routeFound := false
+	for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {
+		if !routeFound {
+			selectedRoute = route
+			routeFound = true
+		}
+		if rs.nextHops.Get(route.nextHop) == nextHop(preferredNH) {
+			selectedRoute = route
+			break
+		}
+	}
+
+	if !routeFound {
+		return routeAttributes{}, nextHop{}, 0, false
+	}
+
+	return rs.rtas.Get(selectedRoute.attributes),
+		rs.nextHops.Get(selectedRoute.nextHop),
+		selectedRoute.prefixLen, true
+}
+
+// newRIB initializes a new RIB with the specified number of shards.
+func newRIB(nShards int) *rib {
+	shards := make([]*ribShard, nShards)
+	for i := range nShards {
+		shards[i] = &ribShard{
+			idx:           i,
+			routes:        make(map[routeKey]route),
+			nlris:         intern.NewPool[nlri](),
+			nextHops:      intern.NewPool[nextHop](),
+			rtas:          intern.NewPool[routeAttributes](),
+			nextPrefixID:  1, // Start from 1, 0 means to be removed
+			freePrefixIDs: make([]prefixIndex, 0),
+		}
+	}
 	return &rib{
-		tree:          &bart.Table[prefixIndex]{},
-		routes:        make(map[routeKey]route),
-		nlris:         intern.NewPool[nlri](),
-		nextHops:      intern.NewPool[nextHop](),
-		rtas:          intern.NewPool[routeAttributes](),
-		nextPrefixID:  1, // Start from 1, 0 means to be removed
-		freePrefixIDs: make([]prefixIndex, 0),
+		tree:   &bart.Table[prefixIndex]{},
+		shards: shards,
 	}
 }

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -184,48 +184,47 @@ func TestRTAEqual(t *testing.T) {
 }
 
 func TestRemoveRoutes(t *testing.T) {
-	nr := func(r *rib, peer uint32) route {
-		return route{
-			peer:    peer,
-			nlri:    r.nlris.Put(nlri{family: bgp.RF_IPv4_UC, path: 1}),
-			nextHop: r.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:198.51.100.8"))),
-			attributes: r.rtas.Put(routeAttributes{
-				asn: 65300,
-			}),
-			prefixLen: 96 + 24,
-		}
+	addRoute := func(r *rib, peer uint32) {
+		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), rawRoute{
+			peer:       peer,
+			nlri:       nlri{family: bgp.RF_IPv4_UC, path: 1},
+			nextHop:    nextHop(netip.MustParseAddr("::ffff:198.51.100.8")),
+			attributes: routeAttributes{asn: 65300},
+			prefixLen:  96 + 24,
+		})
 	}
 	t.Run("only route", func(t *testing.T) {
-		r := newRIB()
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), nr(r, 10))
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(route) bool { return true }, true)
+		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, true)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
 		}
 		if count != 1 {
 			t.Error("removeRoutes() should have removed 1 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{}); diff != "" {
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{}); diff != "" {
 			t.Errorf("removeRoutes() (-got, +want):\n%s", diff)
 		}
 	})
 
 	t.Run("first route", func(t *testing.T) {
-		r := newRIB()
-		r1 := nr(r, 10)
-		r2 := nr(r, 11)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r2)
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
+		addRoute(r, 11)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(r route) bool { return r.peer == 10 }, true)
+		r2 := rs.routes[makeRouteKey(idx, 1)]
+		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 10 }, true)
 		if empty {
 			t.Error("removeRoutes() should not have removed all routes from node")
 		}
 		if count != 1 {
 			t.Error("removeRoutes() should have removed 1 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{
 			makeRouteKey(idx, 0): r2,
 		}); diff != "" {
 			t.Errorf("removeRoutes() (-got, +want):\n%s", diff)
@@ -233,42 +232,42 @@ func TestRemoveRoutes(t *testing.T) {
 	})
 
 	t.Run("second route", func(t *testing.T) {
-		r := newRIB()
-		r1 := nr(r, 10)
-		r2 := nr(r, 11)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r2)
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
+		addRoute(r, 11)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
+		r1 := rs.routes[makeRouteKey(idx, 0)]
+		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
 		if empty {
 			t.Error("removeRoutes() should not have removed all routes from node")
 		}
 		if count != 1 {
 			t.Error("removeRoutes() should have removed 1 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{
 			makeRouteKey(idx, 0): r1,
 		}); diff != "" {
 			t.Errorf("removeRoutes() (-got, +want):\n%s", diff)
 		}
 	})
 	t.Run("middle route", func(t *testing.T) {
-		r := newRIB()
-		r1 := nr(r, 10)
-		r2 := nr(r, 11)
-		r3 := nr(r, 12)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r2)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r3)
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
+		addRoute(r, 11)
+		addRoute(r, 12)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
+		r1 := rs.routes[makeRouteKey(idx, 0)]
+		r3 := rs.routes[makeRouteKey(idx, 2)]
+		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
 		if empty {
 			t.Error("removeRoutes() should not have removed all routes from node")
 		}
 		if count != 1 {
 			t.Error("removeRoutes() should have removed 1 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{
 			makeRouteKey(idx, 0): r1,
 			makeRouteKey(idx, 1): r3,
 		}); diff != "" {
@@ -276,26 +275,24 @@ func TestRemoveRoutes(t *testing.T) {
 		}
 	})
 	t.Run("one route out of two", func(t *testing.T) {
-		r := newRIB()
-		r1 := nr(r, 10)
-		r2 := nr(r, 11)
-		r3 := nr(r, 12)
-		r4 := nr(r, 13)
-		r5 := nr(r, 14)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r2)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r3)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r4)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r5)
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
+		addRoute(r, 11)
+		addRoute(r, 12)
+		addRoute(r, 13)
+		addRoute(r, 14)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(r route) bool { return r.peer%2 == 0 }, false)
+		r2 := rs.routes[makeRouteKey(idx, 1)]
+		r4 := rs.routes[makeRouteKey(idx, 3)]
+		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer%2 == 0 }, false)
 		if empty {
 			t.Error("removeRoutes() should not have removed all routes from node")
 		}
 		if count != 3 {
 			t.Error("removeRoutes() should have removed 3 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{
 			makeRouteKey(idx, 0): r2,
 			makeRouteKey(idx, 1): r4,
 		}); diff != "" {
@@ -304,26 +301,22 @@ func TestRemoveRoutes(t *testing.T) {
 	})
 
 	t.Run("all routes", func(t *testing.T) {
-		r := newRIB()
-		r1 := nr(r, 10)
-		r2 := nr(r, 11)
-		r3 := nr(r, 12)
-		r4 := nr(r, 13)
-		r5 := nr(r, 14)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r1)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r2)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r3)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r4)
-		r.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/120"), r5)
+		r := newRIB(1)
+		rs := r.shards[0]
+		addRoute(r, 10)
+		addRoute(r, 11)
+		addRoute(r, 12)
+		addRoute(r, 13)
+		addRoute(r, 14)
 		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
-		count, empty := r.removeRoutes(idx, func(route) bool { return true }, false)
+		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, false)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
 		}
 		if count != 5 {
 			t.Error("removeRoutes() should have removed 5 route")
 		}
-		if diff := helpers.Diff(r.routes, map[routeKey]route{}); diff != "" {
+		if diff := helpers.Diff(rs.routes, map[routeKey]route{}); diff != "" {
 			t.Errorf("removeRoutes() (-got, +want):\n%s", diff)
 		}
 	})
@@ -344,7 +337,7 @@ func TestRIBHarness(t *testing.T) {
 			run, totalExporters, peerPerExporter,
 			maxInitialRoutePerPeer, maxRemovedRoutePerPeer, maxReaddedRoutePerPeer)
 
-		r := newRIB()
+		r := newRIB(16)
 		type lookup struct {
 			peer    uint32
 			addr    netip.Addr
@@ -391,15 +384,13 @@ func TestRIBHarness(t *testing.T) {
 						asn:     uint32(random.IntN(1000)),
 						comment: "added during first pass",
 					}
-					routesAdded, _ := r.AddRoute(netip.PrefixFrom(lookup.addr, 64),
-						route{
-							peer:    peer,
-							nlri:    r.nlris.Put(nlri{rd: lookup.rd}),
-							nextHop: r.nextHops.Put(nextHop(lookup.nextHop)),
-							attributes: r.rtas.Put(routeAttributes{
-								asn: lookup.asn,
-							}),
-						})
+					routesAdded, _ := r.AddRoute(netip.PrefixFrom(lookup.addr, 64), rawRoute{
+						peer:       peer,
+						nlri:       nlri{rd: lookup.rd},
+						nextHop:    nextHop(lookup.nextHop),
+						attributes: routeAttributes{asn: lookup.asn},
+						prefixLen:  64,
+					})
 					added += routesAdded
 					removeLookup(lookup, fmt.Sprintf("erased by NH: %s, ASN: %d", lookup.nextHop, lookup.asn))
 					lookups = append(lookups, lookup)
@@ -412,21 +403,16 @@ func TestRIBHarness(t *testing.T) {
 					prefix := netip.MustParseAddr(fmt.Sprintf("2001:db8:f:%x::",
 						random.IntN(300)))
 					rd := RD(random.IntN(4))
-					if nlriRef, ok := r.nlris.Ref(nlri{
-						rd: rd,
-					}); ok {
-						routesRemoved, _ := r.RemoveRoute(netip.PrefixFrom(prefix, 64),
-							route{
-								peer: peer,
-								nlri: nlriRef,
-							})
-						removed += routesRemoved
-						removeLookup(lookup{
-							peer: peer,
-							addr: prefix,
-							rd:   rd,
-						}, "removed during second pass")
-					}
+					routesRemoved, _ := r.RemoveRoute(netip.PrefixFrom(prefix, 64), rawRoute{
+						peer: peer,
+						nlri: nlri{rd: rd},
+					})
+					removed += routesRemoved
+					removeLookup(lookup{
+						peer: peer,
+						addr: prefix,
+						rd:   rd,
+					}, "removed during second pass")
 				}
 				t.Logf("Run %d: removed = %d/%d", run, removed, toRemove)
 
@@ -442,15 +428,13 @@ func TestRIBHarness(t *testing.T) {
 						asn:     uint32(random.IntN(1010)),
 						comment: "added during third pass",
 					}
-					routesAdded, _ := r.AddRoute(netip.PrefixFrom(lookup.addr, 64),
-						route{
-							peer:    peer,
-							nlri:    r.nlris.Put(nlri{}),
-							nextHop: r.nextHops.Put(nextHop(lookup.nextHop)),
-							attributes: r.rtas.Put(routeAttributes{
-								asn: lookup.asn,
-							}),
-						})
+					routesAdded, _ := r.AddRoute(netip.PrefixFrom(lookup.addr, 64), rawRoute{
+						peer:       peer,
+						nlri:       nlri{},
+						nextHop:    nextHop(lookup.nextHop),
+						attributes: routeAttributes{asn: lookup.asn},
+						prefixLen:  64,
+					})
 					added += routesAdded
 					removeLookup(lookup, fmt.Sprintf("erased by NH: %s, ASN: %d", lookup.nextHop, lookup.asn))
 					lookups = append(lookups, lookup)
@@ -477,12 +461,13 @@ func TestRIBHarness(t *testing.T) {
 			found := false
 			routeFound := false
 
-			for route := range r.iterateRoutesForPrefixIndex(prefixIdx) {
+			rs := r.shards[prefixIdx.shardIdx()]
+			for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {
 				routeFound = true // At least one route exists
-				if r.nextHops.Get(route.nextHop) != nextHop(lookup.nextHop) || r.nlris.Get(route.nlri).rd != lookup.rd {
+				if rs.nextHops.Get(route.nextHop) != nextHop(lookup.nextHop) || rs.nlris.Get(route.nlri).rd != lookup.rd {
 					continue
 				}
-				if r.rtas.Get(route.attributes).asn != lookup.asn {
+				if rs.rtas.Get(route.attributes).asn != lookup.asn {
 					continue
 				}
 				found = true
@@ -500,11 +485,11 @@ func TestRIBHarness(t *testing.T) {
 					lookup.addr, lookup.peer,
 					lookup.nextHop, lookup.rd, lookup.asn, lookup.comment)
 				t.Logf("> available routes in tree for %s:", lookup.addr)
-				for route := range r.iterateRoutesForPrefixIndex(prefixIdx) {
+				for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {
 					t.Logf("  peer %d, NH: %s, RD: %s, ASN: %d",
 						route.peer,
-						netip.Addr(r.nextHops.Get(route.nextHop)),
-						r.nlris.Get(route.nlri).rd, r.rtas.Get(route.attributes).asn)
+						netip.Addr(rs.nextHops.Get(route.nextHop)),
+						rs.nlris.Get(route.nlri).rd, rs.rtas.Get(route.attributes).asn)
 				}
 				t.Logf("> route history for prefix %s:", lookup.addr)
 				for _, olookup := range lookups {
@@ -537,15 +522,23 @@ func TestRIBHarness(t *testing.T) {
 			r.FlushPeer(peer)
 		}
 
-		// Check for leak of interned values
-		if r.nlris.Len() > 0 {
-			t.Errorf("%d NLRIs have leaked", r.nlris.Len())
+		// Check for leak of interned values across all shards
+		totalNlris := 0
+		totalNextHops := 0
+		totalRtas := 0
+		for _, rs := range r.shards {
+			totalNlris += rs.nlris.Len()
+			totalNextHops += rs.nextHops.Len()
+			totalRtas += rs.rtas.Len()
 		}
-		if r.nextHops.Len() > 0 {
-			t.Errorf("%d next hops have leaked", r.nextHops.Len())
+		if totalNlris > 0 {
+			t.Errorf("%d NLRIs have leaked", totalNlris)
 		}
-		if r.rtas.Len() > 0 {
-			t.Errorf("%d route attributes have leaked", r.rtas.Len())
+		if totalNextHops > 0 {
+			t.Errorf("%d next hops have leaked", totalNextHops)
+		}
+		if totalRtas > 0 {
+			t.Errorf("%d route attributes have leaked", totalRtas)
 		}
 
 		if t.Failed() {

--- a/outlet/routing/provider/bmp/root.go
+++ b/outlet/routing/provider/bmp/root.go
@@ -61,7 +61,7 @@ func (configuration Configuration) New(r *reporter.Reporter, dependencies Depend
 		d:      &dependencies,
 		config: configuration,
 
-		rib:   newRIB(),
+		rib:   newRIB(int(configuration.RIBShards)),
 		peers: make(map[peerKey]*peerInfo),
 	}
 	if len(p.config.RDs) > 0 {

--- a/outlet/routing/provider/bmp/root_test.go
+++ b/outlet/routing/provider/bmp/root_test.go
@@ -44,11 +44,15 @@ func TestBMP(t *testing.T) {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
 		result := map[netip.Addr][]string{}
+		c.rib.mu.RLock()
+		defer c.rib.mu.RUnlock()
 		for prefix, prefixIdx := range c.rib.tree.All() {
-			for route := range c.rib.iterateRoutesForPrefixIndex(prefixIdx) {
-				nlriRef := c.rib.nlris.Get(route.nlri)
-				nh := c.rib.nextHops.Get(route.nextHop)
-				attrs := c.rib.rtas.Get(route.attributes)
+			rs := c.rib.shards[prefixIdx.shardIdx()]
+			rs.mu.RLock()
+			for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {
+				nlriRef := rs.nlris.Get(route.nlri)
+				nh := rs.nextHops.Get(route.nextHop)
+				attrs := rs.rtas.Get(route.attributes)
 				var peer netip.Addr
 				for pkey, pinfo := range c.peers {
 					if pinfo.reference == route.peer {
@@ -71,6 +75,7 @@ func TestBMP(t *testing.T) {
 						attrs.communities, attrs.largeCommunities))
 				slices.Sort(result[peer])
 			}
+			rs.mu.RUnlock()
 		}
 		return result
 	}
@@ -1231,11 +1236,12 @@ func TestBMP(t *testing.T) {
 		}
 
 		// Add another prefix
-		p.rib.AddRoute(netip.MustParsePrefix("2001:db8:1::/64"), route{
+		p.rib.AddRoute(netip.MustParsePrefix("2001:db8:1::/64"), rawRoute{
 			peer:       1,
-			nlri:       p.rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC}),
-			nextHop:    p.rib.nextHops.Put(nextHop(netip.MustParseAddr("2001:db8::a"))),
-			attributes: p.rib.rtas.Put(routeAttributes{asn: 176}),
+			nlri:       nlri{family: bgp.RF_IPv4_UC},
+			nextHop:    nextHop(netip.MustParseAddr("2001:db8::a")),
+			attributes: routeAttributes{asn: 176},
+			prefixLen:  64,
 		})
 
 		lookup, _ = p.Lookup(t.Context(),

--- a/outlet/routing/provider/bmp/tests.go
+++ b/outlet/routing/provider/bmp/tests.go
@@ -48,87 +48,85 @@ func (p *Provider) PopulateRIB(t *testing.T) {
 		ptype:    bmp.BMP_PEER_TYPE_GLOBAL,
 		asn:      64500,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.0/123"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.0/123"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC, path: 1}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:198.51.100.4"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{family: bgp.RF_IPv4_UC, path: 1},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:198.51.100.4")),
+		attributes: routeAttributes{
 			asn:              174,
 			asPath:           []uint32{64200, 1299, 174},
 			communities:      []uint32{100, 200, 400},
 			largeCommunities: []bgp.LargeCommunity{{ASN: 64200, LocalData1: 2, LocalData2: 3}},
-		}),
+		},
 		prefixLen: 96 + 27,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.0/123"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.0/123"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC, path: 2}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:198.51.100.8"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{family: bgp.RF_IPv4_UC, path: 2},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:198.51.100.8")),
+		attributes: routeAttributes{
 			asn:         174,
 			asPath:      []uint32{64200, 174, 174, 174},
 			communities: []uint32{100},
-		}),
+		},
 		prefixLen: 96 + 27,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.128/123"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.0.2.128/123"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:198.51.100.8"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{family: bgp.RF_IPv4_UC},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:198.51.100.8")),
+		attributes: routeAttributes{
 			asn:         1299,
 			asPath:      []uint32{64200, 1299},
 			communities: []uint32{500},
-		}),
+		},
 		prefixLen: 96 + 27,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:1.0.0.0/120"), route{
-		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{family: bgp.RF_IPv4_UC}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:198.51.100.8"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
-			asn: 65300,
-		}),
-		prefixLen: 96 + 24,
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:1.0.0.0/120"), rawRoute{
+		peer:       pinfo.reference,
+		nlri:       nlri{family: bgp.RF_IPv4_UC},
+		nextHop:    nextHop(netip.MustParseAddr("::ffff:198.51.100.8")),
+		attributes: routeAttributes{asn: 65300},
+		prefixLen:  96 + 24,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/117"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/117"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:203.0.113.14"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:203.0.113.14")),
+		attributes: routeAttributes{
 			asn:    1234,
 			asPath: []uint32{54321, 1234},
-		}),
+		},
 		prefixLen: 96 + 21,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/118"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.144.0/118"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:203.0.113.15"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:203.0.113.15")),
+		attributes: routeAttributes{
 			asn:    1234,
 			asPath: []uint32{1234},
-		}),
+		},
 		prefixLen: 96 + 22,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.148.0/118"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.148.0/118"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:203.0.113.15"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:203.0.113.15")),
+		attributes: routeAttributes{
 			asn:    1234,
 			asPath: []uint32{1234},
-		}),
+		},
 		prefixLen: 96 + 22,
 	})
-	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.148.1/128"), route{
+	p.rib.AddRoute(netip.MustParsePrefix("::ffff:192.168.148.1/128"), rawRoute{
 		peer:    pinfo.reference,
-		nlri:    p.rib.nlris.Put(nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0}),
-		nextHop: p.rib.nextHops.Put(nextHop(netip.MustParseAddr("::ffff:203.0.113.14"))),
-		attributes: p.rib.rtas.Put(routeAttributes{
+		nlri:    nlri{rd: 10, family: bgp.RF_IPv4_UC, path: 0},
+		nextHop: nextHop(netip.MustParseAddr("::ffff:203.0.113.14")),
+		attributes: routeAttributes{
 			asn:    1234,
 			asPath: []uint32{1234},
-		}),
+		},
 		prefixLen: 96 + 32,
 	})
 }


### PR DESCRIPTION
This enables more finer-grained locks and should help with lock contention with almost no downside (except increased memory usage).

It was not benchmarked yet.

Use of `struct rawRoute` could be reversed by providing a function to get a RIB shard from a prefix and have `AddRoute()` works on that. This way, we can avoid internalising several times the same variable.