### PR TITLE
console: add bidirectional direction for sankey graphs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,16 @@ can spawn them through `docker compose -f docker/docker-compose-dev.yml`:
 
 For manual tests, you can use `make docker-dev` to build a Docker container,
 then use `docker compose --profile demo up` to run Docker Compose. Each time you
-modify the code, repeat these two steps:
+modify the code, repeat this step:
 
 ```console
-$ make docker-dev && CONSOLE_HEALTHCHECK_DISABLED=true docker compose --profile demo up -d
+$ make docker-dev && docker compose --profile demo up --wait
+
+```
+Alternatively, if you are only working on the console:
+
+```console
+$ make docker-dev && CONSOLE_HEALTHCHECK_DISABLED=true docker compose --profile demo up akvorado-console --wait --no-deps
 ```
 
 Once done, run `docker compose --profile demo down` to stop all the containers.

--- a/console/data/docs/03-usage.md
+++ b/console/data/docs/03-usage.md
@@ -126,9 +126,11 @@ appearance.
   display time series, and “sankey” to show flow distributions between various
   dimensions.
 
-- For “stacked”, “lines”, and “grid” graphs, the *bidirectional*
-  option adds flows in the opposite direction to the graph. They
-  are displayed as negative values on the graph.
+- For “stacked”, “lines”, and “grid” graphs, the *bidirectional* option adds
+  flows in the opposite direction to the graph. They are displayed as negative
+  values on the graph. For “sankey” graphs, the *bidirectional* option splits
+  the diagram into two side-by-side parts: the left side shows the forward
+  direction, the right side shows the reverse direction.
 
 - For “stacked” graphs, the *previous period* option adds a line for
   the traffic levels from the previous period. Depending on

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -12,7 +12,10 @@ identified with a specific icon:
 
 ## Unreleased
 
-- ✨ *outlet*: add `SrcCommunities` and `SrcLargeCommunities` (disabled by default, as they can be inaccurate)
+- ✨ *console*: add a "bidirectional" option for sankey graphs, splitting the
+  diagram into forward and reverse halves side by side
+- ✨ *outlet*: add `SrcCommunities` and `SrcLargeCommunities` (disabled by
+  default, as they can be inaccurate)
 - 🩹 *outlet*: when static metadata is missing, don't return an empty interface
 - 🩹 *orchestrator*: improve detection of changed configuration file
 - 🌱 *outlet*: cache the SNMPv3 engine ID to not trigger discovery probe on subsequent polls

--- a/console/frontend/src/views/VisualizePage.vue
+++ b/console/frontend/src/views/VisualizePage.vue
@@ -156,7 +156,6 @@ const jsonPayload = computed(
       const input: GraphSankeyHandlerInput = {
         ...omit(state.value, [
           "graphType",
-          "bidirectional",
           "previousPeriod",
           "humanStart",
           "humanEnd",
@@ -229,7 +228,13 @@ const { data, execute, isFetching, aborted, abort, canAbort, error } = useFetch(
         fetchedData.value = {
           graphType: "sankey",
           ...(data as GraphSankeyHandlerOutput),
-          ...pick(state.value, ["start", "end", "dimensions", "units"]),
+          ...pick(state.value, [
+            "start",
+            "end",
+            "dimensions",
+            "units",
+            "bidirectional",
+          ]),
         };
       } else {
         fetchedData.value = {

--- a/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
+++ b/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
@@ -36,17 +36,29 @@ const option = computed((): ECOption => {
   const theme = isDark.value ? "dark" : "light";
   const data = props.data || {};
   if (!data.xps) return {};
-  let greyNodes = 0;
-  let colorNodes = 0;
-  const makeNode = ({ name }: GraphSankeyHandlerResult["nodes"][0]) => ({
-    id: name,
-    name: name.split(": ").slice(1).join(": "),
-    itemStyle: {
-      color: name.endsWith(" Other")
-        ? dataColorGrey(greyNodes++, false, theme)
-        : dataColor(colorNodes++, false, theme),
-    },
-  });
+  // Allocate colors by node value (the part after ": ") so the same value
+  // gets the same color across the forward and reverse halves.
+  const colorByValue = new Map<string, number>();
+  const greyByValue = new Map<string, number>();
+  const makeNode = ({ name }: GraphSankeyHandlerResult["nodes"][0]) => {
+    const label = name.split(": ").slice(1).join(": ");
+    const isGrey = name.endsWith(" Other");
+    const cache = isGrey ? greyByValue : colorByValue;
+    let idx = cache.get(label);
+    if (idx === undefined) {
+      idx = cache.size;
+      cache.set(label, idx);
+    }
+    return {
+      id: name,
+      name: label,
+      itemStyle: {
+        color: isGrey
+          ? dataColorGrey(idx, false, theme)
+          : dataColor(idx, false, theme),
+      },
+    };
+  };
   const makeLink = ({
     source,
     target,

--- a/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
+++ b/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
@@ -38,74 +38,103 @@ const option = computed((): ECOption => {
   if (!data.xps) return {};
   let greyNodes = 0;
   let colorNodes = 0;
+  const makeNode = ({ name }: GraphSankeyHandlerResult["nodes"][0]) => ({
+    id: name,
+    name: name.split(": ").slice(1).join(": "),
+    itemStyle: {
+      color: name.endsWith(" Other")
+        ? dataColorGrey(greyNodes++, false, theme)
+        : dataColor(colorNodes++, false, theme),
+    },
+  });
+  const makeLink = ({
+    source,
+    target,
+    xps,
+  }: GraphSankeyHandlerResult["links"][0]) => ({
+    source,
+    target,
+    value: xps,
+  });
+  const seriesBase = {
+    type: "sankey" as const,
+    animationDuration: 500,
+    emphasis: { focus: "trajectory" as const },
+    label: { formatter: "{b}" },
+    lineStyle: { color: "gradient" as const, curveness: 0.5 },
+  };
+  const tooltip: TooltipComponentOption = {
+    confine: true,
+    trigger: "item",
+    triggerOn: "mousemove",
+    formatter(params) {
+      if (Array.isArray(params)) return "";
+      const { dataType, marker, data, value } =
+        params as TooltipCallbackDataParams;
+      if (dataType === "node") {
+        const nodeData = data as NonNullable<SankeySeriesOption["nodes"]>[0];
+        return [
+          marker,
+          `<span style="display:inline-block;margin-left:1em;">${nodeData.name}</span>`,
+          `<span style="display:inline-block;margin-left:2em;font-weight:bold;">${formatXps(
+            (value?.valueOf() as number) ?? 0,
+          )}`,
+        ].join("");
+      } else if (dataType === "edge") {
+        const edgeData = data as NonNullable<SankeySeriesOption["edges"]>[0];
+        const source =
+          edgeData.source?.toString().split(": ").slice(1).join(": ") ?? "???";
+        const target =
+          edgeData.target?.toString().split(": ").slice(1).join(": ") ?? "???";
+        return value
+          ? [
+              `${source} → ${target}`,
+              `<span style="display:inline-block;margin-left:2em;font-weight:bold;">${formatXps(
+                value.valueOf() as number,
+              )}`,
+            ].join("")
+          : "";
+      }
+      return "";
+    },
+    valueFormatter: (value) => formatXps((value?.valueOf() as number) ?? 0),
+  };
+
+  if (data.bidirectional) {
+    const fwdNodes = data.nodes.filter((n) => n.axis === 1).map(makeNode);
+    const revNodes = data.nodes.filter((n) => n.axis === 2).map(makeNode);
+    const fwdLinks = data.links.filter((l) => l.axis === 1).map(makeLink);
+    const revLinks = data.links.filter((l) => l.axis === 2).map(makeLink);
+    return {
+      backgroundColor: "transparent",
+      tooltip,
+      series: [
+        {
+          ...seriesBase,
+          left: "5%",
+          right: "55%",
+          data: fwdNodes,
+          links: fwdLinks,
+        },
+        {
+          ...seriesBase,
+          left: "55%",
+          right: "5%",
+          data: revNodes,
+          links: revLinks,
+        },
+      ],
+    };
+  }
+
   return {
     backgroundColor: "transparent",
-    tooltip: {
-      confine: true,
-      trigger: "item",
-      triggerOn: "mousemove",
-      formatter(params) {
-        if (Array.isArray(params)) return "";
-        const { dataType, marker, data, value } =
-          params as TooltipCallbackDataParams;
-        if (dataType === "node") {
-          const nodeData = data as NonNullable<SankeySeriesOption["nodes"]>[0];
-          return [
-            marker,
-            `<span style="display:inline-block;margin-left:1em;">${nodeData.name}</span>`,
-            `<span style="display:inline-block;margin-left:2em;font-weight:bold;">${formatXps(
-              (value?.valueOf() as number) ?? 0,
-            )}`,
-          ].join("");
-        } else if (dataType === "edge") {
-          const edgeData = data as NonNullable<SankeySeriesOption["edges"]>[0];
-          const source =
-            edgeData.source?.toString().split(": ").slice(1).join(": ") ??
-            "???";
-          const target =
-            edgeData.target?.toString().split(": ").slice(1).join(": ") ??
-            "???";
-          return value
-            ? [
-                `${source} → ${target}`,
-                `<span style="display:inline-block;margin-left:2em;font-weight:bold;">${formatXps(
-                  value.valueOf() as number,
-                )}`,
-              ].join("")
-            : "";
-        }
-        return "";
-      },
-      valueFormatter: (value) => formatXps((value?.valueOf() as number) ?? 0),
-    },
+    tooltip,
     series: [
       {
-        type: "sankey",
-        animationDuration: 500,
-        emphasis: {
-          focus: "trajectory",
-        },
-        data: data.nodes.map((v) => ({
-          id: v,
-          name: v.split(": ").slice(1).join(": "),
-          itemStyle: {
-            color: v.endsWith(" Other")
-              ? dataColorGrey(greyNodes++, false, theme)
-              : dataColor(colorNodes++, false, theme),
-          },
-        })),
-        links: data.links.map(({ source, target, xps }) => ({
-          source,
-          target,
-          value: xps,
-        })),
-        label: {
-          formatter: "{b}",
-        },
-        lineStyle: {
-          color: "gradient",
-          curveness: 0.5,
-        },
+        ...seriesBase,
+        data: data.nodes.map(makeNode),
+        links: data.links.map(makeLink),
       },
     ],
   };

--- a/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
+++ b/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
@@ -113,10 +113,27 @@ const option = computed((): ECOption => {
   };
 
   if (data.bidirectional) {
-    const fwdNodes = data.nodes.filter((n) => n.axis === 1).map(makeNode);
+    // The two halves meet at the middle. Move the labels of the rightmost
+    // forward column (last forward dimension) to the left of those nodes so
+    // they don't overlap the leftmost reverse column.
+    const lastFwdDim = data.dimensions[data.dimensions.length - 1];
+    const fwdNodes = data.nodes
+      .filter((n) => n.axis === 1)
+      .map((n) => {
+        const node = makeNode(n);
+        if (n.name.startsWith(`${lastFwdDim}: `)) {
+          return { ...node, label: { position: "left" as const } };
+        }
+        return node;
+      });
     const revNodes = data.nodes.filter((n) => n.axis === 2).map(makeNode);
     const fwdLinks = data.links.filter((l) => l.axis === 1).map(makeLink);
-    const revLinks = data.links.filter((l) => l.axis === 2).map(makeLink);
+    // Flip source/target on the reverse half so the column order is
+    // mirrored: the dimension closest to the forward side appears first.
+    const revLinks = data.links
+      .filter((l) => l.axis === 2)
+      .map(makeLink)
+      .map((l) => ({ ...l, source: l.target, target: l.source }));
     return {
       backgroundColor: "transparent",
       tooltip,
@@ -124,13 +141,13 @@ const option = computed((): ECOption => {
         {
           ...seriesBase,
           left: "5%",
-          right: "55%",
+          right: "50%",
           data: fwdNodes,
           links: fwdLinks,
         },
         {
           ...seriesBase,
-          left: "55%",
+          left: "50%",
           right: "5%",
           data: revNodes,
           links: revLinks,

--- a/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
+++ b/console/frontend/src/views/VisualizePage/DataGraphSankey.vue
@@ -16,14 +16,11 @@ import { SankeyChart, type SankeySeriesOption } from "echarts/charts";
 import {
   TooltipComponent,
   type TooltipComponentOption,
-  type GridComponentOption,
 } from "echarts/components";
 import type { TooltipCallbackDataParams } from "echarts/types/src/component/tooltip/TooltipView.d.ts";
 import VChart from "vue-echarts";
 use([CanvasRenderer, SankeyChart, TooltipComponent]);
-type ECOption = ComposeOption<
-  SankeySeriesOption | TooltipComponentOption | GridComponentOption
->;
+type ECOption = ComposeOption<SankeySeriesOption | TooltipComponentOption>;
 
 const props = defineProps<{
   data: GraphSankeyHandlerResult;

--- a/console/frontend/src/views/VisualizePage/DataTable.vue
+++ b/console/frontend/src/views/VisualizePage/DataTable.vue
@@ -122,7 +122,7 @@ const highlight = (index: number | null) => {
   emit("highlighted", originalIndex);
 };
 const axes = computed(() => {
-  if (!props.data || props.data.graphType === "sankey") return null;
+  if (!props.data) return null;
   return toPairs(props.data["axis-names"])
     .map(([k, v]) => ({ id: Number(k), name: v }))
     .filter(({ id }) => [1, 2].includes(id))
@@ -227,17 +227,19 @@ const table = computed(
           // Average
           { name: "Average", classNames: "text-right" },
         ],
-        rows: data.rows?.map((row, idx) => ({
-          values: [
-            // Dimensions
-            ...row.map((r) => ({ value: r })),
-            // Average
-            {
-              value: formatValue(data.xps[idx]),
-              classNames: "text-right tabular-nums",
-            },
-          ],
-        })),
+        rows: data.rows
+          ?.map((row, idx) => ({
+            values: [
+              // Dimensions
+              ...row.map((r) => ({ value: r })),
+              // Average
+              {
+                value: formatValue(data.xps[idx]),
+                classNames: "text-right tabular-nums",
+              },
+            ],
+          }))
+          .filter((_, idx) => data.axis[idx] === displayedAxis.value),
       };
     }
     return null;

--- a/console/frontend/src/views/VisualizePage/OptionsPanel.vue
+++ b/console/frontend/src/views/VisualizePage/OptionsPanel.vue
@@ -79,7 +79,8 @@
                 graphType.type === 'stacked' ||
                 graphType.type === 'stacked100' ||
                 graphType.type === 'lines' ||
-                graphType.type === 'grid'
+                graphType.type === 'grid' ||
+                graphType.type === 'sankey'
               "
               v-model="bidirectional"
               label="Bidirectional"
@@ -213,6 +214,9 @@ const options = computed((): InternalModelType => {
       bidirectional: bidirectional.value,
     }),
     ...(graphType.value.type === "grid" && {
+      bidirectional: bidirectional.value,
+    }),
+    ...(graphType.value.type === "sankey" && {
       bidirectional: bidirectional.value,
     }),
   };

--- a/console/frontend/src/views/VisualizePage/OptionsPanel.vue
+++ b/console/frontend/src/views/VisualizePage/OptionsPanel.vue
@@ -75,13 +75,7 @@
             class="order-4 flex grow flex-row justify-between gap-x-3 sm:max-lg:order-2 sm:max-lg:grow-0 sm:max-lg:flex-col"
           >
             <InputCheckbox
-              v-if="
-                graphType.type === 'stacked' ||
-                graphType.type === 'stacked100' ||
-                graphType.type === 'lines' ||
-                graphType.type === 'grid' ||
-                graphType.type === 'sankey'
-              "
+              v-if="bidirectionalGraphTypes.includes(graphType.type)"
               v-model="bidirectional"
               label="Bidirectional"
             />
@@ -162,6 +156,14 @@ const graphTypeList = Object.entries(graphTypes).map(([k, v], idx) => ({
   name: v,
 }));
 
+const bidirectionalGraphTypes: (keyof typeof graphTypes)[] = [
+  "stacked",
+  "stacked100",
+  "lines",
+  "grid",
+  "sankey",
+];
+
 const open = ref(false);
 const graphType = ref(graphTypeList[0]);
 const timeRange = ref<InputTimeRangeModelType>(null);
@@ -200,25 +202,10 @@ const options = computed((): InternalModelType => {
     "truncate-v6": dimensions.value?.truncate6,
     filter: filter.value?.expression,
     units: units.value,
-    bidirectional: false,
-    previousPeriod: false,
-    // Depending on the graph type...
-    ...(graphType.value.type === "stacked" && {
-      bidirectional: bidirectional.value,
-      previousPeriod: previousPeriod.value,
-    }),
-    ...(graphType.value.type === "stacked100" && {
-      bidirectional: bidirectional.value,
-    }),
-    ...(graphType.value.type === "lines" && {
-      bidirectional: bidirectional.value,
-    }),
-    ...(graphType.value.type === "grid" && {
-      bidirectional: bidirectional.value,
-    }),
-    ...(graphType.value.type === "sankey" && {
-      bidirectional: bidirectional.value,
-    }),
+    bidirectional:
+      bidirectionalGraphTypes.includes(graphType.value.type) &&
+      bidirectional.value,
+    previousPeriod: graphType.value.type === "stacked" && previousPeriod.value,
   };
 });
 const applyLabel = computed(() =>

--- a/console/frontend/src/views/VisualizePage/OptionsPanel.vue
+++ b/console/frontend/src/views/VisualizePage/OptionsPanel.vue
@@ -80,7 +80,7 @@
               label="Bidirectional"
             />
             <InputCheckbox
-              v-if="graphType.type === 'stacked'"
+              v-if="previousPeriodGraphTypes.includes(graphType.type)"
               v-model="previousPeriod"
               label="Previous period"
             />
@@ -164,6 +164,8 @@ const bidirectionalGraphTypes: (keyof typeof graphTypes)[] = [
   "sankey",
 ];
 
+const previousPeriodGraphTypes: (keyof typeof graphTypes)[] = ["stacked"];
+
 const open = ref(false);
 const graphType = ref(graphTypeList[0]);
 const timeRange = ref<InputTimeRangeModelType>(null);
@@ -205,7 +207,9 @@ const options = computed((): InternalModelType => {
     bidirectional:
       bidirectionalGraphTypes.includes(graphType.value.type) &&
       bidirectional.value,
-    previousPeriod: graphType.value.type === "stacked" && previousPeriod.value,
+    previousPeriod:
+      previousPeriodGraphTypes.includes(graphType.value.type) &&
+      previousPeriod.value,
   };
 });
 const applyLabel = computed(() =>

--- a/console/frontend/src/views/VisualizePage/index.d.ts
+++ b/console/frontend/src/views/VisualizePage/index.d.ts
@@ -11,20 +11,23 @@ export type GraphSankeyHandlerInput = {
   limit: number;
   filter: string;
   units: Units;
+  bidirectional: boolean;
 };
 export type GraphLineHandlerInput = GraphSankeyHandlerInput & {
   points: number;
-  bidirectional: boolean;
   "previous-period": boolean;
 };
 export type GraphSankeyHandlerOutput = {
   rows: string[][];
   xps: number[];
-  nodes: string[];
+  axis: number[];
+  "axis-names": Record<number, string>;
+  nodes: { name: string; axis: number }[];
   links: {
     source: string;
     target: string;
     xps: number;
+    axis: number;
   }[];
 };
 export type GraphLineHandlerOutput = {
@@ -42,7 +45,10 @@ export type GraphLineHandlerOutput = {
 };
 export type GraphSankeyHandlerResult = GraphSankeyHandlerOutput & {
   graphType: Extract<GraphType, "sankey">;
-} & Pick<GraphSankeyHandlerInput, "start" | "end" | "dimensions" | "units">;
+} & Pick<
+    GraphSankeyHandlerInput,
+    "start" | "end" | "dimensions" | "units" | "bidirectional"
+  >;
 export type GraphLineHandlerResult = GraphLineHandlerOutput & {
   graphType: Exclude<GraphType, "sankey">;
 } & Pick<

--- a/console/graph.go
+++ b/console/graph.go
@@ -27,6 +27,18 @@ type graphCommonHandlerInput struct {
 	Units          string         `json:"units" validate:"required,oneof=fps pps l3bps l2bps inl2% outl2%"`
 }
 
+// reverseUnits returns the unit name for the opposite traffic direction. Most
+// units are direction-agnostic; only the percentage-of-interface units swap.
+func reverseUnits(units string) string {
+	switch units {
+	case "inl2%":
+		return "outl2%"
+	case "outl2%":
+		return "inl2%"
+	}
+	return units
+}
+
 // sourceSelect builds a SELECT query to use as a source for data. Notably, it
 // will do IP truncation.
 func (input graphCommonHandlerInput) sourceSelect() string {

--- a/console/line.go
+++ b/console/line.go
@@ -152,12 +152,7 @@ func (input graphLineHandlerInput) toSQL1(axis int, options toSQL1Options) templ
 	// Units
 	units := input.Units
 	if options.reverseDirection {
-		switch units {
-		case "inl2%":
-			units = "outl2%"
-		case "outl2%":
-			units = "inl2%"
-		}
+		units = reverseUnits(units)
 	}
 
 	template := fmt.Sprintf(`%s

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -6,6 +6,7 @@ package console
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 
@@ -17,34 +18,65 @@ import (
 // graphSankeyHandlerInput describes the input for the /graph/sankey endpoint.
 type graphSankeyHandlerInput struct {
 	graphCommonHandlerInput
+	Bidirectional bool `json:"bidirectional"`
 }
 
 // graphSankeyHandlerOutput describes the output for the /graph/sankey endpoint.
 type graphSankeyHandlerOutput struct {
 	// Unprocessed data for table view
-	Rows [][]string `json:"rows"`
-	Xps  []int      `json:"xps"` // row → xps
+	Rows      [][]string     `json:"rows"`
+	Xps       []int          `json:"xps"`  // row → xps
+	Axis      []int          `json:"axis"` // row → axis
+	AxisNames map[int]string `json:"axis-names"`
 	// Processed data for sankey graph
-	Nodes []string     `json:"nodes"`
+	Nodes []sankeyNode `json:"nodes"`
 	Links []sankeyLink `json:"links"`
+}
+type sankeyNode struct {
+	Name string `json:"name"`
+	Axis int    `json:"axis"`
 }
 type sankeyLink struct {
 	Source string `json:"source"`
 	Target string `json:"target"`
 	Xps    int    `json:"xps"`
+	Axis   int    `json:"axis"`
 }
 
-// sankeyHandlerInputToSQL converts a sankey query to an SQL request
-func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
+// reverseDirection reverts the direction of a provided input. It does not
+// modify the original.
+func (input graphSankeyHandlerInput) reverseDirection() graphSankeyHandlerInput {
+	input.Filter.Swap()
+	input.Dimensions = slices.Clone(input.Dimensions)
+	query.Columns(input.Dimensions).Reverse(input.schema)
+	return input
+}
+
+type sankeyToSQL1Options struct {
+	skipWithClause   bool
+	reverseDirection bool
+	// rowsColumns names, for each dimension in input.Dimensions, the column
+	// from the forward `rows` CTE that corresponds positionally to it. For the
+	// forward query it is left nil and falls back to input.Dimensions. For the
+	// reverse query it is the original (forward) dimensions, so the reverse
+	// query probes the same `rows` set positionally.
+	rowsColumns []query.Column
+}
+
+func (input graphSankeyHandlerInput) toSQL1(axis int, options sankeyToSQL1Options) templateQuery {
 	where := templateWhere(input.Filter)
+	rowsColumns := options.rowsColumns
+	if rowsColumns == nil {
+		rowsColumns = input.Dimensions
+	}
 
 	// Select
 	arrayFields := []string{}
 	dimensions := []string{}
-	for _, column := range input.Dimensions {
+	for i, column := range input.Dimensions {
 		arrayFields = append(arrayFields, fmt.Sprintf(`if(%s IN (SELECT %s FROM rows), %s, 'Other')`,
 			column.String(),
-			column.String(),
+			rowsColumns[i].String(),
 			column.ToSQLSelect(input.schema)))
 		dimensions = append(dimensions, column.String())
 	}
@@ -54,35 +86,56 @@ func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
 	}
 
 	// With
-	with := []string{
-		fmt.Sprintf("source AS (%s)", input.sourceSelect()),
-		fmt.Sprintf(`(SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE %s) AS range`, where),
+	withStr := ""
+	if !options.skipWithClause {
+		with := []string{
+			fmt.Sprintf("source AS (%s)", input.sourceSelect()),
+			fmt.Sprintf(`(SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE %s) AS range`, where),
+		}
+		with = append(with, selectSankeyRowsByLimitType(input, dimensions, where))
+		withStr = fmt.Sprintf("WITH\n %s\n", strings.Join(with, ",\n "))
 	}
-	with = append(with, selectSankeyRowsByLimitType(input, dimensions, where))
 
-	template := fmt.Sprintf(`
-WITH
- %s
+	// Units
+	units := input.Units
+	if options.reverseDirection {
+		units = reverseUnits(units)
+	}
+
+	template := fmt.Sprintf(`%sSELECT %d AS axis, * FROM (
 SELECT
  %s
 FROM source
 WHERE %s
 GROUP BY dimensions
-ORDER BY xps DESC`,
-		strings.Join(with, ",\n "), strings.Join(fields, ",\n "), where)
+ORDER BY xps DESC)`,
+		withStr, axis, strings.Join(fields, ",\n "), where)
 
 	context := inputContext{
 		Start:             input.Start,
 		End:               input.End,
 		MainTableRequired: requireMainTable(input.schema, input.Dimensions, input.Filter),
 		Points:            20,
-		Units:             input.Units,
+		Units:             units,
 	}
 
-	return []templateQuery{{
+	return templateQuery{
 		Template: strings.TrimSpace(template),
 		Context:  context,
-	}}, nil
+	}
+}
+
+// toSQL converts a sankey query to an SQL request
+func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
+	queries := []templateQuery{input.toSQL1(1, sankeyToSQL1Options{})}
+	if input.Bidirectional {
+		queries = append(queries, input.reverseDirection().toSQL1(2, sankeyToSQL1Options{
+			skipWithClause:   true,
+			reverseDirection: true,
+			rowsColumns:      input.Dimensions,
+		}))
+	}
+	return queries, nil
 }
 
 func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Request) {
@@ -117,6 +170,7 @@ func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Requ
 	sqlQuery := c.finalizeTemplateQueries(queries)
 	w.Header().Set("X-SQL-Query", strings.ReplaceAll(sqlQuery, "\n", "  "))
 	results := []struct {
+		Axis       uint8    `ch:"axis"`
 		Xps        float64  `ch:"xps"`
 		Dimensions []string `ch:"dimensions"`
 	}{}
@@ -128,48 +182,79 @@ func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Requ
 
 	// Prepare output
 	output := graphSankeyHandlerOutput{
-		Rows:  make([][]string, 0, len(results)),
-		Xps:   make([]int, 0, len(results)),
-		Nodes: make([]string, 0),
-		Links: make([]sankeyLink, 0),
+		Rows:      make([][]string, 0, len(results)),
+		Xps:       make([]int, 0, len(results)),
+		Axis:      make([]int, 0, len(results)),
+		AxisNames: make(map[int]string),
+		Nodes:     make([]sankeyNode, 0),
+		Links:     make([]sankeyLink, 0),
 	}
-	completeName := func(name string, index int) string {
-		return fmt.Sprintf("%s: %s", input.Dimensions[index].String(), name)
+
+	// Compute per-axis dimension labels used as node prefixes.
+	dimensionLabels := map[int][]string{1: make([]string, len(input.Dimensions))}
+	if input.Bidirectional {
+		dimensionLabels[2] = make([]string, len(input.Dimensions))
 	}
-	addedNodes := map[string]struct{}{}
-	addNode := func(name string) {
-		if _, ok := addedNodes[name]; !ok {
-			addedNodes[name] = struct{}{}
-			output.Nodes = append(output.Nodes, name)
+	for i, col := range input.Dimensions {
+		dimensionLabels[1][i] = col.String()
+		if input.Bidirectional {
+			dimensionLabels[2][i] = input.schema.ReverseColumnDirection(col.Key()).String()
 		}
 	}
-	addLink := func(source, target string, xps int) {
+
+	type nodeKey struct {
+		name string
+		axis int
+	}
+	addedNodes := map[nodeKey]struct{}{}
+	addNode := func(name string, axis int) {
+		key := nodeKey{name, axis}
+		if _, ok := addedNodes[key]; !ok {
+			addedNodes[key] = struct{}{}
+			output.Nodes = append(output.Nodes, sankeyNode{Name: name, Axis: axis})
+		}
+	}
+	addLink := func(source, target string, xps, axis int) {
 		for idx, link := range output.Links {
-			if link.Source == source && link.Target == target {
+			if link.Axis == axis && link.Source == source && link.Target == target {
 				output.Links[idx].Xps += xps
 				return
 			}
 		}
-		output.Links = append(output.Links, sankeyLink{source, target, xps})
+		output.Links = append(output.Links, sankeyLink{Source: source, Target: target, Xps: xps, Axis: axis})
 	}
 	for _, result := range results {
+		axis := int(result.Axis)
 		output.Rows = append(output.Rows, result.Dimensions)
 		output.Xps = append(output.Xps, int(result.Xps))
-		// Consider each pair of successive dimensions
-		for i := range len(input.Dimensions) - 1 {
-			dimension1 := completeName(result.Dimensions[i], i)
-			dimension2 := completeName(result.Dimensions[i+1], i+1)
-			addNode(dimension1)
-			addNode(dimension2)
-			addLink(dimension1, dimension2, int(result.Xps))
+		output.Axis = append(output.Axis, axis)
+		labels := dimensionLabels[axis]
+		for i := range len(result.Dimensions) - 1 {
+			dimension1 := fmt.Sprintf("%s: %s", labels[i], result.Dimensions[i])
+			dimension2 := fmt.Sprintf("%s: %s", labels[i+1], result.Dimensions[i+1])
+			addNode(dimension1, axis)
+			addNode(dimension2, axis)
+			addLink(dimension1, dimension2, int(result.Xps), axis)
 		}
 	}
 	sort.Slice(output.Links, func(i, j int) bool {
+		if output.Links[i].Axis != output.Links[j].Axis {
+			return output.Links[i].Axis < output.Links[j].Axis
+		}
 		if output.Links[i].Xps == output.Links[j].Xps {
 			return output.Links[i].Source < output.Links[j].Source
 		}
 		return output.Links[i].Xps > output.Links[j].Xps
 	})
+
+	for _, axis := range output.Axis {
+		switch axis {
+		case 1:
+			output.AxisNames[axis] = "Direct"
+		case 2:
+			output.AxisNames[axis] = "Reverse"
+		}
+	}
 
 	httpserver.WriteJSON(w, http.StatusOK, output)
 }

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -4,6 +4,7 @@
 package console
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +14,49 @@ import (
 	"akvorado/common/schema"
 	"akvorado/console/query"
 )
+
+func TestGraphSankeyInputReverseDirection(t *testing.T) {
+	input := graphSankeyHandlerInput{
+		graphCommonHandlerInput: graphCommonHandlerInput{
+			schema: schema.NewMock(t),
+			Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+			End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+			Dimensions: query.Columns{
+				query.NewColumn("ExporterName"),
+				query.NewColumn("InIfProvider"),
+			},
+			Filter: query.NewFilter("DstCountry = 'FR' AND SrcCountry = 'US'"),
+			Units:  "l3bps",
+		},
+		Bidirectional: true,
+	}
+	original1 := fmt.Sprintf("%+v", input)
+	expected := graphSankeyHandlerInput{
+		graphCommonHandlerInput: graphCommonHandlerInput{
+			Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+			End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+			Dimensions: query.Columns{
+				query.NewColumn("ExporterName"),
+				query.NewColumn("OutIfProvider"),
+			},
+			Filter: query.NewFilter("SrcCountry = 'FR' AND DstCountry = 'US'"),
+			Units:  "l3bps",
+		},
+		Bidirectional: true,
+	}
+	input.Filter.Validate(input.schema)
+	expected.Filter.Validate(input.schema)
+	query.Columns(input.Dimensions).Validate(input.schema)
+	query.Columns(expected.Dimensions).Validate(input.schema)
+	got := input.reverseDirection()
+	original2 := fmt.Sprintf("%+v", input)
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Fatalf("reverseDirection() (-got, +want):\n%s", diff)
+	}
+	if original1 != original2 {
+		t.Fatalf("reverseDirection() modified original to:\n-%s\n+%s", original1, original2)
+	}
+}
 
 func TestSankeyQuerySQL(t *testing.T) {
 	cases := []struct {
@@ -25,7 +69,7 @@ func TestSankeyQuerySQL(t *testing.T) {
 			Description: "two dimensions, no filters, l3 bps",
 			Pos:         helpers.Mark(),
 			Input: graphSankeyHandlerInput{
-				graphCommonHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 					Dimensions: []query.Column{
@@ -49,6 +93,7 @@ func TestSankeyQuerySQL(t *testing.T) {
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
  rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+SELECT 1 AS axis, * FROM (
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
@@ -56,14 +101,14 @@ SELECT
 FROM source
 WHERE {{ .Timefilter }}
 GROUP BY dimensions
-ORDER BY xps DESC`,
+ORDER BY xps DESC)`,
 				},
 			},
 		}, {
 			Description: "two dimensions, no filters, l3 bps, limitType by max",
 			Pos:         helpers.Mark(),
 			Input: graphSankeyHandlerInput{
-				graphCommonHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 					Dimensions: []query.Column{
@@ -88,6 +133,7 @@ ORDER BY xps DESC`,
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
  rows AS (SELECT SrcAS, ExporterName FROM ( SELECT SrcAS, ExporterName, {{ .Units }} AS sum_at_time FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ) GROUP BY SrcAS, ExporterName ORDER BY MAX(sum_at_time) DESC LIMIT 5)
+SELECT 1 AS axis, * FROM (
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
@@ -95,14 +141,14 @@ SELECT
 FROM source
 WHERE {{ .Timefilter }}
 GROUP BY dimensions
-ORDER BY xps DESC`,
+ORDER BY xps DESC)`,
 				},
 			},
 		}, {
 			Description: "two dimensions, no filters, l2 bps",
 			Pos:         helpers.Mark(),
 			Input: graphSankeyHandlerInput{
-				graphCommonHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 					Dimensions: []query.Column{
@@ -126,6 +172,7 @@ ORDER BY xps DESC`,
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
  rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+SELECT 1 AS axis, * FROM (
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
@@ -133,14 +180,14 @@ SELECT
 FROM source
 WHERE {{ .Timefilter }}
 GROUP BY dimensions
-ORDER BY xps DESC`,
+ORDER BY xps DESC)`,
 				},
 			},
 		}, {
 			Description: "two dimensions, no filters, pps",
 			Pos:         helpers.Mark(),
 			Input: graphSankeyHandlerInput{
-				graphCommonHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 					Dimensions: []query.Column{
@@ -164,6 +211,7 @@ ORDER BY xps DESC`,
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
  rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+SELECT 1 AS axis, * FROM (
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
@@ -171,14 +219,14 @@ SELECT
 FROM source
 WHERE {{ .Timefilter }}
 GROUP BY dimensions
-ORDER BY xps DESC`,
+ORDER BY xps DESC)`,
 				},
 			},
 		}, {
 			Description: "two dimensions, with filter",
 			Pos:         helpers.Mark(),
 			Input: graphSankeyHandlerInput{
-				graphCommonHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 					Dimensions: []query.Column{
@@ -202,6 +250,7 @@ ORDER BY xps DESC`,
  source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
  (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR')) AS range,
  rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 10)
+SELECT 1 AS axis, * FROM (
 SELECT
  {{ .Units }}/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
@@ -209,7 +258,63 @@ SELECT
 FROM source
 WHERE {{ .Timefilter }} AND (DstCountry = 'FR')
 GROUP BY dimensions
-ORDER BY xps DESC`,
+ORDER BY xps DESC)`,
+				},
+			},
+		}, {
+			Description: "two dimensions, bidirectional",
+			Pos:         helpers.Mark(),
+			Input: graphSankeyHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
+					Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+					End:   time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+					Dimensions: []query.Column{
+						query.NewColumn("SrcAS"),
+						query.NewColumn("InIfProvider"),
+					},
+					Limit:  5,
+					Filter: query.NewFilter("DstCountry = 'FR'"),
+					Units:  "l3bps",
+				},
+				Bidirectional: true,
+			},
+			Expected: []templateQuery{
+				{
+					Context: inputContext{
+						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+						Points: 20,
+						Units:  "l3bps",
+					},
+					Template: `WITH
+ source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR')) AS range,
+ rows AS (SELECT SrcAS, InIfProvider FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR') GROUP BY SrcAS, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 5)
+SELECT 1 AS axis, * FROM (
+SELECT
+ {{ .Units }}/range AS xps,
+ [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
+  if(InIfProvider IN (SELECT InIfProvider FROM rows), InIfProvider, 'Other')] AS dimensions
+FROM source
+WHERE {{ .Timefilter }} AND (DstCountry = 'FR')
+GROUP BY dimensions
+ORDER BY xps DESC)`,
+				}, {
+					Context: inputContext{
+						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+						Points: 20,
+						Units:  "l3bps",
+					},
+					Template: `SELECT 2 AS axis, * FROM (
+SELECT
+ {{ .Units }}/range AS xps,
+ [if(DstAS IN (SELECT SrcAS FROM rows), concat(toString(DstAS), ': ', dictGetOrDefault('asns', 'name', DstAS, '???')), 'Other'),
+  if(OutIfProvider IN (SELECT InIfProvider FROM rows), OutIfProvider, 'Other')] AS dimensions
+FROM source
+WHERE {{ .Timefilter }} AND (SrcCountry = 'FR')
+GROUP BY dimensions
+ORDER BY xps DESC)`,
 				},
 			},
 		},
@@ -235,6 +340,7 @@ func TestSankeyHandler(t *testing.T) {
 	_, h, mockConn, _ := NewMock(t, DefaultConfiguration())
 
 	expectedSQL := []struct {
+		Axis       uint8    `ch:"axis"`
 		Xps        float64  `ch:"xps"`
 		Dimensions []string `ch:"dimensions"`
 	}{
@@ -242,27 +348,27 @@ func TestSankeyHandler(t *testing.T) {
 		//  for x in set([(random.choice(asn),
 		//                 random.choice(providers),
 		//                 random.choice(routers)) for x in range(30)])]
-		{9677, []string{"AS100", "Other", "router1"}},
-		{9472, []string{"AS300", "provider1", "Other"}},
-		{7593, []string{"AS300", "provider2", "router1"}},
-		{7234, []string{"AS200", "provider1", "Other"}},
-		{6006, []string{"AS100", "provider1", "Other"}},
-		{5988, []string{"Other", "provider1", "Other"}},
-		{4675, []string{"AS200", "provider3", "Other"}},
-		{4348, []string{"AS200", "Other", "router2"}},
-		{3999, []string{"AS100", "provider3", "Other"}},
-		{3978, []string{"AS100", "provider3", "router2"}},
-		{3623, []string{"Other", "Other", "router1"}},
-		{3080, []string{"AS300", "provider3", "router2"}},
-		{2915, []string{"AS300", "Other", "router1"}},
-		{2623, []string{"AS100", "provider1", "router1"}},
-		{2482, []string{"AS200", "provider2", "router2"}},
-		{2234, []string{"AS100", "provider2", "Other"}},
-		{1360, []string{"AS200", "Other", "router1"}},
-		{975, []string{"AS300", "Other", "Other"}},
-		{717, []string{"AS200", "provider3", "router2"}},
-		{621, []string{"Other", "Other", "Other"}},
-		{159, []string{"Other", "provider1", "router1"}},
+		{1, 9677, []string{"AS100", "Other", "router1"}},
+		{1, 9472, []string{"AS300", "provider1", "Other"}},
+		{1, 7593, []string{"AS300", "provider2", "router1"}},
+		{1, 7234, []string{"AS200", "provider1", "Other"}},
+		{1, 6006, []string{"AS100", "provider1", "Other"}},
+		{1, 5988, []string{"Other", "provider1", "Other"}},
+		{1, 4675, []string{"AS200", "provider3", "Other"}},
+		{1, 4348, []string{"AS200", "Other", "router2"}},
+		{1, 3999, []string{"AS100", "provider3", "Other"}},
+		{1, 3978, []string{"AS100", "provider3", "router2"}},
+		{1, 3623, []string{"Other", "Other", "router1"}},
+		{1, 3080, []string{"AS300", "provider3", "router2"}},
+		{1, 2915, []string{"AS300", "Other", "router1"}},
+		{1, 2623, []string{"AS100", "provider1", "router1"}},
+		{1, 2482, []string{"AS200", "provider2", "router2"}},
+		{1, 2234, []string{"AS100", "provider2", "Other"}},
+		{1, 1360, []string{"AS200", "Other", "router1"}},
+		{1, 975, []string{"AS300", "Other", "Other"}},
+		{1, 717, []string{"AS200", "provider3", "router2"}},
+		{1, 621, []string{"Other", "Other", "Other"}},
+		{1, 159, []string{"Other", "provider1", "router1"}},
 	}
 	mockConn.EXPECT().
 		Select(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -328,116 +434,216 @@ func TestSankeyHandler(t *testing.T) {
 					621,
 					159,
 				},
+				"axis": []int{
+					1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+					1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+				},
+				"axis-names": map[int]string{1: "Direct"},
 				// For graph
-				"nodes": []string{
-					"SrcAS: AS100",
-					"InIfProvider: Other",
-					"ExporterName: router1",
-					"SrcAS: AS300",
-					"InIfProvider: provider1",
-					"ExporterName: Other",
-					"InIfProvider: provider2",
-					"SrcAS: AS200",
-					"SrcAS: Other",
-					"InIfProvider: provider3",
-					"ExporterName: router2",
+				"nodes": []helpers.M{
+					{"name": "SrcAS: AS100", "axis": 1},
+					{"name": "InIfProvider: Other", "axis": 1},
+					{"name": "ExporterName: router1", "axis": 1},
+					{"name": "SrcAS: AS300", "axis": 1},
+					{"name": "InIfProvider: provider1", "axis": 1},
+					{"name": "ExporterName: Other", "axis": 1},
+					{"name": "InIfProvider: provider2", "axis": 1},
+					{"name": "SrcAS: AS200", "axis": 1},
+					{"name": "SrcAS: Other", "axis": 1},
+					{"name": "InIfProvider: provider3", "axis": 1},
+					{"name": "ExporterName: router2", "axis": 1},
 				},
 				"links": []helpers.M{
 					{
 						"source": "InIfProvider: provider1", "target": "ExporterName: Other",
-						"xps": 9472 + 7234 + 6006 + 5988,
+						"xps": 9472 + 7234 + 6006 + 5988, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: Other", "target": "ExporterName: router1",
-						"xps": 9677 + 3623 + 2915 + 1360,
+						"xps": 9677 + 3623 + 2915 + 1360, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS100", "target": "InIfProvider: Other",
-						"xps": 9677,
+						"xps": 9677, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS300", "target": "InIfProvider: provider1",
-						"xps": 9472,
+						"xps": 9472, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider3", "target": "ExporterName: Other",
-						"xps": 4675 + 3999,
+						"xps": 4675 + 3999, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS100", "target": "InIfProvider: provider1",
-						"xps": 6006 + 2623,
+						"xps": 6006 + 2623, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS100", "target": "InIfProvider: provider3",
-						"xps": 3999 + 3978,
+						"xps": 3999 + 3978, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider3", "target": "ExporterName: router2",
-						"xps": 3978 + 3080 + 717,
+						"xps": 3978 + 3080 + 717, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider2", "target": "ExporterName: router1",
-						"xps": 7593,
+						"xps": 7593, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS300", "target": "InIfProvider: provider2",
-						"xps": 7593,
+						"xps": 7593, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS200", "target": "InIfProvider: provider1",
-						"xps": 7234,
+						"xps": 7234, "axis": 1,
 					},
 					{
 						"source": "SrcAS: Other", "target": "InIfProvider: provider1",
-						"xps": 5988 + 159,
+						"xps": 5988 + 159, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS200", "target": "InIfProvider: Other",
-						"xps": 4348 + 1360,
+						"xps": 4348 + 1360, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS200", "target": "InIfProvider: provider3",
-						"xps": 4675 + 717,
+						"xps": 4675 + 717, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: Other", "target": "ExporterName: router2",
-						"xps": 4348,
+						"xps": 4348, "axis": 1,
 					},
 					{
 						"source": "SrcAS: Other", "target": "InIfProvider: Other",
-						"xps": 3623 + 621,
+						"xps": 3623 + 621, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS300", "target": "InIfProvider: Other",
-						"xps": 2915 + 975,
+						"xps": 2915 + 975, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS300", "target": "InIfProvider: provider3",
-						"xps": 3080,
+						"xps": 3080, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider1", "target": "ExporterName: router1",
-						"xps": 2623 + 159,
+						"xps": 2623 + 159, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider2", "target": "ExporterName: router2",
-						"xps": 2482,
+						"xps": 2482, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS200", "target": "InIfProvider: provider2",
-						"xps": 2482,
+						"xps": 2482, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: provider2", "target": "ExporterName: Other",
-						"xps": 2234,
+						"xps": 2234, "axis": 1,
 					},
 					{
 						"source": "SrcAS: AS100", "target": "InIfProvider: provider2",
-						"xps": 2234,
+						"xps": 2234, "axis": 1,
 					},
 					{
 						"source": "InIfProvider: Other", "target": "ExporterName: Other",
-						"xps": 975 + 621,
+						"xps": 975 + 621, "axis": 1,
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestSankeyHandlerBidirectional(t *testing.T) {
+	_, h, mockConn, _ := NewMock(t, DefaultConfiguration())
+
+	expectedSQL := []struct {
+		Axis       uint8    `ch:"axis"`
+		Xps        float64  `ch:"xps"`
+		Dimensions []string `ch:"dimensions"`
+	}{
+		// Forward direction (axis 1): SrcAS, InIfProvider
+		{1, 9000, []string{"AS100", "provider1"}},
+		{1, 7000, []string{"AS200", "provider1"}},
+		{1, 5000, []string{"AS100", "provider2"}},
+		{1, 3000, []string{"Other", "provider1"}},
+		// Reverse direction (axis 2): DstAS, OutIfProvider
+		{2, 8000, []string{"AS300", "provider1"}},
+		{2, 4000, []string{"AS300", "provider3"}},
+		{2, 2000, []string{"AS100", "Other"}},
+	}
+	mockConn.EXPECT().
+		Select(gomock.Any(), gomock.Any(), gomock.Any()).
+		SetArg(1, expectedSQL).
+		Return(nil)
+
+	helpers.TestHTTPEndpoints(t, h.LocalAddr(), helpers.HTTPEndpointCases{
+		{
+			URL: "/api/v0/console/graph/sankey",
+			JSONInput: helpers.M{
+				"start":         time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+				"end":           time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+				"dimensions":    []string{"SrcAS", "InIfProvider"},
+				"limit":         10,
+				"filter":        "DstCountry = 'FR'",
+				"units":         "l3bps",
+				"bidirectional": true,
+			},
+			JSONOutput: helpers.M{
+				"rows": [][]string{
+					{"AS100", "provider1"},
+					{"AS200", "provider1"},
+					{"AS100", "provider2"},
+					{"Other", "provider1"},
+					{"AS300", "provider1"},
+					{"AS300", "provider3"},
+					{"AS100", "Other"},
+				},
+				"xps":        []int{9000, 7000, 5000, 3000, 8000, 4000, 2000},
+				"axis":       []int{1, 1, 1, 1, 2, 2, 2},
+				"axis-names": map[int]string{1: "Direct", 2: "Reverse"},
+				"nodes": []helpers.M{
+					{"name": "SrcAS: AS100", "axis": 1},
+					{"name": "InIfProvider: provider1", "axis": 1},
+					{"name": "SrcAS: AS200", "axis": 1},
+					{"name": "InIfProvider: provider2", "axis": 1},
+					{"name": "SrcAS: Other", "axis": 1},
+					{"name": "DstAS: AS300", "axis": 2},
+					{"name": "OutIfProvider: provider1", "axis": 2},
+					{"name": "OutIfProvider: provider3", "axis": 2},
+					{"name": "DstAS: AS100", "axis": 2},
+					{"name": "OutIfProvider: Other", "axis": 2},
+				},
+				"links": []helpers.M{
+					{
+						"source": "SrcAS: AS100", "target": "InIfProvider: provider1",
+						"xps": 9000, "axis": 1,
+					},
+					{
+						"source": "SrcAS: AS200", "target": "InIfProvider: provider1",
+						"xps": 7000, "axis": 1,
+					},
+					{
+						"source": "SrcAS: AS100", "target": "InIfProvider: provider2",
+						"xps": 5000, "axis": 1,
+					},
+					{
+						"source": "SrcAS: Other", "target": "InIfProvider: provider1",
+						"xps": 3000, "axis": 1,
+					},
+					{
+						"source": "DstAS: AS300", "target": "OutIfProvider: provider1",
+						"xps": 8000, "axis": 2,
+					},
+					{
+						"source": "DstAS: AS300", "target": "OutIfProvider: provider3",
+						"xps": 4000, "axis": 2,
+					},
+					{
+						"source": "DstAS: AS100", "target": "OutIfProvider: Other",
+						"xps": 2000, "axis": 2,
 					},
 				},
 			},

--- a/console/tests.go
+++ b/console/tests.go
@@ -49,4 +49,5 @@ func NewMock(t *testing.T, config Configuration) (*Component, *httpserver.Compon
 func init() {
 	helpers.RegisterCmpOption(cmpopts.IgnoreUnexported(graphCommonHandlerInput{}))
 	helpers.RegisterCmpOption(cmp.AllowUnexported(graphLineHandlerInput{}))
+	helpers.RegisterCmpOption(cmp.AllowUnexported(graphSankeyHandlerInput{}))
 }


### PR DESCRIPTION
The two directions are presented side-by-side.

Fix #2422

<img width="3557" height="957" alt="image" src="https://github.com/user-attachments/assets/cfe4921c-9b11-4d44-ae61-576159401648" />
