### PR TITLE
outlet/flow: add PBB decapsulation

### DIFF
--- a/common/constants/ether.go
+++ b/common/constants/ether.go
@@ -12,4 +12,8 @@ const (
 	ETypeMPLS = 0x8847
 	// ETypeVLAN is the ether type for Dot1Q
 	ETypeVLAN = 0x8100
+	// ETypeDot1AD is the ether type for Dot1ad
+	ETypeDot1AD = 0x88a8
+	// ETypePBB is the ether type for Provider Backbone Bridges
+	ETypePBB = 0x88e7
 )

--- a/common/pb/rawflow.go
+++ b/common/pb/rawflow.go
@@ -84,6 +84,7 @@ var decapsulationMap = bimap.New(map[RawFlow_DecapsulationProtocol]string{
 	RawFlow_DECAP_GRE:   "gre",
 	RawFlow_DECAP_VXLAN: "vxlan",
 	RawFlow_DECAP_SRV6:  "srv6",
+	RawFlow_DECAP_PBB:   "pbb",
 })
 
 // MarshalText turns a timestamp source to text
@@ -97,6 +98,11 @@ func (dp RawFlow_DecapsulationProtocol) MarshalText() ([]byte, error) {
 
 // UnmarshalText provides a timestamp source from text
 func (dp *RawFlow_DecapsulationProtocol) UnmarshalText(input []byte) error {
+	switch string(input) {
+	case "spbm", "mac-in-mac":
+		*dp = RawFlow_DECAP_PBB
+		return nil
+	}
 	got, ok := decapsulationMap.LoadKey(string(input))
 	if ok {
 		*dp = got

--- a/common/pb/rawflow.proto
+++ b/common/pb/rawflow.proto
@@ -30,5 +30,6 @@ message RawFlow {
         DECAP_GRE = 2;
         DECAP_VXLAN = 3;
         DECAP_SRV6 = 4;
+        DECAP_PBB = 5;
     }
 }

--- a/common/pb/rawflow_test.go
+++ b/common/pb/rawflow_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package pb
+
+import "testing"
+
+func TestDecapsulationProtocolPBBText(t *testing.T) {
+	for _, input := range []string{"pbb", "spbm", "mac-in-mac"} {
+		var got RawFlow_DecapsulationProtocol
+		if err := got.UnmarshalText([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalText(%q) error:\n%+v", input, err)
+		}
+		if got != RawFlow_DECAP_PBB {
+			t.Fatalf("UnmarshalText(%q) = %v, expected %v", input, got, RawFlow_DECAP_PBB)
+		}
+	}
+
+	got, err := RawFlow_DECAP_PBB.MarshalText()
+	if err != nil {
+		t.Fatalf("MarshalText() error:\n%+v", err)
+	}
+	if string(got) != "pbb" {
+		t.Fatalf("MarshalText() = %q, expected pbb", got)
+	}
+}

--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -220,6 +220,7 @@ const (
 	ColumnMPLS2ndLabel
 	ColumnMPLS3rdLabel
 	ColumnMPLS4thLabel
+	ColumnPBBISID
 
 	// ColumnLast points to after the last static column, custom dictionaries
 	// (dynamic columns) come after ColumnLast
@@ -333,6 +334,7 @@ END`,
 				ClickHouseGenerateFrom: "c_SrcNetworks[tenant]",
 			},
 			{Key: ColumnSrcVlan, ParserType: "uint", ClickHouseType: "UInt16", Disabled: true, Group: ColumnGroupL2},
+			{Key: ColumnPBBISID, ParserType: "uint", ClickHouseType: "UInt32", Disabled: true, Group: ColumnGroupL2},
 			{
 				Key:                    ColumnSrcCountry,
 				ParserType:             "string",

--- a/common/schema/testdata/schema.yaml
+++ b/common/schema/testdata/schema.yaml
@@ -163,6 +163,11 @@
   group: 1
   parsertype: uint
   clickhousetype: UInt16
+- key: PBBISID
+  name: PBBISID
+  group: 1
+  parsertype: uint
+  clickhousetype: UInt32
 - key: SrcCountry
   name: SrcCountry
   parsertype: string

--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -87,9 +87,10 @@ For all available inputs, the following options are available:
   to use the “first switched” field from NetFlow/IPFIX.
 - `decapsulation-protocol` to look inside a tunneling protocol. The supported
   protocols are `none` (the default), `ipip` (both IPv4 and IPv6), `gre`
-  (version 0), `vxlan` (UDP port 4789), and `srv6` (DT4, DT6, DT46, DX4, DX6 are
-  supported, not DX2, nor DT2). This requires the presence of a sampled packet
-  for sFlow or the use of [IPFIX
+  (version 0), `vxlan` (UDP port 4789), `srv6` (DT4, DT6, DT46, DX4, DX6 are
+  supported, not DX2, nor DT2), and `pbb` for IEEE 802.1ah Provider Backbone
+  Bridges / MAC-in-MAC, also used by SPB-M. This requires the presence of a
+  sampled packet for sFlow or the use of [IPFIX
   315](https://datatracker.ietf.org/doc/html/rfc7133). If there is a protocol
   mismatch, the packet will be dropped.
 - `rate-limit` to set the maximum number of flows per second per exporter. When

--- a/outlet/flow/decoder/helpers.go
+++ b/outlet/flow/decoder/helpers.go
@@ -195,26 +195,40 @@ func ParseEthernet(sch *schema.Component, bf *schema.FlowMessage, decap pb.RawFl
 	if len(data) < 14 {
 		return 0
 	}
-	if !sch.IsDisabled(schema.ColumnGroupL2) && decap == pb.RawFlow_DECAP_NONE {
-		bf.AppendUint(schema.ColumnDstMAC,
-			binary.BigEndian.Uint64([]byte{0, 0, data[0], data[1], data[2], data[3], data[4], data[5]}))
-		bf.AppendUint(schema.ColumnSrcMAC,
-			binary.BigEndian.Uint64([]byte{0, 0, data[6], data[7], data[8], data[9], data[10], data[11]}))
-	}
+	ethernetHeader := data
 	etherType := binary.BigEndian.Uint16(data[12:14])
 	data = data[14:]
 	var vlan uint16
-	for etherType == constants.ETypeVLAN {
+	for etherType == constants.ETypeVLAN || etherType == constants.ETypeDot1AD {
 		if len(data) < 4 {
 			return 0
 		}
-		if !sch.IsDisabled(schema.ColumnGroupL2) && decap == pb.RawFlow_DECAP_NONE {
+		if !sch.IsDisabled(schema.ColumnGroupL2) {
 			vlan = (uint16(data[0]&0xf) << 8) + uint16(data[1])
 		}
 		etherType = binary.BigEndian.Uint16(data[2:4])
 		data = data[4:]
 	}
-	if vlan != 0 && bf.SrcVlan == 0 {
+	if etherType == constants.ETypePBB {
+		if decap != pb.RawFlow_DECAP_PBB || len(data) < 4 {
+			return 0
+		}
+		if column, ok := sch.LookupColumnByKey(schema.ColumnPBBISID); ok && !column.Disabled {
+			bf.AppendUint(schema.ColumnPBBISID,
+				uint64(binary.BigEndian.Uint32([]byte{0, data[1], data[2], data[3]})))
+		}
+		return ParseEthernet(sch, bf, pb.RawFlow_DECAP_NONE, data[4:])
+	}
+	if decap == pb.RawFlow_DECAP_PBB {
+		decap = pb.RawFlow_DECAP_NONE
+	}
+	if !sch.IsDisabled(schema.ColumnGroupL2) && decap == pb.RawFlow_DECAP_NONE {
+		bf.AppendUint(schema.ColumnDstMAC,
+			binary.BigEndian.Uint64([]byte{0, 0, ethernetHeader[0], ethernetHeader[1], ethernetHeader[2], ethernetHeader[3], ethernetHeader[4], ethernetHeader[5]}))
+		bf.AppendUint(schema.ColumnSrcMAC,
+			binary.BigEndian.Uint64([]byte{0, 0, ethernetHeader[6], ethernetHeader[7], ethernetHeader[8], ethernetHeader[9], ethernetHeader[10], ethernetHeader[11]}))
+	}
+	if vlan != 0 && bf.SrcVlan == 0 && decap == pb.RawFlow_DECAP_NONE {
 		bf.SrcVlan = vlan
 	}
 	if etherType == constants.ETypeMPLS {

--- a/outlet/flow/decoder/helpers_test.go
+++ b/outlet/flow/decoder/helpers_test.go
@@ -218,6 +218,102 @@ func TestDecodeSRv6(t *testing.T) {
 	}
 }
 
+func TestDecodePBB(t *testing.T) {
+	sch := schema.NewMock(t).EnableAllColumns()
+	packet := []byte{
+		// Outer Ethernet
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+		0x88, 0xa8,
+		// B-TAG
+		0x00, 0x64,
+		0x88, 0xe7,
+		// I-TAG: flags, then 24-bit I-SID
+		0x00, 0x12, 0x34, 0x56,
+		// Inner Ethernet
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+		0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+		0x81, 0x00,
+		// Inner VLAN
+		0x00, 0xc8,
+		0x08, 0x00,
+		// IPv4
+		0x45, 0x00, 0x00, 0x1c,
+		0xab, 0xcd, 0x00, 0x00,
+		0x40, 0x11, 0x00, 0x00,
+		0xc0, 0x00, 0x02, 0x01,
+		0xc6, 0x33, 0x64, 0x02,
+		// UDP
+		0x30, 0x39, 0x00, 0xa1,
+		0x00, 0x08, 0x00, 0x00,
+	}
+	bf := sch.NewFlowMessage()
+	l := ParseEthernet(sch, bf, pb.RawFlow_DECAP_PBB, packet)
+	if l != 28 {
+		t.Errorf("ParseEthernet() returned %d, expected 28", l)
+	}
+	expected := &schema.FlowMessage{
+		SrcVlan: 200,
+		SrcAddr: netip.MustParseAddr("::ffff:192.0.2.1"),
+		DstAddr: netip.MustParseAddr("::ffff:198.51.100.2"),
+		OtherColumns: map[schema.ColumnKey]any{
+			schema.ColumnEType:        uint32(constants.ETypeIPv4),
+			schema.ColumnProto:        uint32(constants.ProtoUDP),
+			schema.ColumnSrcPort:      uint16(12345),
+			schema.ColumnDstPort:      uint16(161),
+			schema.ColumnIPTTL:        uint8(64),
+			schema.ColumnIPFragmentID: uint32(0xabcd),
+			schema.ColumnPBBISID:      uint32(0x123456),
+			schema.ColumnSrcMAC:       uint64(0x123456789abc),
+			schema.ColumnDstMAC:       uint64(0xaabbccddeeff),
+		},
+	}
+	if diff := helpers.Diff(bf, expected); diff != "" {
+		t.Fatalf("ParseEthernet() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestDecodePBBFallbackToNativeEthernet(t *testing.T) {
+	sch := schema.NewMock(t).EnableAllColumns()
+	packet := []byte{
+		// Ethernet
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+		0x08, 0x00,
+		// IPv4
+		0x45, 0x00, 0x00, 0x1c,
+		0xab, 0xcd, 0x00, 0x00,
+		0x40, 0x11, 0x00, 0x00,
+		0xc0, 0x00, 0x02, 0x01,
+		0xc6, 0x33, 0x64, 0x02,
+		// UDP
+		0x30, 0x39, 0x00, 0xa1,
+		0x00, 0x08, 0x00, 0x00,
+	}
+	bf := sch.NewFlowMessage()
+	l := ParseEthernet(sch, bf, pb.RawFlow_DECAP_PBB, packet)
+	if l != 28 {
+		t.Errorf("ParseEthernet() returned %d, expected 28", l)
+	}
+	expected := &schema.FlowMessage{
+		SrcAddr: netip.MustParseAddr("::ffff:192.0.2.1"),
+		DstAddr: netip.MustParseAddr("::ffff:198.51.100.2"),
+		OtherColumns: map[schema.ColumnKey]any{
+			schema.ColumnEType:        uint32(constants.ETypeIPv4),
+			schema.ColumnProto:        uint32(constants.ProtoUDP),
+			schema.ColumnSrcPort:      uint16(12345),
+			schema.ColumnDstPort:      uint16(161),
+			schema.ColumnIPTTL:        uint8(64),
+			schema.ColumnIPFragmentID: uint32(0xabcd),
+			schema.ColumnSrcMAC:       uint64(0x66778899aabb),
+			schema.ColumnDstMAC:       uint64(0x001122334455),
+		},
+	}
+	if diff := helpers.Diff(bf, expected); diff != "" {
+		t.Fatalf("ParseEthernet() (-got, +want):\n%s", diff)
+	}
+}
+
 func TestDecodeIP(t *testing.T) {
 	for _, tc := range []struct {
 		input  []byte


### PR DESCRIPTION
## Summary

This adds `pbb` as a decapsulation protocol for sampled packet decoding. It supports IEEE 802.1ah Provider Backbone Bridges / MAC-in-MAC, including SPB-M deployments.

When enabled, Akvorado decapsulates the outer PBB frame, extracts the 24-bit I-SID into a new `PBBISID` L2 column, and continues decoding the inner Ethernet frame.

## Implementation

- add `DECAP_PBB` and expose it as `decapsulation-protocol: pbb`
- accept `spbm` and `mac-in-mac` as configuration aliases for `pbb`
- add EtherTypes for 802.1ad and PBB
- parse PBB I-TAG and extract I-SID
- decode the inner Ethernet frame after PBB decapsulation
- add disabled-by-default L2 dimension `PBBISID`
- document `pbb` in the decapsulation protocol list

If `pbb` is configured but the sampled packet is a normal Ethernet frame, decoding falls back to native Ethernet parsing. This keeps mixed captures usable.

## Tests

- `git diff --check`
- `go test ./common/pb`
- `go test ./common/schema`
- `go test ./outlet/flow/decoder`
- `go test ./inlet/flow`
- `go test ./outlet/flow/decoder/sflow`
- `go test ./outlet/flow/decoder/netflow`
