### PR TITLE
More efficient RIB tree for BMP

### DIFF
--- a/common/helpers/intern/intern.go
+++ b/common/helpers/intern/intern.go
@@ -51,8 +51,8 @@ type Pool[T Value[T]] struct {
 // keeping to the raw value.
 type internValue[T Value[T]] struct {
 	next     Reference[T] // next value with the same hash
-	previous Reference[T] // previous value with the same hash
 	refCount uint32
+	hash     uint64 // cached hash, avoids recomputing in Take
 
 	value T
 }
@@ -78,21 +78,23 @@ func (p *Pool[T]) Take(ref Reference[T]) {
 	value.refCount--
 	if value.refCount == 0 {
 		p.availableIndexes = append(p.availableIndexes, ref)
-		if value.previous > 0 {
-			// Not the first one, link previous to next
-			p.values[value.previous].next = value.next
-			p.values[value.next].previous = value.previous
+		head := p.valueIndexes[value.hash]
+		if head == ref {
+			// We are the head of the chain
+			if value.next > 0 {
+				p.valueIndexes[value.hash] = value.next
+			} else {
+				delete(p.valueIndexes, value.hash)
+			}
 			return
 		}
-		hash := value.value.Hash()
-		if value.next > 0 {
-			// We are the first one of a chain, move the pointer to the next one
-			p.valueIndexes[hash] = value.next
-			p.values[value.next].previous = 0
-			return
+		// Walk the chain to find our predecessor. Only reached on hash
+		// collisions, which are rare with a full uint64 hash.
+		prev := head
+		for p.values[prev].next != ref {
+			prev = p.values[prev].next
 		}
-		// Last case, we are the last one, let's find our hash and delete us from here
-		delete(p.valueIndexes, hash)
+		p.values[prev].next = value.next
 	}
 }
 
@@ -112,11 +114,11 @@ func (p *Pool[T]) Ref(value T) (Reference[T], bool) {
 
 // Put adds a value to the intern pool, returning its reference.
 func (p *Pool[T]) Put(value T) Reference[T] {
+	hash := value.Hash()
 	v := internValue[T]{
 		value:    value,
 		refCount: 1,
-		previous: 0,
-		next:     0,
+		hash:     hash,
 	}
 
 	// Allocate a new index
@@ -139,7 +141,6 @@ func (p *Pool[T]) Put(value T) Reference[T] {
 	}
 
 	// Check if we have already something
-	hash := value.Hash()
 	if index := p.valueIndexes[hash]; index > 0 {
 		prevIndex := index
 		for index > 0 {
@@ -153,7 +154,6 @@ func (p *Pool[T]) Put(value T) Reference[T] {
 
 		// We have a collision, add to the chain
 		index = newIndex()
-		v.previous = prevIndex
 		p.values[prevIndex].next = index
 		p.values[index] = v
 		return index

--- a/common/helpers/intern/intern_test.go
+++ b/common/helpers/intern/intern_test.go
@@ -89,10 +89,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues := []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 1, next: 3},
-		{value: 22, refCount: 1, previous: 2, next: 4},
-		{value: 32, refCount: 1, previous: 3},
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 1, hash: 2, next: 3},
+		{value: 22, refCount: 1, hash: 2, next: 4},
+		{value: 32, refCount: 1, hash: 2},
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)
@@ -102,10 +102,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues = []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 1, next: 4},
-		{value: 22, refCount: 0, previous: 2, next: 4}, // free
-		{value: 32, refCount: 1, previous: 2},
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 1, hash: 2, next: 4},
+		{value: 22, refCount: 0, hash: 2, next: 4}, // free
+		{value: 32, refCount: 1, hash: 2},
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)
@@ -118,10 +118,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues = []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 1, next: 4},
-		{value: 42, refCount: 1, previous: 4},
-		{value: 32, refCount: 1, previous: 2, next: 3},
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 1, hash: 2, next: 4},
+		{value: 42, refCount: 1, hash: 2},
+		{value: 32, refCount: 1, hash: 2, next: 3},
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)
@@ -131,10 +131,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues = []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 0, next: 4}, // free
-		{value: 42, refCount: 1, previous: 4},
-		{value: 32, refCount: 1, next: 3},
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 0, hash: 2, next: 4}, // free
+		{value: 42, refCount: 1, hash: 2},
+		{value: 32, refCount: 1, hash: 2, next: 3},
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)
@@ -144,10 +144,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues = []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 0, next: 4}, // free
-		{value: 42, refCount: 1},
-		{value: 32, refCount: 0, next: 3}, // free
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 0, hash: 2, next: 4}, // free
+		{value: 42, refCount: 1, hash: 2},
+		{value: 32, refCount: 0, hash: 2, next: 3}, // free
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)
@@ -157,10 +157,10 @@ func TestTake(t *testing.T) {
 
 	expectedValues = []internValue[likeInt]{
 		{},
-		{value: 10, refCount: 2},
-		{value: 12, refCount: 0, next: 4}, // free
-		{value: 42, refCount: 0},          // free
-		{value: 32, refCount: 0, next: 3}, // free
+		{value: 10, refCount: 2, hash: 0},
+		{value: 12, refCount: 0, hash: 2, next: 4}, // free
+		{value: 42, refCount: 0, hash: 2},          // free
+		{value: 32, refCount: 0, hash: 2, next: 3}, // free
 	}
 	if diff := helpers.Diff(p.values, expectedValues, diffOpt); diff != "" {
 		t.Fatalf("p.values (-got, +want):\n%s", diff)

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -21,6 +21,7 @@ identified with a specific icon:
 - 🩹 *outlet*: when static metadata is missing, don't return an empty interface
 - 🩹 *orchestrator*: improve detection of changed configuration file
 - 🌱 *outlet*: cache the SNMPv3 engine ID to not trigger discovery probe on subsequent polls
+- 🌱 *outlet*: improve BMP RIB performance with lock-free readers (see this [blog post](https://vincent.bernat.ch/en/blog/2026-akvorado-rib-sharding))
 - 🌱 *docker*: update Kafka to 4.2.0 (not mandatory)
 - 🌱 *docker*: update ClickHouse to 26.3 (not mandatory)
 - 🌱 *build*: reduce the number of dependencies by switching from Gin to

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -261,11 +261,11 @@ func BenchmarkRIBInsertion(b *testing.B) {
 				runtime.ReadMemStats(&endMem)
 				b.ReportMetric(0, "ns/op")
 				b.ReportMetric(float64(b.Elapsed())/float64(inserted), "ns/route")
-				b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/float64(rib.tree.Size()), "bytes/route")
+				b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/float64(rib.tree.Load().Size()), "bytes/route")
 				b.ReportMetric(float64(inserted)/float64(tentative)*100, "%ins")
 
 				// Avoid elimination of the RIB
-				rib.tree.Lookup(netip.MustParseAddr("::ffff:192.168.1.1"))
+				rib.tree.Load().Lookup(netip.MustParseAddr("::ffff:192.168.1.1"))
 			})
 		}
 	}

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -40,6 +40,9 @@ type routeIndex uint32
 // routeKey is a typed key for route map entries
 type routeKey uint64
 
+// generation tags a prefix index so a stale reference can be detected
+type generation uint32
+
 // makePrefixIndex creates a global prefixIndex from shard index and local ID.
 func makePrefixIndex(shardIdx shardIndex, localIdx localPrefixIndex) prefixIndex {
 	return prefixIndex(uint32(shardIdx)<<(32-shardBits)) | (prefixIndex(localIdx) & localPrefixMask)
@@ -55,6 +58,13 @@ func (idx prefixIndex) localIdx() localPrefixIndex {
 	return localPrefixIndex(idx & localPrefixMask)
 }
 
+// prefixRef combines a prefix index and a generation. This is useful to check
+// if the prefix index was not recycled for something else.
+type prefixRef struct {
+	idx prefixIndex
+	gen generation
+}
+
 // ribShard holds the per-shard state for a RIB shard.
 type ribShard struct {
 	mu                 sync.RWMutex
@@ -65,13 +75,14 @@ type ribShard struct {
 	rtas               *intern.Pool[routeAttributes]
 	nextLocalPrefixID  localPrefixIndex   // counter for next local prefix index
 	freeLocalPrefixIDs []localPrefixIndex // free list for reused prefix indices
+	generations        []generation       // generation per local prefix index, bumped on free
 }
 
 // rib represents the RIB. The prefix tree uses an atomic pointer for lock-free
 // read. Writers should take take the mutex.
 type rib struct {
-	treeMu sync.Mutex                              // serializes tree writers
-	tree   atomic.Pointer[bart.Table[prefixIndex]] // global prefix indices, RCU-published
+	treeMu sync.Mutex                            // serializes tree writers
+	tree   atomic.Pointer[bart.Table[prefixRef]] // global prefix indices, RCU-published
 	shards []*ribShard
 }
 
@@ -205,19 +216,26 @@ func (r *rib) shardForPrefix(prefix netip.Prefix) int {
 	return int(h % uint32(len(r.shards)))
 }
 
-// newPrefixIndex allocates a new prefix index for this shard.
-func (rs *ribShard) newPrefixIndex() prefixIndex {
-	if len(rs.freeLocalPrefixIDs) > 0 {
-		localID := rs.freeLocalPrefixIDs[len(rs.freeLocalPrefixIDs)-1]
-		rs.freeLocalPrefixIDs = rs.freeLocalPrefixIDs[:len(rs.freeLocalPrefixIDs)-1]
-		return makePrefixIndex(rs.idx, localID)
+// newPrefixIndex allocates a prefix index for this shard, paired with its
+// current generation.
+func (rs *ribShard) newPrefixIndex() prefixRef {
+	var localID localPrefixIndex
+	if n := len(rs.freeLocalPrefixIDs); n > 0 {
+		localID = rs.freeLocalPrefixIDs[n-1]
+		rs.freeLocalPrefixIDs = rs.freeLocalPrefixIDs[:n-1]
+	} else {
+		localID = rs.nextLocalPrefixID
+		rs.nextLocalPrefixID++
+		rs.generations = append(rs.generations, 0)
 	}
-	localID := rs.nextLocalPrefixID
-	rs.nextLocalPrefixID++
-	return makePrefixIndex(rs.idx, localID)
+	return prefixRef{
+		idx: makePrefixIndex(rs.idx, localID),
+		gen: rs.generations[localID],
+	}
 }
 
-// freePrefixIndex returns a prefix ID to the shard's free list.
+// freePrefixIndex returns a prefix ID to the shard's free list and bumps its
+// generation.
 func (rs *ribShard) freePrefixIndex(idx prefixIndex) {
 	localIdx := idx.localIdx()
 	if helpers.Testing() {
@@ -225,6 +243,7 @@ func (rs *ribShard) freePrefixIndex(idx prefixIndex) {
 			panic("cannot free index 0")
 		}
 	}
+	rs.generations[localIdx]++
 	rs.freeLocalPrefixIDs = append(rs.freeLocalPrefixIDs, localIdx)
 }
 
@@ -312,21 +331,21 @@ func (r *rib) AddRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 		prefixLen:  rr.prefixLen,
 	}
 
-	// Resolve the prefix to its index, creating it in the tree if needed.
+	// Resolve the prefix to its reference, creating it in the tree if needed.
 	// Only a brand-new prefix mutates the tree; updating a route on an
 	// existing prefix leaves the tree untouched.
 	r.treeMu.Lock()
 	tree := r.tree.Load()
-	prefixIdx, exists := tree.Get(prefix)
+	ref, exists := tree.Get(prefix)
 	isNew := !exists
 	if isNew {
-		prefixIdx = rs.newPrefixIndex()
-		r.tree.Store(tree.InsertPersist(prefix, prefixIdx))
+		ref = rs.newPrefixIndex()
+		r.tree.Store(tree.InsertPersist(prefix, ref))
 	}
 	r.treeMu.Unlock()
 
 	// Check if route already exists (same peer and nlri)
-	key := makeRouteKey(prefixIdx, 0)
+	key := makeRouteKey(ref.idx, 0)
 	for {
 		existingRoute, exists := rs.routes[key]
 		if !exists {
@@ -366,13 +385,13 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 
 	r.treeMu.Lock()
 	tree := r.tree.Load()
-	if prefixIdx, exists := tree.Get(prefix); exists {
+	if ref, exists := tree.Get(prefix); exists {
 		var empty bool
-		removedCount, empty = rs.removeRoutes(prefixIdx, func(route route) bool {
+		removedCount, empty = rs.removeRoutes(ref.idx, func(route route) bool {
 			return route.peer == rr.peer && route.nlri == nlriRef
 		}, true)
 		if empty {
-			rs.freePrefixIndex(prefixIdx)
+			rs.freePrefixIndex(ref.idx)
 			r.tree.Store(tree.DeletePersist(prefix))
 			prefixRemoved = true
 		}
@@ -397,14 +416,14 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	tree := r.tree.Load()
 
 	// Iterate through all prefixes and remove peer routes.
-	for _, prefixIdx := range tree.All() {
-		rs := r.shards[prefixIdx.shardIdx()]
-		removed, empty := rs.removeRoutes(prefixIdx, func(route route) bool {
+	for _, ref := range tree.All() {
+		rs := r.shards[ref.idx.shardIdx()]
+		removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
 			return route.peer == peer
 		}, false)
 		routesRemoved += removed
 		if empty {
-			rs.freePrefixIndex(prefixIdx)
+			rs.freePrefixIndex(ref.idx)
 			prefixesRemoved++
 		}
 		anyEmpty = anyEmpty || empty
@@ -412,10 +431,10 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 
 	if anyEmpty {
 		// Rebuild the tree excluding empty prefixes and publish it.
-		newTree := &bart.Table[prefixIndex]{}
-		for prefix, prefixIdx := range tree.All() {
-			if _, hasRoutes := r.shards[prefixIdx.shardIdx()].routes[makeRouteKey(prefixIdx, 0)]; hasRoutes {
-				newTree.Insert(prefix, prefixIdx)
+		newTree := &bart.Table[prefixRef]{}
+		for prefix, ref := range tree.All() {
+			if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
+				newTree.Insert(prefix, ref)
 			}
 		}
 		r.tree.Store(newTree)
@@ -433,20 +452,26 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 // preferring routes with the given next hop. It returns route attributes,
 // next hop, prefix length, and whether a route was found.
 func (r *rib) LookupRoute(ip, preferredNH netip.Addr) (routeAttributes, nextHop, uint8, bool) {
-	prefixIdx, found := r.tree.Load().Lookup(ip.Unmap())
+	ref, found := r.tree.Load().Lookup(ip.Unmap())
 
 	if !found {
 		return routeAttributes{}, nextHop{}, 0, false
 	}
 
-	rs := r.shards[prefixIdx.shardIdx()]
+	rs := r.shards[ref.idx.shardIdx()]
 
 	rs.mu.RLock()
 	defer rs.mu.RUnlock()
 
+	// The tree snapshot may predate this index being freed and recycled for a
+	// different prefix; a generation mismatch means exactly that.
+	if rs.generations[ref.idx.localIdx()] != ref.gen {
+		return routeAttributes{}, nextHop{}, 0, false
+	}
+
 	var selectedRoute route
 	routeFound := false
-	for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {
+	for route := range rs.iterateRoutesForPrefixIndex(ref.idx) {
 		if !routeFound {
 			selectedRoute = route
 			routeFound = true
@@ -478,9 +503,10 @@ func newRIB(nShards int) *rib {
 			rtas:               intern.NewPool[routeAttributes](),
 			nextLocalPrefixID:  1, // Start from 1, 0 means to be removed
 			freeLocalPrefixIDs: make([]localPrefixIndex, 0),
+			generations:        make([]generation, 1), // index 0 unused, kept in step with nextLocalPrefixID
 		}
 	}
 	r := &rib{shards: shards}
-	r.tree.Store(&bart.Table[prefixIndex]{})
+	r.tree.Store(&bart.Table[prefixRef]{})
 	return r
 }

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"akvorado/common/helpers"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/gaissmai/bart"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
-	"golang.org/x/sys/cpu"
 )
 
 // shardBits is the number of high bits used to encode the shard number.
@@ -67,11 +67,11 @@ type ribShard struct {
 	freeLocalPrefixIDs []localPrefixIndex // free list for reused prefix indices
 }
 
-// rib represents the RIB.
+// rib represents the RIB. The prefix tree uses an atomic pointer for lock-free
+// read. Writers should take take the mutex.
 type rib struct {
-	mu     sync.RWMutex             // protects tree
-	_      cpu.CacheLinePad         // avoid false sharing between mutex and tree
-	tree   *bart.Table[prefixIndex] // stores global prefix indices
+	treeMu sync.Mutex                              // serializes tree writers
+	tree   atomic.Pointer[bart.Table[prefixIndex]] // global prefix indices, RCU-published
 	shards []*ribShard
 }
 
@@ -312,19 +312,18 @@ func (r *rib) AddRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 		prefixLen:  rr.prefixLen,
 	}
 
-	var prefixIdx prefixIndex
-	var isNew bool
-	r.mu.Lock()
-	r.tree.Modify(prefix, func(existing prefixIndex, found bool) (prefixIndex, bool) {
-		if found {
-			prefixIdx = existing
-		} else {
-			isNew = true
-			prefixIdx = rs.newPrefixIndex()
-		}
-		return prefixIdx, false
-	})
-	r.mu.Unlock()
+	// Resolve the prefix to its index, creating it in the tree if needed.
+	// Only a brand-new prefix mutates the tree; updating a route on an
+	// existing prefix leaves the tree untouched.
+	r.treeMu.Lock()
+	tree := r.tree.Load()
+	prefixIdx, exists := tree.Get(prefix)
+	isNew := !exists
+	if isNew {
+		prefixIdx = rs.newPrefixIndex()
+		r.tree.Store(tree.InsertPersist(prefix, prefixIdx))
+	}
+	r.treeMu.Unlock()
 
 	// Check if route already exists (same peer and nlri)
 	key := makeRouteKey(prefixIdx, 0)
@@ -365,23 +364,20 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 	removedCount := 0
 	prefixRemoved := false
 
-	r.mu.Lock()
-	r.tree.Modify(prefix, func(existing prefixIndex, found bool) (prefixIndex, bool) {
-		if found {
-			var empty bool
-			removedCount, empty = rs.removeRoutes(existing, func(route route) bool {
-				return route.peer == rr.peer && route.nlri == nlriRef
-			}, true)
-			if empty {
-				rs.freePrefixIndex(existing)
-				prefixRemoved = true
-				return 0, true
-			}
-			return existing, false
+	r.treeMu.Lock()
+	tree := r.tree.Load()
+	if prefixIdx, exists := tree.Get(prefix); exists {
+		var empty bool
+		removedCount, empty = rs.removeRoutes(prefixIdx, func(route route) bool {
+			return route.peer == rr.peer && route.nlri == nlriRef
+		}, true)
+		if empty {
+			rs.freePrefixIndex(prefixIdx)
+			r.tree.Store(tree.DeletePersist(prefix))
+			prefixRemoved = true
 		}
-		return 0, true
-	})
-	r.mu.Unlock()
+	}
+	r.treeMu.Unlock()
 
 	return removedCount, prefixRemoved
 }
@@ -393,14 +389,15 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	prefixesRemoved := 0
 	anyEmpty := false
 
-	// Lock all shards in order, then tree
+	// Lock all shards in order, then the tree writer lock.
 	for _, rs := range r.shards {
 		rs.mu.Lock()
 	}
-	r.mu.Lock()
+	r.treeMu.Lock()
+	tree := r.tree.Load()
 
 	// Iterate through all prefixes and remove peer routes.
-	for _, prefixIdx := range r.tree.All() {
+	for _, prefixIdx := range tree.All() {
 		rs := r.shards[prefixIdx.shardIdx()]
 		removed, empty := rs.removeRoutes(prefixIdx, func(route route) bool {
 			return route.peer == peer
@@ -414,17 +411,17 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	}
 
 	if anyEmpty {
-		// Rebuild the tree excluding empty prefixes.
+		// Rebuild the tree excluding empty prefixes and publish it.
 		newTree := &bart.Table[prefixIndex]{}
-		for prefix, prefixIdx := range r.tree.All() {
+		for prefix, prefixIdx := range tree.All() {
 			if _, hasRoutes := r.shards[prefixIdx.shardIdx()].routes[makeRouteKey(prefixIdx, 0)]; hasRoutes {
 				newTree.Insert(prefix, prefixIdx)
 			}
 		}
-		r.tree = newTree
+		r.tree.Store(newTree)
 	}
 
-	r.mu.Unlock()
+	r.treeMu.Unlock()
 	for i := len(r.shards) - 1; i >= 0; i-- {
 		r.shards[i].mu.Unlock()
 	}
@@ -436,9 +433,7 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 // preferring routes with the given next hop. It returns route attributes,
 // next hop, prefix length, and whether a route was found.
 func (r *rib) LookupRoute(ip, preferredNH netip.Addr) (routeAttributes, nextHop, uint8, bool) {
-	r.mu.RLock()
-	prefixIdx, found := r.tree.Lookup(ip.Unmap())
-	r.mu.RUnlock()
+	prefixIdx, found := r.tree.Load().Lookup(ip.Unmap())
 
 	if !found {
 		return routeAttributes{}, nextHop{}, 0, false
@@ -485,8 +480,7 @@ func newRIB(nShards int) *rib {
 			freeLocalPrefixIDs: make([]localPrefixIndex, 0),
 		}
 	}
-	return &rib{
-		tree:   &bart.Table[prefixIndex]{},
-		shards: shards,
-	}
+	r := &rib{shards: shards}
+	r.tree.Store(&bart.Table[prefixIndex]{})
+	return r
 }

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gaissmai/bart"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"golang.org/x/sys/cpu"
 )
 
 // shardBits is the number of high bits used to encode the shard number.
@@ -69,6 +70,7 @@ type ribShard struct {
 // rib represents the RIB.
 type rib struct {
 	mu     sync.RWMutex             // protects tree
+	_      cpu.CacheLinePad         // avoid false sharing between mutex and tree
 	tree   *bart.Table[prefixIndex] // stores global prefix indices
 	shards []*ribShard
 }

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -197,7 +197,7 @@ func TestRemoveRoutes(t *testing.T) {
 		r := newRIB(1)
 		rs := r.shards[0]
 		addRoute(r, 10)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, true)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
@@ -215,7 +215,7 @@ func TestRemoveRoutes(t *testing.T) {
 		rs := r.shards[0]
 		addRoute(r, 10)
 		addRoute(r, 11)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		r2 := rs.routes[makeRouteKey(idx, 1)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 10 }, true)
 		if empty {
@@ -236,7 +236,7 @@ func TestRemoveRoutes(t *testing.T) {
 		rs := r.shards[0]
 		addRoute(r, 10)
 		addRoute(r, 11)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		r1 := rs.routes[makeRouteKey(idx, 0)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
 		if empty {
@@ -257,7 +257,7 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 10)
 		addRoute(r, 11)
 		addRoute(r, 12)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		r1 := rs.routes[makeRouteKey(idx, 0)]
 		r3 := rs.routes[makeRouteKey(idx, 2)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
@@ -282,7 +282,7 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 12)
 		addRoute(r, 13)
 		addRoute(r, 14)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		r2 := rs.routes[makeRouteKey(idx, 1)]
 		r4 := rs.routes[makeRouteKey(idx, 3)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer%2 == 0 }, false)
@@ -308,7 +308,7 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 12)
 		addRoute(r, 13)
 		addRoute(r, 14)
-		idx, _ := r.tree.Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
 		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, false)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
@@ -450,7 +450,7 @@ func TestRIBHarness(t *testing.T) {
 				continue
 			}
 			// Find prefix in tree
-			prefixIdx, ok := r.tree.Lookup(lookup.addr)
+			prefixIdx, ok := r.tree.Load().Lookup(lookup.addr)
 			if !ok {
 				t.Errorf("cannot find %s for %d",
 					lookup.addr, lookup.peer)

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -197,7 +197,8 @@ func TestRemoveRoutes(t *testing.T) {
 		r := newRIB(1)
 		rs := r.shards[0]
 		addRoute(r, 10)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, true)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
@@ -215,7 +216,8 @@ func TestRemoveRoutes(t *testing.T) {
 		rs := r.shards[0]
 		addRoute(r, 10)
 		addRoute(r, 11)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		r2 := rs.routes[makeRouteKey(idx, 1)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 10 }, true)
 		if empty {
@@ -236,7 +238,8 @@ func TestRemoveRoutes(t *testing.T) {
 		rs := r.shards[0]
 		addRoute(r, 10)
 		addRoute(r, 11)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		r1 := rs.routes[makeRouteKey(idx, 0)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
 		if empty {
@@ -257,7 +260,8 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 10)
 		addRoute(r, 11)
 		addRoute(r, 12)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		r1 := rs.routes[makeRouteKey(idx, 0)]
 		r3 := rs.routes[makeRouteKey(idx, 2)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer == 11 }, true)
@@ -282,7 +286,8 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 12)
 		addRoute(r, 13)
 		addRoute(r, 14)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		r2 := rs.routes[makeRouteKey(idx, 1)]
 		r4 := rs.routes[makeRouteKey(idx, 3)]
 		count, empty := rs.removeRoutes(idx, func(r route) bool { return r.peer%2 == 0 }, false)
@@ -308,7 +313,8 @@ func TestRemoveRoutes(t *testing.T) {
 		addRoute(r, 12)
 		addRoute(r, 13)
 		addRoute(r, 14)
-		idx, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		ref, _ := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+		idx := ref.idx
 		count, empty := rs.removeRoutes(idx, func(route) bool { return true }, false)
 		if !empty {
 			t.Error("removeRoutes() should have removed all routes from node")
@@ -320,6 +326,59 @@ func TestRemoveRoutes(t *testing.T) {
 			t.Errorf("removeRoutes() (-got, +want):\n%s", diff)
 		}
 	})
+}
+
+func TestRIBStalePrefixIndex(t *testing.T) {
+	r := newRIB(1)
+	rs := r.shards[0]
+
+	routeFor := func(peer uint32) rawRoute {
+		return rawRoute{
+			peer:       peer,
+			nlri:       nlri{family: bgp.RF_IPv4_UC, path: 1},
+			nextHop:    nextHop(netip.MustParseAddr("::ffff:198.51.100.8")),
+			attributes: routeAttributes{asn: 65300},
+			prefixLen:  96 + 24,
+		}
+	}
+	pPrefix := netip.MustParsePrefix("::ffff:192.168.144.0/120")
+	qPrefix := netip.MustParsePrefix("::ffff:10.1.2.0/120")
+
+	// Add prefix P and snapshot its reference, as a reader's lookup would.
+	r.AddRoute(pPrefix, routeFor(10))
+	staleRef, ok := r.tree.Load().Lookup(netip.MustParseAddr("192.168.144.10"))
+	if !ok {
+		t.Fatal("Lookup() did not find the just-added prefix")
+	}
+
+	// Withdraw P, then add a different prefix Q.
+	r.RemoveRoute(pPrefix, routeFor(10))
+	r.AddRoute(qPrefix, routeFor(20))
+	newRef, ok := r.tree.Load().Lookup(netip.MustParseAddr("10.1.2.10"))
+	if !ok {
+		t.Fatal("Lookup() did not find the recycled prefix")
+	}
+	if diff := helpers.Diff(newRef.idx, staleRef.idx); diff != "" {
+		t.Fatalf("index was not recycled (-got, +want):\n%s", diff)
+	}
+
+	// The recycled index now holds Q's route.
+	recycled, ok := rs.routes[makeRouteKey(staleRef.idx, 0)]
+	if !ok {
+		t.Fatal("recycled index has no route")
+	}
+	if diff := helpers.Diff(recycled.peer, uint32(20)); diff != "" {
+		t.Fatalf("recycled route peer (-got, +want):\n%s", diff)
+	}
+
+	// The generation guard must reject the stale reference and accept the fresh one.
+	if rs.generations[staleRef.idx.localIdx()] == staleRef.gen {
+		t.Errorf("stale prefixRef not rejected by generation guard %d",
+			staleRef.gen)
+	}
+	if diff := helpers.Diff(rs.generations[newRef.idx.localIdx()], newRef.gen); diff != "" {
+		t.Errorf("fresh prefixRef rejected by generation guard (-got, +want):\n%s", diff)
+	}
 }
 
 func TestRIBHarness(t *testing.T) {
@@ -450,12 +509,13 @@ func TestRIBHarness(t *testing.T) {
 				continue
 			}
 			// Find prefix in tree
-			prefixIdx, ok := r.tree.Load().Lookup(lookup.addr)
+			ref, ok := r.tree.Load().Lookup(lookup.addr)
 			if !ok {
 				t.Errorf("cannot find %s for %d",
 					lookup.addr, lookup.peer)
 				continue
 			}
+			prefixIdx := ref.idx
 
 			// Check if routes exist for this prefix
 			found := false

--- a/outlet/routing/provider/bmp/root_test.go
+++ b/outlet/routing/provider/bmp/root_test.go
@@ -44,7 +44,8 @@ func TestBMP(t *testing.T) {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
 		result := map[netip.Addr][]string{}
-		for prefix, prefixIdx := range c.rib.tree.Load().All() {
+		for prefix, ref := range c.rib.tree.Load().All() {
+			prefixIdx := ref.idx
 			rs := c.rib.shards[prefixIdx.shardIdx()]
 			rs.mu.RLock()
 			for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {

--- a/outlet/routing/provider/bmp/root_test.go
+++ b/outlet/routing/provider/bmp/root_test.go
@@ -44,9 +44,7 @@ func TestBMP(t *testing.T) {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
 		result := map[netip.Addr][]string{}
-		c.rib.mu.RLock()
-		defer c.rib.mu.RUnlock()
-		for prefix, prefixIdx := range c.rib.tree.All() {
+		for prefix, prefixIdx := range c.rib.tree.Load().All() {
 			rs := c.rib.shards[prefixIdx.shardIdx()]
 			rs.mu.RLock()
 			for route := range rs.iterateRoutesForPrefixIndex(prefixIdx) {

--- a/outlet/routing/provider/bmp/testdata/sharding-before.txt
+++ b/outlet/routing/provider/bmp/testdata/sharding-before.txt
@@ -1,0 +1,126 @@
+goos: linux
+goarch: amd64
+pkg: akvorado/outlet/routing/provider/bmp
+cpu: AMD Ryzen 5 5600X 6-Core Processor             
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1680	        69.97 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1666	        70.67 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1636	        71.04 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1532	        70.66 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1668	        70.60 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_1_readers-12         	    1657	        71.01 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     570	       207.1 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     564	       205.9 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     553	       207.0 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     567	       206.8 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     571	       207.2 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_4_readers-12         	     570	       207.0 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       468.4 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       468.9 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       466.5 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       465.0 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       465.6 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_16_readers-12        	     153	       468.9 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      75	       505.1 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      75	       507.8 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      75	       506.2 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      74	       506.6 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      74	       507.0 ns/read
+BenchmarkRIBConcurrent/500000_routes,_0_writers,_32_readers-12        	      74	       502.0 ns/read
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1396 ns/read	      1398 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1421 ns/read	      1427 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1278 ns/read	      1406 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1385 ns/read	      1389 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1373 ns/read	      1375 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_1_readers-12         	       1	      1299 ns/read	      1385 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1745 ns/read	      1914 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1756 ns/read	      1880 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1674 ns/read	      1878 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1789 ns/read	      1896 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1748 ns/read	      1854 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_4_readers-12         	       1	      1728 ns/read	      1892 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3751 ns/read	      4832 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3718 ns/read	      4923 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3805 ns/read	      4942 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3708 ns/read	      4926 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3680 ns/read	      4969 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_16_readers-12        	       1	      3783 ns/read	      4832 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5969 ns/read	      9028 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5619 ns/read	      8975 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5676 ns/read	      8910 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5979 ns/read	      8876 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5832 ns/read	      8983 ns/write
+BenchmarkRIBConcurrent/500000_routes,_1_writers,_32_readers-12        	       1	      5847 ns/read	      9038 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1702 ns/read	      3471 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1741 ns/read	      3563 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1750 ns/read	      3562 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1774 ns/read	      3622 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1745 ns/read	      3566 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_1_readers-12         	       1	      1733 ns/read	      3534 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2038 ns/read	      4297 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2018 ns/read	      4327 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2000 ns/read	      4353 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2022 ns/read	      4227 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2055 ns/read	      4255 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_4_readers-12         	       1	      2101 ns/read	      4627 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      4031 ns/read	     11200 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      3898 ns/read	     11161 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      4129 ns/read	     11217 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      4019 ns/read	     11119 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      3955 ns/read	     11151 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_16_readers-12        	       1	      3975 ns/read	     11236 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      6103 ns/read	     19275 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      5740 ns/read	     20056 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      6023 ns/read	     19441 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      5801 ns/read	     19801 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      5405 ns/read	     20099 ns/write
+BenchmarkRIBConcurrent/500000_routes,_2_writers,_32_readers-12        	       1	      6136 ns/read	     19334 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1752 ns/read	      7169 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1738 ns/read	      7057 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1779 ns/read	      7184 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1744 ns/read	      7157 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1825 ns/read	      7348 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_1_readers-12         	       1	      1807 ns/read	      7353 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2093 ns/read	      8478 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2094 ns/read	      8598 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2072 ns/read	      8448 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2304 ns/read	      9325 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2014 ns/read	      8446 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_4_readers-12         	       1	      2040 ns/read	      8462 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      3984 ns/read	     22034 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      3975 ns/read	     21168 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      3913 ns/read	     21320 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      3884 ns/read	     20851 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      3948 ns/read	     21590 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_16_readers-12        	       1	      4090 ns/read	     21509 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      5845 ns/read	     37804 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      5963 ns/read	     37425 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      5812 ns/read	     37360 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      6049 ns/read	     37339 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      5427 ns/read	     40357 ns/write
+BenchmarkRIBConcurrent/500000_routes,_4_writers,_32_readers-12        	       1	      5373 ns/read	     38522 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      1897 ns/read	     15135 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      1925 ns/read	     15275 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      1877 ns/read	     15095 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      1913 ns/read	     15246 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      2005 ns/read	     16075 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_1_readers-12         	       1	      1780 ns/read	     14487 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      2002 ns/read	     15776 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      2040 ns/read	     15779 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      2052 ns/read	     16294 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      2031 ns/read	     14977 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      1995 ns/read	     16600 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_4_readers-12         	       1	      2497 ns/read	     20648 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      3659 ns/read	     44455 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      4006 ns/read	     42374 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      3935 ns/read	     43165 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      4070 ns/read	     43676 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      3913 ns/read	     43799 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_16_readers-12        	       1	      3900 ns/read	     45840 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5682 ns/read	     74291 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5399 ns/read	     76571 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5784 ns/read	     75514 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5873 ns/read	     74785 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5910 ns/read	     72764 ns/write
+BenchmarkRIBConcurrent/500000_routes,_8_writers,_32_readers-12        	       1	      5688 ns/read	     75947 ns/write
+PASS
+ok  	akvorado/outlet/routing/provider/bmp	314.840s

--- a/outlet/routing/provider/bmp/testdata/sharding-step1.txt
+++ b/outlet/routing/provider/bmp/testdata/sharding-step1.txt
@@ -1,0 +1,246 @@
+goos: linux
+goarch: amd64
+pkg: akvorado/outlet/routing/provider/bmp
+cpu: AMD Ryzen 5 5600X 6-Core Processor             
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1562	        74.63 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1552	        79.78 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1560	        75.48 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1568	        74.80 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1576	        75.90 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1528	        75.83 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     644	       180.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     648	       181.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     640	       181.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     646	       181.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     648	       181.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     642	       181.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     189	       369.6 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     189	       373.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     189	       372.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     190	       370.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     190	       371.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     190	       369.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      94	       395.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      92	       398.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      92	       392.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      94	       396.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      93	       393.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	      94	       383.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       698.8 ns/read	      1624 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       767.9 ns/read	      1784 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       870.0 ns/read	      2022 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       778.9 ns/read	      1825 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       694.0 ns/read	      1613 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	       737.5 ns/read	      1704 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1049 ns/read	      2600 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1051 ns/read	      2535 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1088 ns/read	      2627 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1091 ns/read	      2608 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1098 ns/read	      2600 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1017 ns/read	      2474 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2278 ns/read	      6566 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2213 ns/read	      6550 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2444 ns/read	      6964 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2401 ns/read	      6903 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2438 ns/read	      6924 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2242 ns/read	      6592 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3340 ns/read	     11474 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3304 ns/read	     11241 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3233 ns/read	     11433 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3466 ns/read	     11181 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3293 ns/read	     11345 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3391 ns/read	     11415 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       774.1 ns/read	      3715 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       810.3 ns/read	      3871 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       773.8 ns/read	      3692 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       776.9 ns/read	      3705 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       855.0 ns/read	      4064 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	       821.7 ns/read	      3936 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1139 ns/read	      5435 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1139 ns/read	      5488 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1144 ns/read	      5540 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1141 ns/read	      5517 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1149 ns/read	      5504 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1118 ns/read	      5388 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2666 ns/read	     15325 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2640 ns/read	     15250 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2609 ns/read	     15244 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2583 ns/read	     15142 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2631 ns/read	     15387 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2541 ns/read	     15444 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3997 ns/read	     25809 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3699 ns/read	     26733 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3676 ns/read	     26435 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3967 ns/read	     26063 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3975 ns/read	     25908 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4076 ns/read	     25820 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       770.6 ns/read	      7534 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       829.9 ns/read	      8159 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       808.7 ns/read	      7945 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       771.8 ns/read	      7565 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       764.3 ns/read	      7514 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	       831.0 ns/read	      8151 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1109 ns/read	     11085 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1100 ns/read	     11492 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1102 ns/read	     10977 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1095 ns/read	     10940 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1105 ns/read	     10955 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1147 ns/read	     11438 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2421 ns/read	     28659 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2452 ns/read	     28874 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2490 ns/read	     29881 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2489 ns/read	     29411 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2576 ns/read	     29841 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2515 ns/read	     29867 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3516 ns/read	     47466 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3268 ns/read	     48322 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3650 ns/read	     47066 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3663 ns/read	     47252 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3558 ns/read	     47655 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3768 ns/read	     51948 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       764.6 ns/read	     14644 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       800.3 ns/read	     15242 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       816.6 ns/read	     15562 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       795.5 ns/read	     14976 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       792.1 ns/read	     15087 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	       798.4 ns/read	     15215 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1123 ns/read	     21037 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1123 ns/read	     20570 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1123 ns/read	     21757 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1113 ns/read	     20925 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1096 ns/read	     20415 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1119 ns/read	     21489 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2560 ns/read	     58872 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2518 ns/read	     60557 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2575 ns/read	     58746 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2490 ns/read	     59792 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2418 ns/read	     56348 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2386 ns/read	     56861 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3566 ns/read	     92199 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3653 ns/read	     91108 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3477 ns/read	     92344 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3514 ns/read	     93645 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3551 ns/read	     92082 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3670 ns/read	     91442 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1468	        80.19 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1506	        78.23 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1482	        78.79 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1480	        78.85 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1502	        78.03 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1462	        80.08 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     858	       134.3 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     888	       128.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     834	       135.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     830	       129.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     819	       134.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     870	       133.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     214	       323.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     213	       322.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     213	       329.1 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     214	       329.1 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     214	       329.1 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     214	       324.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       349.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       335.1 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       342.3 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       350.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       356.9 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     100	       350.9 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       663.9 ns/read	      1270 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       660.1 ns/read	      1272 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       643.0 ns/read	      1253 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       2	       661.9 ns/read	      1272 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       664.0 ns/read	      1255 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       659.5 ns/read	      1272 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1338 ns/read	      2064 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1413 ns/read	      2064 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1444 ns/read	      2204 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1465 ns/read	      2210 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1422 ns/read	      2301 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	      1425 ns/read	      2104 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2542 ns/read	      5664 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2576 ns/read	      5770 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2651 ns/read	      5719 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2580 ns/read	      5747 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2628 ns/read	      5745 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	      2555 ns/read	      5764 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3682 ns/read	      9416 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3728 ns/read	      9331 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3762 ns/read	      9292 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3652 ns/read	      9398 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3615 ns/read	      9450 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	      3700 ns/read	      9450 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       816.8 ns/read	      2712 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       951.1 ns/read	      3064 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       855.1 ns/read	      2839 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       837.9 ns/read	      2775 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       885.2 ns/read	      2926 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       900.5 ns/read	      2916 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1147 ns/read	      4565 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1149 ns/read	      4630 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1147 ns/read	      4531 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1159 ns/read	      4602 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1191 ns/read	      4647 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	      1168 ns/read	      4611 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2656 ns/read	     11281 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2614 ns/read	     11172 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2607 ns/read	     11022 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2624 ns/read	     11147 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2606 ns/read	     11032 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      2653 ns/read	     11165 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      4021 ns/read	     17296 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      4056 ns/read	     17439 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      3983 ns/read	     17369 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      4060 ns/read	     17528 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      3984 ns/read	     17570 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      4075 ns/read	     17417 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1120 ns/read	      5127 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1137 ns/read	      5151 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1145 ns/read	      5212 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1121 ns/read	      5144 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1154 ns/read	      5177 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1180 ns/read	      5287 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1441 ns/read	      7805 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1431 ns/read	      7721 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1441 ns/read	      7706 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1413 ns/read	      7720 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1455 ns/read	      7742 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1421 ns/read	      7737 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      2931 ns/read	     16976 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      2927 ns/read	     16962 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      3028 ns/read	     17721 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      2985 ns/read	     17463 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      3063 ns/read	     17828 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      3018 ns/read	     17654 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4639 ns/read	     29115 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4620 ns/read	     29556 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4669 ns/read	     29046 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4692 ns/read	     29395 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4570 ns/read	     28925 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      4642 ns/read	     29237 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       2	      2593 ns/read	      9840 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      3164 ns/read	     11031 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2919 ns/read	     10493 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2590 ns/read	      9827 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2694 ns/read	      9934 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       2	      2710 ns/read	     10024 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2326 ns/read	     13391 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2307 ns/read	     13014 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2451 ns/read	     13475 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2437 ns/read	     13205 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2417 ns/read	     13090 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2434 ns/read	     13047 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3949 ns/read	     25871 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3848 ns/read	     25182 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3834 ns/read	     25042 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3817 ns/read	     24949 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3827 ns/read	     25218 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      3754 ns/read	     24777 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5728 ns/read	     42960 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5755 ns/read	     43074 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5910 ns/read	     44238 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5631 ns/read	     42822 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5717 ns/read	     43163 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      5732 ns/read	     43039 ns/write
+PASS
+ok  	akvorado/outlet/routing/provider/bmp	656.142s

--- a/outlet/routing/provider/bmp/testdata/sharding-step2.txt
+++ b/outlet/routing/provider/bmp/testdata/sharding-step2.txt
@@ -1,0 +1,246 @@
+goos: linux
+goarch: amd64
+pkg: akvorado/outlet/routing/provider/bmp
+cpu: AMD Ryzen 5 5600X 6-Core Processor             
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1593	        73.34 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1586	        73.36 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1587	        73.83 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1560	        74.37 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1496	        75.69 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1473	        77.48 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     901	       123.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     882	       124.4 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     906	       125.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     867	       129.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     871	       127.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     885	       126.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     268	       252.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     268	       253.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     270	       254.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     266	       255.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     267	       254.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     271	       253.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     141	       273.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       274.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       273.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     139	       270.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     139	       270.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     138	       267.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1377 ns/read	      3197 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1400 ns/read	      3254 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1586 ns/read	      3686 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1564 ns/read	      3631 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1469 ns/read	      3456 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1371 ns/read	      3187 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1602 ns/read	      4050 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1643 ns/read	      4074 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1679 ns/read	      4081 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1572 ns/read	      4140 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1726 ns/read	      4234 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      2078 ns/read	      5090 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3146 ns/read	      8919 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3106 ns/read	      8994 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3321 ns/read	      8937 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3103 ns/read	     10089 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3087 ns/read	      9081 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3195 ns/read	      9145 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4149 ns/read	     14699 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4011 ns/read	     15055 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4159 ns/read	     14769 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3883 ns/read	     15286 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      3972 ns/read	     14871 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4467 ns/read	     14525 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1526 ns/read	      7270 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1676 ns/read	      8065 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1646 ns/read	      7871 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1572 ns/read	      7473 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1685 ns/read	      8139 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1663 ns/read	      7898 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1888 ns/read	      9533 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1999 ns/read	      9677 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1783 ns/read	      8894 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1805 ns/read	      8825 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      2094 ns/read	     10138 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1885 ns/read	      9118 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3311 ns/read	     19011 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3180 ns/read	     18367 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3148 ns/read	     18660 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3182 ns/read	     18380 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3023 ns/read	     18538 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3211 ns/read	     18297 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4762 ns/read	     29886 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4489 ns/read	     30769 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4403 ns/read	     30973 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4024 ns/read	     31249 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4522 ns/read	     30513 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4385 ns/read	     30549 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1552 ns/read	     14937 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1647 ns/read	     15950 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1586 ns/read	     15401 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1577 ns/read	     15176 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1584 ns/read	     15044 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1530 ns/read	     14463 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1803 ns/read	     17953 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1716 ns/read	     17511 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1832 ns/read	     18190 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1799 ns/read	     18546 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1770 ns/read	     17346 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1763 ns/read	     18752 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3159 ns/read	     36699 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3249 ns/read	     36625 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3166 ns/read	     36197 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2846 ns/read	     38504 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3114 ns/read	     37010 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3096 ns/read	     38746 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4188 ns/read	     59911 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4686 ns/read	     59331 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4135 ns/read	     62415 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4652 ns/read	     60476 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4514 ns/read	     60314 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3906 ns/read	     63261 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1586 ns/read	     29517 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1666 ns/read	     30508 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1498 ns/read	     28088 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1497 ns/read	     28021 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1480 ns/read	     27932 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1506 ns/read	     27718 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1772 ns/read	     33434 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1785 ns/read	     34320 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1754 ns/read	     33398 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1784 ns/read	     32608 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1818 ns/read	     33406 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1850 ns/read	     34527 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3138 ns/read	     71666 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3041 ns/read	     70627 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3267 ns/read	     70825 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3186 ns/read	     73423 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3053 ns/read	     73099 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3271 ns/read	     71033 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4205 ns/read	    122945 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4534 ns/read	    123672 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4558 ns/read	    120280 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4568 ns/read	    119724 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4297 ns/read	    121281 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4144 ns/read	    122023 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1298	        91.94 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1260	        94.16 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1258	        93.26 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1074	        97.59 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1248	        93.82 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1166	        97.69 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     998	       102.5 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1047	       104.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1040	       103.9 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1154	        97.50 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	     987	       104.8 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1098	       102.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     476	       129.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     475	       130.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     481	       131.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     482	       125.8 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     482	       127.3 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     469	       131.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     278	       135.5 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     291	       130.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     283	       134.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     268	       135.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     218	       135.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     291	       131.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       973.9 ns/read	      3008 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       907.7 ns/read	      2849 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       883.7 ns/read	      2868 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       855.0 ns/read	      2733 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       917.3 ns/read	      2849 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       852.9 ns/read	      2668 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       713.9 ns/read	      3913 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       675.7 ns/read	      3669 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       675.6 ns/read	      3652 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       669.8 ns/read	      3621 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       660.0 ns/read	      3613 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       686.0 ns/read	      3714 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       809.3 ns/read	      5569 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       826.2 ns/read	      5940 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       810.9 ns/read	      5660 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       847.5 ns/read	      5910 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       845.2 ns/read	      5706 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       817.8 ns/read	      5536 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       884.9 ns/read	      7272 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       868.5 ns/read	      7057 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       842.7 ns/read	      7129 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       864.5 ns/read	      7154 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       876.7 ns/read	      7159 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       861.1 ns/read	      7131 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       833.7 ns/read	      4981 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       834.9 ns/read	      4923 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       841.4 ns/read	      4981 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       843.9 ns/read	      5006 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       840.7 ns/read	      4978 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       838.4 ns/read	      4935 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       844.9 ns/read	      6182 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       841.3 ns/read	      6216 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       834.6 ns/read	      6162 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       852.7 ns/read	      6256 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       839.1 ns/read	      6164 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       862.7 ns/read	      6343 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       979.2 ns/read	      8825 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       835.5 ns/read	      9140 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       978.3 ns/read	      8784 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	      1001 ns/read	      8973 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       953.0 ns/read	      8931 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       956.6 ns/read	      8722 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1061 ns/read	     10915 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1061 ns/read	     10744 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1099 ns/read	     11263 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1097 ns/read	     11072 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1100 ns/read	     11376 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1058 ns/read	     10955 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1310 ns/read	      9512 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1314 ns/read	      9526 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1307 ns/read	      9510 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1342 ns/read	      9692 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1351 ns/read	      9712 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1460 ns/read	     10358 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1315 ns/read	     10820 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1358 ns/read	     11111 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1340 ns/read	     10868 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1350 ns/read	     11077 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1356 ns/read	     11113 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1327 ns/read	     10851 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1560 ns/read	     14604 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1517 ns/read	     14174 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1530 ns/read	     14204 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1521 ns/read	     14128 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1494 ns/read	     13755 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1535 ns/read	     14411 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1758 ns/read	     17216 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1218 ns/read	     16300 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1597 ns/read	     16161 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1625 ns/read	     15970 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1636 ns/read	     15979 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1681 ns/read	     16343 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2688 ns/read	     18424 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2642 ns/read	     18199 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2605 ns/read	     18493 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2620 ns/read	     18267 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2537 ns/read	     17846 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2685 ns/read	     18840 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2592 ns/read	     20671 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2449 ns/read	     19683 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2495 ns/read	     19767 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2504 ns/read	     19796 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2546 ns/read	     19959 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2550 ns/read	     19830 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2793 ns/read	     24107 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2742 ns/read	     23880 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2475 ns/read	     24187 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2694 ns/read	     24448 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2764 ns/read	     24238 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2808 ns/read	     24595 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      3014 ns/read	     27240 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2804 ns/read	     27473 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2995 ns/read	     27285 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2807 ns/read	     27466 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2961 ns/read	     26848 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2976 ns/read	     27291 ns/write
+PASS
+ok  	akvorado/outlet/routing/provider/bmp	1186.449s

--- a/outlet/routing/provider/bmp/testdata/sharding-visualisation.py
+++ b/outlet/routing/provider/bmp/testdata/sharding-visualisation.py
@@ -2,18 +2,24 @@
 
 """Plot the results of BenchmarkRIBConcurrent.
 
-This script reads the output of `go test -bench RIBConcurrent` on stdin and
-writes three SVG graphs next to itself:
+Two subcommands are available:
 
-  - read_latency.svg   read latency vs writers, one panel per reader count
-  - write_latency.svg  write latency vs writers, one panel per reader count
-  - heatmap_ratio.svg  speedup heatmap of 1 shard vs N shards
+ - single: read one benchmark output on stdin and produce three SVGs (read
+   latency, write latency, heatmap ratio).
+ - compare: take 2+ benchmarks as PATH=LABEL pairs and produce a single SVG
+   with pairwise speedup heatmaps.
 
 Run the benchmark with -count > 1 so medians are meaningful, e.g.:
 
   make test-bench PKG=akvorado/outlet/routing/provider/bmp \\
       GOTEST_ARGS="-bench RIBConcurrent/.*,_500000_routes -count=6" GOAMD64=v3 > bench.txt
-  ./sharding-visualisation.py < bench.txt
+
+Then either:
+
+  ./sharding-visualisation.py single < bench.txt
+  ./sharding-visualisation.py compare \\
+      before.txt='before sharding' step1.txt='step 1' step2.txt='step 2'
+
 """
 
 import argparse
@@ -34,6 +40,8 @@ LINESTYLES = ["-", "--"]
 # A latency measurement: the median across runs, with the min/max bounds.
 Stat = namedtuple("Stat", ("median", "lo", "hi"))
 
+METRICS = [("read", "Read latency"), ("write", "Write latency")]
+
 
 def summarize(values):
     """Reduce repeated benchmark samples to a Stat (median with min/max bounds)."""
@@ -43,13 +51,14 @@ def summarize(values):
 def parse(text):
     """Parse benchmark output into Stat records keyed by (routes, shards, writers, readers)."""
     pattern = re.compile(
-        r"BenchmarkRIBConcurrent/(\d+)_shards,_(\d+)_routes,_(\d+)_writers,_(\d+)_readers-\d+\s+"
+        r"BenchmarkRIBConcurrent/(?:(\d+)_shards,_)?(\d+)_routes,_(\d+)_writers,_(\d+)_readers-\d+\s+"
         r"\d+\s+([\d.]+)\s+ns/read(?:\s+([\d.]+)\s+ns/write)?"
     )
 
     samples = defaultdict(list)
     for m in pattern.finditer(text):
-        shards, routes, writers, readers = int(m[1]), int(m[2]), int(m[3]), int(m[4])
+        shards = int(m[1]) if m[1] else 1
+        routes, writers, readers = int(m[2]), int(m[3]), int(m[4])
         read_ns = float(m[5])
         write_ns = float(m[6]) if m[6] else None
         samples[(routes, shards, writers, readers)].append((read_ns, write_ns))
@@ -81,6 +90,16 @@ def axes_of(values):
     writers = sorted({w for _, w, _ in values})
     readers = sorted({r for _, _, r in values})
     return shards, writers, readers
+
+
+def select_routes(stats, requested, parser):
+    """Pick a route count that exists in stats, honouring --routes when ambiguous."""
+    available = sorted({routes for routes, *_ in stats})
+    if len(available) == 1:
+        return available[0]
+    if requested in available:
+        return requested
+    parser.error(f"benchmark covers routes {available}; select one with --routes")
 
 
 def save(fig, platform, path):
@@ -227,8 +246,10 @@ def heatmap_figure(stats, platform, routes, path):
                         color="black",
                     )
 
-    # Set ticks for the legend.
+    # Set ticks for the legend. LogNorm auto-adds sub-decade minor ticks
+    # (2, 3, … × 10^k) that show up as "6×10⁻¹" etc.; turn them off.
     cb = fig.colorbar(im, ax=list(axes))
+    cb.ax.minorticks_off()
     n = int(np.ceil(np.log2(extreme)))
     ticks = [2.0**i for i in range(-n, n + 1) if 1.0 / extreme <= 2.0**i <= extreme]
     cb.set_ticks(ticks, labels=[f"{t:g}×" for t in ticks])
@@ -236,31 +257,152 @@ def heatmap_figure(stats, platform, routes, path):
     save(fig, platform, path)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    parser.add_argument(
-        "--routes",
-        type=int,
-        default=500000,
-        help="route count to plot when the benchmark has several (default: 500000)",
-    )
-    args = parser.parse_args()
+def comparison_figure(benchmarks, platform, routes, path):
+    """Draw a 2 × C heatmap grid comparing the supplied benchmarks pairwise.
 
+    benchmarks is a list of (label, stats, shards) tuples. The grid has one row
+    per metric (read, write) and one column per ordered pair (i < j) of
+    benchmarks. A cell is the speedup of benchmark j over benchmark i (i.median
+    / j.median, so > 1× means j is faster).
+
+    """
+    # Pool the writer / reader axes from every benchmark.
+    all_keys = set()
+    for _, stats, _, _ in benchmarks:
+        all_keys.update(stats.keys())
+    writers = sorted({w for _, w, _ in all_keys})
+    readers = sorted({r for _, _, r in all_keys})
+    read_writers = writers
+    write_writers = [w for w in writers if w > 0]
+
+    # Pairwise (upper-triangle) comparisons.
+    pairs = [
+        (i, j) for i in range(len(benchmarks)) for j in range(i + 1, len(benchmarks))
+    ]
+    if not pairs:
+        raise ValueError("comparison needs at least two benchmarks")
+
+    def cell(metric, bi, vi, nw, nr):
+        _, b_stats, b_shards, _ = benchmarks[bi]
+        _, v_stats, v_shards, _ = benchmarks[vi]
+        a = b_stats.get((b_shards, nw, nr))
+        a = a.get(metric) if a else None
+        b = v_stats.get((v_shards, nw, nr))
+        b = b.get(metric) if b else None
+        if a is None or b is None:
+            return np.nan
+        return a.median / b.median
+
+    def matrix(metric, bi, vi, wlist):
+        return np.array(
+            [[cell(metric, bi, vi, nw, nr) for nw in wlist] for nr in readers]
+        )
+
+    matrices = {}
+    for mi, (metric, _) in enumerate(METRICS):
+        wlist = read_writers if metric == "read" else write_writers
+        for pi, (bi, vi) in enumerate(pairs):
+            matrices[(mi, pi)] = (matrix(metric, bi, vi, wlist), wlist)
+
+    def fmt(bi):
+        # Hide the shard suffix for benchmarks whose data has no sharding axis.
+        label, _, shards, has_shards_info = benchmarks[bi]
+        if not has_shards_info:
+            return label
+        return f"{label} ({shards} shard{'s' if shards > 1 else ''})"
+
+    # With a single pair, lay the two metrics out side by side rather than
+    # stacked, and move the comparison title up to the suptitle.
+    single_pair = len(pairs) == 1
+    if single_pair:
+        rows, cols = 1, len(METRICS)
+        figsize = (10, 4)
+    else:
+        rows, cols = len(METRICS), len(pairs)
+        figsize = (max(5, 4 * len(pairs) + 1), 6)
+
+    fig, axes = plt.subplots(
+        rows,
+        cols,
+        figsize=figsize,
+        constrained_layout=True,
+        squeeze=False,
+    )
+
+    suptitle = f"Variant speedup — {routes:,} routes".replace(",", " ")
+    if single_pair:
+        bi, vi = pairs[0]
+        suptitle += f"\n{fmt(bi)} vs {fmt(vi)}"
+    fig.suptitle(suptitle, fontsize=13, fontweight="bold")
+
+    # Log-symmetric colour scale shared by every panel.
+    valid = np.concatenate(
+        [m[~np.isnan(m)] for m, _ in matrices.values() if (~np.isnan(m)).any()]
+    )
+    extreme = max(valid.max(), 1.0 / valid.min(), 1.1)
+    norm = mcolors.LogNorm(vmin=1.0 / extreme, vmax=extreme)
+
+    def ax_for(mi, pi):
+        return axes[0, mi] if single_pair else axes[mi, pi]
+
+    im = None
+    for (mi, pi), (m, wlist) in matrices.items():
+        ax = ax_for(mi, pi)
+        im = ax.imshow(m, cmap=plt.cm.RdYlGn, norm=norm, aspect="auto")
+        ax.set_xticks(range(len(wlist)), [str(w) for w in wlist])
+        ax.set_yticks(range(len(readers)), [str(r) for r in readers])
+        ax.invert_yaxis()
+        if single_pair:
+            ax.set_title(METRICS[mi][1], fontsize=11)
+            ax.set_xlabel("Writers")
+            if mi == 0:
+                ax.set_ylabel("Readers")
+        else:
+            if pi == 0:
+                ax.set_ylabel(f"{METRICS[mi][1]}\nReaders")
+            if mi == len(METRICS) - 1:
+                ax.set_xlabel("Writers")
+            if mi == 0:
+                bi, vi = pairs[pi]
+                ax.set_title(
+                    f"{fmt(bi)} vs {fmt(vi)}",
+                    fontsize=9,
+                )
+        for ri in range(len(readers)):
+            for ci in range(len(wlist)):
+                val = m[ri, ci]
+                if not np.isnan(val):
+                    ax.text(
+                        ci,
+                        ri,
+                        f"{val:.2f}×",
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                        fontweight="bold",
+                        color="black",
+                    )
+
+    cb = fig.colorbar(im, ax=axes.ravel().tolist())
+    cb.ax.minorticks_off()
+    n_ticks = int(np.ceil(np.log2(extreme)))
+    ticks = [
+        2.0**i
+        for i in range(-n_ticks, n_ticks + 1)
+        if 1.0 / extreme <= 2.0**i <= extreme
+    ]
+    cb.set_ticks(ticks, labels=[f"{t:g}×" for t in ticks])
+
+    save(fig, platform, path)
+
+
+def cmd_single(args, parser):
     text = sys.stdin.read()
     stats = parse(text)
     if not stats:
         parser.error("no BenchmarkRIBConcurrent data on stdin")
 
-    available = sorted({routes for routes, *_ in stats})
-    if len(available) == 1:
-        routes = available[0]
-    elif args.routes in available:
-        routes = args.routes
-    else:
-        parser.error(f"benchmark covers routes {available}; select one with --routes")
-
+    routes = select_routes(stats, args.routes, parser)
     selected = {key[1:]: v for key, v in stats.items() if key[0] == routes}
     platform = parse_platform(text)
 
@@ -269,6 +411,125 @@ def main():
         selected, platform, "write", routes, OUTPUT_DIR / "write_latency.svg"
     )
     heatmap_figure(selected, platform, routes, OUTPUT_DIR / "heatmap_ratio.svg")
+
+
+def parse_benchmark_arg(arg):
+    """Parse a 'path=label' string into (Path, label)."""
+    if "=" not in arg:
+        raise argparse.ArgumentTypeError(f"expected PATH=LABEL, got {arg!r}")
+    path_str, label = arg.split("=", 1)
+    label = label.strip()
+    if not label:
+        raise argparse.ArgumentTypeError(f"empty label in {arg!r}")
+    return Path(path_str), label
+
+
+def cmd_compare(args, parser):
+    if len(args.benchmarks) < 2:
+        parser.error("compare requires at least two PATH=LABEL arguments")
+
+    # Parse each input file and keep its raw text for the platform banner.
+    loaded = []  # list of (label, stats, text)
+    for path, label in args.benchmarks:
+        text = path.read_text()
+        stats = parse(text)
+        if not stats:
+            parser.error(f"{path}: no BenchmarkRIBConcurrent data")
+        loaded.append((label, stats, text))
+
+    # Pick a route count present in every benchmark.
+    common = None
+    for _, stats, _ in loaded:
+        rs = {r for r, *_ in stats}
+        common = rs if common is None else common & rs
+    common = sorted(common or [])
+    if not common:
+        parser.error("no common route count across benchmarks")
+    if len(common) == 1:
+        routes = common[0]
+    elif args.routes in common:
+        routes = args.routes
+    else:
+        parser.error(f"benchmarks share routes {common}; select one with --routes")
+
+    # Resolve effective shards per benchmark.
+    benchmarks = (
+        []
+    )  # list of (label, stats_for_routes, effective_shards, has_shards_info)
+    for label, stats, _ in loaded:
+        filtered = {key[1:]: v for key, v in stats.items() if key[0] == routes}
+        have = {s for s, _, _ in filtered}
+        has_shards_info = len(have) > 1
+        if args.shards in have:
+            effective = args.shards
+        elif not has_shards_info and 1 in have:
+            # No shard axis in this benchmark (e.g. pre-sharding output): fall
+            # back to its single shard value, which is 1.
+            effective = 1
+        else:
+            parser.error(
+                f"{label!r}: no data for {args.shards} shards at {routes} routes"
+            )
+        benchmarks.append((label, filtered, effective, has_shards_info))
+
+    platform = parse_platform(loaded[-1][2])
+    comparison_figure(benchmarks, platform, routes, OUTPUT_DIR / "comparison.svg")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sp_single = sub.add_parser(
+        "single",
+        help="plot one benchmark run (read on stdin)",
+        description=(
+            "Read one benchmark output on stdin and produce read_latency.svg, "
+            "write_latency.svg and heatmap_ratio.svg next to the script."
+        ),
+    )
+    sp_single.add_argument(
+        "--routes",
+        type=int,
+        default=500000,
+        help="route count to plot when the benchmark has several",
+    )
+    sp_single.set_defaults(func=cmd_single)
+
+    sp_compare = sub.add_parser(
+        "compare",
+        help="compare two or more benchmark runs pairwise",
+        description=(
+            "Compare two or more benchmark output files and produce a "
+            "single comparison.svg with one column per pairwise speedup heatmap "
+            "(2 metrics × C comparisons, where C = N×(N−1)/2 for N inputs)."
+        ),
+    )
+    sp_compare.add_argument(
+        "benchmarks",
+        nargs="+",
+        type=parse_benchmark_arg,
+        metavar="PATH=LABEL",
+        help="benchmark file paired with a display label",
+    )
+    sp_compare.add_argument(
+        "--shards",
+        type=int,
+        default=16,
+        help="target shard count to plot (fallback to 1)",
+    )
+    sp_compare.add_argument(
+        "--routes",
+        type=int,
+        default=500000,
+        help="route count to plot when the benchmark has several",
+    )
+    sp_compare.set_defaults(func=cmd_compare)
+
+    args = parser.parse_args()
+    args.func(args, parser)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While writing a blog post about RIB sharding, I find myself looking a bit more at the code and was thinking the global lock looks very bad. Since we now have a concurrent benchmark, we can look again at using "persist" variants from bart package. It works well! -60% read, -30% write! There was a trick not used in the previous tentatives: not using ModifyPersist which triggers "false" modifications, but instead use `Get()` + `InsertPersist()` or `DeletePersist()`.

The second change is unrelated as it fixes a bug that was already there: it was possible to fetch a stale index from the tree and retrieve the wrong routes if the index is recycled. The third commit of this PR fixes that by introducing a generation number to detect when a prefix is recycled. It does not seem to impact performance.

cc @bogi788 if you want to test (but I need to spend a bit more time to ensure everything is correct, so no hurry).