### PR TITLE
Populate DstVlan from the vlan id of the ethernet frame

### DIFF
--- a/outlet/flow/decoder/helpers.go
+++ b/outlet/flow/decoder/helpers.go
@@ -214,8 +214,13 @@ func ParseEthernet(sch *schema.Component, bf *schema.FlowMessage, decap pb.RawFl
 		etherType = binary.BigEndian.Uint16(data[2:4])
 		data = data[4:]
 	}
-	if vlan != 0 && bf.SrcVlan == 0 {
-		bf.SrcVlan = vlan
+	if vlan != 0 {
+		if bf.SrcVlan == 0 {
+			bf.SrcVlan = vlan
+		}
+		if bf.DstVlan == 0 {
+			bf.DstVlan = vlan
+		}
 	}
 	if etherType == constants.ETypeMPLS {
 		mplsLabels := make([]uint32, 0, 5)

--- a/outlet/flow/decoder/helpers_test.go
+++ b/outlet/flow/decoder/helpers_test.go
@@ -54,6 +54,7 @@ func TestDecodeVLANAndIPv6(t *testing.T) {
 	}
 	expected := &schema.FlowMessage{
 		SrcVlan: 100,
+		DstVlan: 100,
 		SrcAddr: netip.MustParseAddr("2402:f000:1:8e01::5555"),
 		DstAddr: netip.MustParseAddr("2607:fcd0:100:2300::b108:2a6b"),
 		OtherColumns: map[schema.ColumnKey]any{

--- a/outlet/flow/decoder/netflow/root_test.go
+++ b/outlet/flow/decoder/netflow/root_test.go
@@ -515,6 +515,7 @@ func TestDecodeDataLink(t *testing.T) {
 			SrcAddr:         netip.MustParseAddr("::ffff:51.51.51.51"),
 			DstAddr:         netip.MustParseAddr("::ffff:52.52.52.52"),
 			SrcVlan:         231,
+			DstVlan:         231,
 			InIf:            582,
 			OutIf:           0,
 			OtherColumns: map[schema.ColumnKey]any{

--- a/outlet/flow/decoder/sflow/root_test.go
+++ b/outlet/flow/decoder/sflow/root_test.go
@@ -332,6 +332,7 @@ func TestDecode(t *testing.T) {
 				SrcAS:           203476,
 				DstAS:           203361,
 				SrcVlan:         809,
+				DstVlan:         809,
 				SrcNetMask:      32,
 				DstNetMask:      22,
 				OtherColumns: map[schema.ColumnKey]any{
@@ -573,6 +574,7 @@ func TestDecode(t *testing.T) {
 				InIf:            369098852,
 				OutIf:           369098851,
 				SrcVlan:         1493,
+				DstVlan:         1493,
 				SrcAddr:         netip.MustParseAddr("::ffff:49.49.49.2"),
 				DstAddr:         netip.MustParseAddr("::ffff:49.49.49.109"),
 				ExporterAddress: netip.MustParseAddr("::ffff:172.17.128.58"),


### PR DESCRIPTION
If we don't receive more precise information from the protocol (for example when using sFlow without extended switch data) use the decoded vlan id of the ethernet frame to populate the ``DstVlan`` field of the flow, making sure that we can match on ``Interface.VLAN`` to classify an interface even for outbound flows when doing egress sampling.

Without this change if we sample on ingress and egress on the same interface any bidirectional graph shows the outbound traffic as "other" because the wrongly classified or unclassified outbound interface doesn't match any inbound interface.

Discussed in https://github.com/akvorado/akvorado/issues/2464.