### PR TITLE
docs: fix inconsistent Juniper configuration example

### DIFF
--- a/console/data/docs/04-operations.md
+++ b/console/data/docs/04-operations.md
@@ -249,7 +249,7 @@ forwarding-options {
               port 2055;
               autonomous-system-type origin;
               source-address 203.0.113.2;
-              version-ipfix {
+              version9 {
                 template {
                   ipv4;
                 }
@@ -266,7 +266,7 @@ forwarding-options {
               port 2055;
               autonomous-system-type origin;
               source-address 203.0.113.2;
-              version-ipfix {
+              version9 {
                 template {
                   ipv6;
                 }
@@ -291,7 +291,7 @@ chassis {
 }
 services {
   flow-monitoring {
-    version-ipfix {
+    version9 {
       template ipv4 {
         nexthop-learning enable;
         flow-active-timeout 10;


### PR DESCRIPTION
Port 2055 is the port for NetFlow v9, but the example configuration is version-ipfix, which is inconsistent.

According to https://github.com/akvorado/akvorado/issues/191, Akvorado does not support IPFIX on Juniper SRX, so it is recommended to align it with NetFlow v9.