### PR TITLE
outlet/clickhouse: add a hook to allow rebalancing on retries

### DIFF
--- a/outlet/clickhouse/functional_test.go
+++ b/outlet/clickhouse/functional_test.go
@@ -82,7 +82,7 @@ func TestInsert(t *testing.T) {
 	expected := []result{}
 
 	// Create one worker and send some values
-	w := ch.NewWorker(1, bf)
+	w := ch.NewWorker(1, bf, nil)
 	for i := range 23 {
 		i = i + 1
 		// 1: first batch (max time)
@@ -227,7 +227,7 @@ func TestMultipleServers(t *testing.T) {
 			bf.AppendUint(schema.ColumnDstAS, 65000)
 			bf.AppendUint(schema.ColumnBytes, 200)
 			bf.Finalize()
-			w := ch.NewWorker(1, bf)
+			w := ch.NewWorker(1, bf, nil)
 			w.Flush(ctx)
 		}()
 

--- a/outlet/clickhouse/root.go
+++ b/outlet/clickhouse/root.go
@@ -14,7 +14,7 @@ import (
 
 // Component is the interface for the ClickHouse exporter component.
 type Component interface {
-	NewWorker(int, *schema.FlowMessage) Worker
+	NewWorker(i int, bf *schema.FlowMessage, onRetry func()) Worker
 }
 
 // realComponent implements the ClickHouse exporter

--- a/outlet/clickhouse/root_test.go
+++ b/outlet/clickhouse/root_test.go
@@ -27,7 +27,7 @@ func TestMock(t *testing.T) {
 	helpers.StartStop(t, ch)
 
 	expected := []*schema.FlowMessage{}
-	w := ch.NewWorker(1, bf)
+	w := ch.NewWorker(1, bf, nil)
 	for i := range 20 {
 		i = i + 1 // 1 to 20
 		bf.TimeReceived = uint32(100 + i)

--- a/outlet/clickhouse/tests.go
+++ b/outlet/clickhouse/tests.go
@@ -25,7 +25,7 @@ func NewMock(_ *testing.T, callback func(*schema.FlowMessage)) Component {
 }
 
 // NewWorker creates a new mock worker.
-func (c *mockComponent) NewWorker(_ int, bf *schema.FlowMessage) Worker {
+func (c *mockComponent) NewWorker(_ int, bf *schema.FlowMessage, _ func()) Worker {
 	return &mockWorker{
 		c:  c,
 		bf: bf,

--- a/outlet/clickhouse/worker.go
+++ b/outlet/clickhouse/worker.go
@@ -40,10 +40,11 @@ const (
 
 // realWorker is a working implementation of Worker.
 type realWorker struct {
-	c      *realComponent
-	bf     *schema.FlowMessage
-	last   time.Time
-	logger reporter.Logger
+	c       *realComponent
+	bf      *schema.FlowMessage
+	last    time.Time
+	logger  reporter.Logger
+	onRetry func()
 
 	conn          *ch.Client
 	servers       []string
@@ -52,12 +53,13 @@ type realWorker struct {
 }
 
 // NewWorker creates a new worker to push data to ClickHouse.
-func (c *realComponent) NewWorker(i int, bf *schema.FlowMessage) Worker {
+func (c *realComponent) NewWorker(i int, bf *schema.FlowMessage, onRetry func()) Worker {
 	opts, servers := c.d.ClickHouse.ChGoOptions()
 	w := realWorker{
-		c:      c,
-		bf:     bf,
-		logger: c.r.With().Int("worker", i).Logger(),
+		c:       c,
+		bf:      bf,
+		logger:  c.r.With().Int("worker", i).Logger(),
+		onRetry: onRetry,
 
 		servers: servers,
 		options: opts,
@@ -132,6 +134,10 @@ func (w *realWorker) Flush(ctx context.Context) {
 	b := backoff.NewExponentialBackOff()
 	b.MaxInterval = 30 * time.Second
 	b.InitialInterval = 20 * time.Millisecond
+	opts := []backoff.RetryOption{backoff.WithBackOff(b), backoff.WithMaxElapsedTime(0)}
+	if w.onRetry != nil {
+		opts = append(opts, backoff.WithNotify(func(error, time.Duration) { w.onRetry() }))
+	}
 	backoff.Retry(ctx, func() (any, error) {
 		// Connect or reconnect if connection is broken.
 		if err := w.connect(ctx); err != nil {
@@ -184,7 +190,7 @@ func (w *realWorker) Flush(ctx context.Context) {
 		// Clear batch
 		w.bf.Clear()
 		return nil, nil
-	}, backoff.WithBackOff(b), backoff.WithMaxElapsedTime(0))
+	}, opts...)
 }
 
 // connect establishes or reestablish the connection to ClickHouse.

--- a/outlet/core/root_test.go
+++ b/outlet/core/root_test.go
@@ -218,7 +218,7 @@ func TestCore(t *testing.T) {
 
 			// Create a specific worker (for compatibility with synctest).
 			scaleRequestChan := make(chan kafka.ScaleRequest, 100)
-			receiveFunc, _ := c.newWorker(0, scaleRequestChan)
+			receiveFunc, _ := c.newWorker(0, scaleRequestChan, nil)
 
 			// Inject 10 flows with rateLimit=20 (burst=int(20/10)=2).
 			// Under synctest all flows see the same fake time, so

--- a/outlet/core/worker.go
+++ b/outlet/core/worker.go
@@ -30,13 +30,13 @@ type worker struct {
 
 // newWorker instantiates a new worker and returns a callback function to
 // process an incoming flow and a function to call on shutdown.
-func (c *Component) newWorker(i int, scaleRequestChan chan<- kafka.ScaleRequest) (kafka.ReceiveFunc, kafka.ShutdownFunc) {
+func (c *Component) newWorker(i int, scaleRequestChan chan<- kafka.ScaleRequest, allowRebalance func()) (kafka.ReceiveFunc, kafka.ShutdownFunc) {
 	bf := c.d.Schema.NewFlowMessage()
 	w := worker{
 		c:                c,
 		l:                c.r.With().Int("worker", i).Logger(),
 		bf:               bf,
-		cw:               c.d.ClickHouse.NewWorker(i, bf),
+		cw:               c.d.ClickHouse.NewWorker(i, bf, allowRebalance),
 		scaleRequestChan: scaleRequestChan,
 	}
 	return w.processIncomingFlow, w.shutdown

--- a/outlet/kafka/consumer.go
+++ b/outlet/kafka/consumer.go
@@ -35,9 +35,10 @@ type ShutdownFunc func()
 
 // WorkerBuilderFunc returns a function to be called with each received messages
 // and a function to be called when shutting down. It is provided the worker
-// number (for logging purpose) as well as a chan for the worker to request more
-// or less workers.
-type WorkerBuilderFunc func(int, chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc)
+// number (for logging purpose), a chan for the worker to request more or less
+// workers, and a hook to be called between slow retries so the worker can
+// allow a pending Kafka rebalance to proceed.
+type WorkerBuilderFunc func(int, chan<- ScaleRequest, func()) (ReceiveFunc, ShutdownFunc)
 
 // NewConsumer creates a new consumer.
 func (c *realComponent) newConsumer(worker int, callback ReceiveFunc) *Consumer {

--- a/outlet/kafka/functional_test.go
+++ b/outlet/kafka/functional_test.go
@@ -79,7 +79,7 @@ func TestFakeKafka(t *testing.T) {
 		t.Fatalf("Start() error:\n%+v", err)
 	}
 	shutdownCalled := false
-	c.StartWorkers(func(int, chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+	c.StartWorkers(func(int, chan<- ScaleRequest, func()) (ReceiveFunc, ShutdownFunc) {
 		return callback, func() { shutdownCalled = true }
 	})
 
@@ -157,7 +157,7 @@ func TestStartSeveralWorkers(t *testing.T) {
 	if err := c.(*realComponent).Start(); err != nil {
 		t.Fatalf("Start() error:\n%+v", err)
 	}
-	c.StartWorkers(func(int, chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+	c.StartWorkers(func(int, chan<- ScaleRequest, func()) (ReceiveFunc, ShutdownFunc) {
 		return func(context.Context, []byte) error { return nil }, func() {}
 	})
 	time.Sleep(20 * time.Millisecond)
@@ -204,7 +204,7 @@ func TestWorkerStop(t *testing.T) {
 
 	var last int
 	done := make(chan bool)
-	c.StartWorkers(func(int, chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+	c.StartWorkers(func(int, chan<- ScaleRequest, func()) (ReceiveFunc, ShutdownFunc) {
 		return func(_ context.Context, got []byte) error {
 				last, _ = strconv.Atoi(string(got))
 				return nil
@@ -341,7 +341,7 @@ func TestWorkerScaling(t *testing.T) {
 		t.Errorf("Start() max workers should have been capped to 4 instead of %d", maxWorkers)
 	}
 	msg := atomic.Uint32{}
-	c.StartWorkers(func(_ int, ch chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+	c.StartWorkers(func(_ int, ch chan<- ScaleRequest, _ func()) (ReceiveFunc, ShutdownFunc) {
 		return func(context.Context, []byte) error {
 			c := msg.Add(1)
 			if c <= 1 {
@@ -488,7 +488,7 @@ func TestKafkaLagMetric(t *testing.T) {
 	// Start a worker with a callback that blocks on a channel after receiving a message
 	workerBlockReceive := make(chan any)
 	defer close(workerBlockReceive)
-	c.StartWorkers(func(_ int, _ chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+	c.StartWorkers(func(_ int, _ chan<- ScaleRequest, _ func()) (ReceiveFunc, ShutdownFunc) {
 		return func(context.Context, []byte) error {
 			t.Log("worker received a message")
 			<-workerBlockReceive

--- a/outlet/kafka/root_test.go
+++ b/outlet/kafka/root_test.go
@@ -27,7 +27,7 @@ func TestMock(t *testing.T) {
 		return nil
 	}
 	c.StartWorkers(
-		func(int, chan<- ScaleRequest) (ReceiveFunc, ShutdownFunc) {
+		func(int, chan<- ScaleRequest, func()) (ReceiveFunc, ShutdownFunc) {
 			return callback, func() { shutdownCalled.Store(true) }
 		},
 	)

--- a/outlet/kafka/tests.go
+++ b/outlet/kafka/tests.go
@@ -35,7 +35,7 @@ func (c *mockComponent) StartWorkers(workerBuilder WorkerBuilderFunc) error {
 		}
 	}()
 	for i := range c.config.MinWorkers {
-		callback, shutdown := workerBuilder(i, ch)
+		callback, shutdown := workerBuilder(i, ch, func() {})
 		go func() {
 			defer shutdown()
 			for {

--- a/outlet/kafka/worker.go
+++ b/outlet/kafka/worker.go
@@ -55,7 +55,7 @@ func (c *realComponent) startOneWorker() error {
 	if err != nil {
 		return err
 	}
-	callback, shutdown := c.workerBuilder(i, c.workerRequestChan)
+	callback, shutdown := c.workerBuilder(i, c.workerRequestChan, client.AllowRebalance)
 	consumer := c.newConsumer(i, callback)
 
 	// Goroutine for worker


### PR DESCRIPTION
When ClickHouse is unavailable for some reason, we shouldn't block rebalancing.

But I don't think this is a good idea: if we cannot join ClickHouse, there is no point in letting rebalancing happens, we will just loose more data.

Cc: @bleuchtang
Related: #1908

I have also pushed a few commits in main (also included in this PR), but I don't think it will help your case.