### PR TITLE
build: switch to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
         exclude:
           - renovatebot: gomod
         include:
-          - node-version: 22
+          - node-version: 24
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:22-alpine AS build-js
+FROM --platform=$BUILDPLATFORM node:24-alpine AS build-js
 RUN apk add --no-cache make
 WORKDIR /build
 COPY console/frontend console/frontend

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           inherit system;
         };
         l = builtins // pkgs.lib;
-        nodejs = pkgs.nodejs_22;
+        nodejs = pkgs.nodejs_24;
         pnpm = pkgs.pnpm_10;
         go = pkgs.go_latest;
         frontend = pkgs.stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
Node 22 is still supported, but Node 24 has hit Debian Unstable, so that's the version I am using to test during development.