### PR TITLE
outlet/routing: switch to bart.Fast instead of bart.Table

### DIFF
--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -15,6 +15,7 @@ identified with a specific icon:
 - 🩹 *outlet*: fix decoding of destination MAC address for sFlow
 - 🩹 *console*: avoid clipped labels in Sankey graphs
 - 🩹 *console*: fix empty widgets when toggling dark mode
+- 🌱 *outlet*: improve BMP RIB performance by switching to `bart.Fast`
 
 ## 2.4.0 - 2026-05-27
 

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -81,8 +81,8 @@ type ribShard struct {
 // rib represents the RIB. The prefix tree uses an atomic pointer for lock-free
 // read. Writers should take take the mutex.
 type rib struct {
-	treeMu sync.Mutex                            // serializes tree writers
-	tree   atomic.Pointer[bart.Table[prefixRef]] // global prefix indices, RCU-published
+	treeMu sync.Mutex                           // serializes tree writers
+	tree   atomic.Pointer[bart.Fast[prefixRef]] // global prefix indices, RCU-published
 	shards []*ribShard
 }
 
@@ -431,7 +431,7 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 
 	if anyEmpty {
 		// Rebuild the tree excluding empty prefixes and publish it.
-		newTree := &bart.Table[prefixRef]{}
+		newTree := &bart.Fast[prefixRef]{}
 		for prefix, ref := range tree.All() {
 			if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
 				newTree.Insert(prefix, ref)
@@ -507,6 +507,6 @@ func newRIB(nShards int) *rib {
 		}
 	}
 	r := &rib{shards: shards}
-	r.tree.Store(&bart.Table[prefixRef]{})
+	r.tree.Store(&bart.Fast[prefixRef]{})
 	return r
 }

--- a/outlet/routing/provider/bmp/testdata/sharding-bart-0.28.txt
+++ b/outlet/routing/provider/bmp/testdata/sharding-bart-0.28.txt
@@ -1,0 +1,246 @@
+goos: linux
+goarch: amd64
+pkg: akvorado/outlet/routing/provider/bmp
+cpu: AMD Ryzen 5 5600X 6-Core Processor             
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1568	        73.91 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1558	        73.81 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1572	        74.60 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1537	        76.41 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1561	        74.47 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1543	        73.81 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     910	       122.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     939	       122.4 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     921	       124.4 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     927	       124.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     904	       123.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     920	       123.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     266	       261.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     268	       259.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     268	       260.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     267	       261.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     271	       249.6 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     267	       258.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     142	       274.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     142	       275.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     141	       273.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       274.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     141	       273.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     142	       274.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1309 ns/read	      3041 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1299 ns/read	      3019 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1308 ns/read	      3041 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1313 ns/read	      3051 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1308 ns/read	      3038 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1302 ns/read	      3026 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1524 ns/read	      3876 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1564 ns/read	      3915 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1412 ns/read	      3950 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1585 ns/read	      3932 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1598 ns/read	      3954 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1608 ns/read	      3902 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2963 ns/read	      8228 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3004 ns/read	      8261 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3026 ns/read	      8276 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3071 ns/read	      8285 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3018 ns/read	      8300 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2984 ns/read	      8315 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4541 ns/read	     13940 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4381 ns/read	     14158 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4533 ns/read	     13998 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4585 ns/read	     13943 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4512 ns/read	     14054 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4509 ns/read	     13996 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1422 ns/read	      6788 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1494 ns/read	      7129 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1477 ns/read	      7011 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1438 ns/read	      6840 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1436 ns/read	      6785 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1450 ns/read	      6922 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1776 ns/read	      8501 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1773 ns/read	      8551 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1769 ns/read	      8694 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1788 ns/read	      8648 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1787 ns/read	      8556 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1749 ns/read	      8632 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2956 ns/read	     19155 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3211 ns/read	     18840 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3281 ns/read	     18251 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2955 ns/read	     18437 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3120 ns/read	     18894 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3181 ns/read	     17945 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4777 ns/read	     29912 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4686 ns/read	     29985 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4590 ns/read	     30055 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4781 ns/read	     29557 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4787 ns/read	     29673 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4722 ns/read	     29636 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1390 ns/read	     13415 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1392 ns/read	     13386 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1373 ns/read	     13567 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1412 ns/read	     13840 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1386 ns/read	     13640 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1400 ns/read	     13565 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1699 ns/read	     16590 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1741 ns/read	     16947 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1720 ns/read	     17108 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1733 ns/read	     17055 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1656 ns/read	     16467 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1733 ns/read	     17261 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3096 ns/read	     35740 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2959 ns/read	     36171 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3179 ns/read	     36052 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3081 ns/read	     35927 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3175 ns/read	     36412 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3086 ns/read	     35592 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4611 ns/read	     58500 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4622 ns/read	     58529 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4412 ns/read	     58766 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4515 ns/read	     58895 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4582 ns/read	     57936 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4408 ns/read	     59562 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1389 ns/read	     26188 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1389 ns/read	     26559 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1390 ns/read	     26730 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1409 ns/read	     26540 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1423 ns/read	     27302 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1446 ns/read	     27361 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1689 ns/read	     32441 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1726 ns/read	     32396 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1657 ns/read	     32779 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1710 ns/read	     32073 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1725 ns/read	     31882 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1867 ns/read	     35069 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3194 ns/read	     74748 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3220 ns/read	     77631 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3367 ns/read	     77873 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3065 ns/read	     76227 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3049 ns/read	     69800 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2754 ns/read	     70323 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4608 ns/read	    115623 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4568 ns/read	    116377 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4417 ns/read	    116835 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4601 ns/read	    115700 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4633 ns/read	    116225 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4549 ns/read	    116139 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1286	        92.19 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1287	        91.78 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1312	        89.81 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1281	        92.09 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1303	        89.93 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1314	        89.64 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1140	        97.08 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1124	        99.65 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1086	        97.82 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1130	        99.97 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1168	        97.49 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1070	       100.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     495	       125.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     487	       126.3 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     480	       131.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     476	       129.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     492	       126.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     458	       129.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     289	       129.3 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     260	       133.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     286	       132.9 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     268	       133.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     276	       133.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     267	       131.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       955.1 ns/read	      2972 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       815.5 ns/read	      2585 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       856.2 ns/read	      2692 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       843.6 ns/read	      2650 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       812.0 ns/read	      2656 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	      1029 ns/read	      3092 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       727.3 ns/read	      4002 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       658.3 ns/read	      3653 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       663.1 ns/read	      3642 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       658.7 ns/read	      3687 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       665.8 ns/read	      3629 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       658.3 ns/read	      3647 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       806.9 ns/read	      5605 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       823.9 ns/read	      5665 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       810.6 ns/read	      5735 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       779.5 ns/read	      5603 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       766.9 ns/read	      5598 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       784.7 ns/read	      5701 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       877.4 ns/read	      7280 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       947.1 ns/read	      7987 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       863.4 ns/read	      7088 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       872.2 ns/read	      7193 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       881.3 ns/read	      7413 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       923.8 ns/read	      7540 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       915.9 ns/read	      5202 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       831.1 ns/read	      4903 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	      1002 ns/read	      5642 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       850.4 ns/read	      5001 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       826.1 ns/read	      4899 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       891.8 ns/read	      5251 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       817.9 ns/read	      6066 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       825.2 ns/read	      6145 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       811.5 ns/read	      6116 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       821.0 ns/read	      6083 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       825.0 ns/read	      6109 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       816.2 ns/read	      6014 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       950.3 ns/read	      8600 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       917.5 ns/read	      8505 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       926.8 ns/read	      8584 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       936.5 ns/read	      8512 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       923.8 ns/read	      8607 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       955.6 ns/read	      8529 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1009 ns/read	     10405 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1011 ns/read	     10396 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1003 ns/read	     10155 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	       988.5 ns/read	     10077 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1036 ns/read	     10553 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1011 ns/read	     10364 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1323 ns/read	      9431 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1357 ns/read	      9726 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1350 ns/read	      9608 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1339 ns/read	      9644 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1279 ns/read	      9293 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1306 ns/read	      9527 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1314 ns/read	     10832 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1373 ns/read	     11118 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1298 ns/read	     10671 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1471 ns/read	     11757 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1336 ns/read	     11071 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1379 ns/read	     11173 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1480 ns/read	     14272 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1516 ns/read	     14174 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1397 ns/read	     13990 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1481 ns/read	     13800 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1458 ns/read	     13562 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1518 ns/read	     14207 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1541 ns/read	     15162 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1573 ns/read	     15459 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1618 ns/read	     15829 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1495 ns/read	     15684 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1616 ns/read	     16077 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1522 ns/read	     15965 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2586 ns/read	     17731 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2631 ns/read	     17819 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2550 ns/read	     17625 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2568 ns/read	     17908 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2619 ns/read	     17855 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2642 ns/read	     17765 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2569 ns/read	     20141 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2600 ns/read	     19641 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2582 ns/read	     21026 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2690 ns/read	     21968 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2551 ns/read	     20431 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2621 ns/read	     20683 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2930 ns/read	     25989 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2667 ns/read	     23686 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2757 ns/read	     24514 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2693 ns/read	     23397 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2726 ns/read	     23530 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2685 ns/read	     23267 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2922 ns/read	     26896 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2951 ns/read	     26640 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2572 ns/read	     27026 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      1965 ns/read	     27511 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2310 ns/read	     26707 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2725 ns/read	     26119 ns/write
+PASS
+ok  	akvorado/outlet/routing/provider/bmp	1154.897s

--- a/outlet/routing/provider/bmp/testdata/sharding-bart-fast.txt
+++ b/outlet/routing/provider/bmp/testdata/sharding-bart-fast.txt
@@ -1,0 +1,246 @@
+goos: linux
+goarch: amd64
+pkg: akvorado/outlet/routing/provider/bmp
+cpu: AMD Ryzen 5 5600X 6-Core Processor             
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1660	        70.39 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1557	        72.04 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1608	        73.04 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1635	        72.03 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1603	        72.46 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_1_readers-12         	    1513	        75.50 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     938	       120.9 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     949	       120.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     930	       123.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     909	       122.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     950	       120.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_4_readers-12         	     942	       124.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     267	       235.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     268	       256.1 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     271	       256.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     271	       257.0 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     266	       251.7 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_16_readers-12        	     272	       257.8 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     134	       268.5 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       265.3 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     141	       274.6 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     141	       270.4 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       273.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_0_writers,_32_readers-12        	     140	       274.2 ns/read
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1431 ns/read	      3338 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1426 ns/read	      3314 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1508 ns/read	      3507 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1482 ns/read	      3534 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1456 ns/read	      3384 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_1_readers-12         	       1	      1400 ns/read	      3253 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1535 ns/read	      4166 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1697 ns/read	      4222 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1699 ns/read	      4142 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1726 ns/read	      4169 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1751 ns/read	      4133 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_4_readers-12         	       1	      1598 ns/read	      4145 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3084 ns/read	      8459 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      3064 ns/read	      8359 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2982 ns/read	      8615 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2701 ns/read	      8798 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2886 ns/read	      8832 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_16_readers-12        	       1	      2836 ns/read	      8747 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4463 ns/read	     14005 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4381 ns/read	     14236 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4210 ns/read	     14405 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4379 ns/read	     14236 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4334 ns/read	     14316 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_1_writers,_32_readers-12        	       1	      4607 ns/read	     14058 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1627 ns/read	      7759 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1598 ns/read	      7582 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1473 ns/read	      7099 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1501 ns/read	      7142 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1624 ns/read	      7776 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_1_readers-12         	       1	      1527 ns/read	      7430 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1973 ns/read	      9580 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1756 ns/read	      8912 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      2025 ns/read	     10319 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1916 ns/read	      9860 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      2308 ns/read	     11389 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_4_readers-12         	       1	      1798 ns/read	      9037 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2890 ns/read	     18201 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3071 ns/read	     17949 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      3037 ns/read	     17829 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2867 ns/read	     17942 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2913 ns/read	     18071 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_16_readers-12        	       1	      2927 ns/read	     18108 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4021 ns/read	     29718 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      3846 ns/read	     30405 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4070 ns/read	     29320 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4236 ns/read	     29170 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4519 ns/read	     28647 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_2_writers,_32_readers-12        	       1	      4313 ns/read	     29091 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1489 ns/read	     14381 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1478 ns/read	     14262 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1449 ns/read	     14126 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1416 ns/read	     14223 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1591 ns/read	     15281 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_1_readers-12         	       1	      1710 ns/read	     16629 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1934 ns/read	     19171 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1871 ns/read	     19115 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1802 ns/read	     18058 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1837 ns/read	     18055 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1955 ns/read	     19424 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_4_readers-12         	       1	      1770 ns/read	     17493 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3016 ns/read	     35679 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2817 ns/read	     36771 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2828 ns/read	     35278 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2942 ns/read	     36850 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      2988 ns/read	     35869 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_16_readers-12        	       1	      3068 ns/read	     34964 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4243 ns/read	     57729 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4187 ns/read	     56527 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      3985 ns/read	     59048 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4366 ns/read	     57681 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4379 ns/read	     57296 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_4_writers,_32_readers-12        	       1	      4225 ns/read	     58439 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1699 ns/read	     31895 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1564 ns/read	     29196 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1513 ns/read	     28231 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1774 ns/read	     32970 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1654 ns/read	     30001 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_1_readers-12         	       1	      1760 ns/read	     33150 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1894 ns/read	     36852 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1857 ns/read	     36249 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1873 ns/read	     35130 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1912 ns/read	     35986 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1726 ns/read	     33358 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_4_readers-12         	       1	      1987 ns/read	     36504 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3069 ns/read	     71174 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3239 ns/read	     72090 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2965 ns/read	     74871 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2963 ns/read	     72173 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      2945 ns/read	     70675 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_16_readers-12        	       1	      3137 ns/read	     68073 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4116 ns/read	    116045 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4102 ns/read	    115566 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3646 ns/read	    116418 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      4237 ns/read	    114306 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3904 ns/read	    115801 ns/write
+BenchmarkRIBConcurrent/1_shards,_500000_routes,_8_writers,_32_readers-12        	       1	      3619 ns/read	    121790 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1486	        79.58 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1437	        81.75 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1435	        81.01 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1443	        81.34 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1444	        80.27 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_1_readers-12        	    1473	        79.87 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1224	        92.50 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1280	        90.56 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1153	        92.39 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1183	        92.82 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1243	        89.96 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_4_readers-12        	    1264	        89.68 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     525	       116.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     510	       116.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     494	       120.5 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     526	       118.4 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     512	       115.5 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_16_readers-12       	     524	       120.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     303	       122.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     309	       120.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     306	       121.7 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     308	       122.2 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     306	       121.0 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_0_writers,_32_readers-12       	     309	       120.6 ns/read
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       823.3 ns/read	      2701 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       805.4 ns/read	      2703 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       840.7 ns/read	      2751 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       831.8 ns/read	      2714 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       814.4 ns/read	      2687 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_1_readers-12        	       1	       854.4 ns/read	      2756 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       644.0 ns/read	      3613 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       640.2 ns/read	      3597 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       641.6 ns/read	      3611 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       654.5 ns/read	      3662 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       644.1 ns/read	      3601 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_4_readers-12        	       1	       640.4 ns/read	      3641 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       787.9 ns/read	      5512 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       775.4 ns/read	      5570 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       769.5 ns/read	      5598 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       780.0 ns/read	      5589 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       758.4 ns/read	      5537 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_16_readers-12       	       1	       784.5 ns/read	      5543 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       817.6 ns/read	      7031 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       823.8 ns/read	      6988 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       812.0 ns/read	      7106 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       817.8 ns/read	      7065 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       838.7 ns/read	      7468 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_1_writers,_32_readers-12       	       1	       806.2 ns/read	      7194 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       907.2 ns/read	      5442 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       920.3 ns/read	      5416 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       876.2 ns/read	      5170 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       873.6 ns/read	      5179 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       928.7 ns/read	      5403 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_1_readers-12        	       1	       976.8 ns/read	      5594 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       935.5 ns/read	      6897 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       837.1 ns/read	      6310 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       842.3 ns/read	      6313 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       995.7 ns/read	      7269 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       891.7 ns/read	      6628 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_4_readers-12        	       1	       931.4 ns/read	      6822 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       960.1 ns/read	      8724 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       944.8 ns/read	      8744 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       915.8 ns/read	      8847 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       870.4 ns/read	      8900 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       945.5 ns/read	      8711 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_16_readers-12       	       1	       954.0 ns/read	      8696 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1076 ns/read	     10949 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1053 ns/read	     10882 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1008 ns/read	     10341 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	       989.7 ns/read	     10431 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	      1040 ns/read	     10568 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_2_writers,_32_readers-12       	       1	       988.2 ns/read	     10420 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1336 ns/read	      9742 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1379 ns/read	     10034 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1328 ns/read	      9805 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1348 ns/read	      9902 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1368 ns/read	      9971 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_1_readers-12        	       1	      1344 ns/read	      9836 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1289 ns/read	     10766 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1337 ns/read	     11012 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1323 ns/read	     11053 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1347 ns/read	     11088 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1329 ns/read	     10961 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_4_readers-12        	       1	      1316 ns/read	     10835 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1507 ns/read	     14028 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1517 ns/read	     14037 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1550 ns/read	     14373 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1510 ns/read	     14104 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1517 ns/read	     14021 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_16_readers-12       	       1	      1547 ns/read	     14421 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1533 ns/read	     15820 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1152 ns/read	     16650 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1606 ns/read	     15999 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1568 ns/read	     15929 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1604 ns/read	     15888 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_4_writers,_32_readers-12       	       1	      1583 ns/read	     16112 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2645 ns/read	     18789 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2605 ns/read	     18844 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2662 ns/read	     18896 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2791 ns/read	     19830 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2865 ns/read	     19886 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_1_readers-12        	       1	      2740 ns/read	     19581 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2606 ns/read	     21032 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2513 ns/read	     20444 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2563 ns/read	     20160 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2488 ns/read	     20136 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2556 ns/read	     20147 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_4_readers-12        	       1	      2658 ns/read	     20955 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2751 ns/read	     24198 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2773 ns/read	     24182 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2783 ns/read	     24916 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      1501 ns/read	     24651 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2704 ns/read	     23770 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_16_readers-12       	       1	      2805 ns/read	     24831 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2592 ns/read	     27498 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      3022 ns/read	     27661 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      3110 ns/read	     27998 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      3013 ns/read	     27429 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      3031 ns/read	     27605 ns/write
+BenchmarkRIBConcurrent/16_shards,_500000_routes,_8_writers,_32_readers-12       	       1	      2998 ns/read	     27283 ns/write
+PASS
+ok  	akvorado/outlet/routing/provider/bmp	1207.776s


### PR DESCRIPTION
This has positive effects on read performance. As for memory, we go from 305 bytes/route (BenchmarkRIBInsertion/100000_routes,_5_peers-12) to 341.9 bytes/route, so 12% increase which should be OK.

Difficult to know how this may translate in reality, but as we assume the RIB is still mostly about read performance, this seems positive.

<img width="970" height="397" alt="comparison" src="https://github.com/user-attachments/assets/da0940d4-e2f9-4c1a-8592-1d06dc820701" />
