### PR TITLE
outlet/flow: decode IPFIX VRF IDs

### DIFF
--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -220,6 +220,8 @@ const (
 	ColumnMPLS2ndLabel
 	ColumnMPLS3rdLabel
 	ColumnMPLS4thLabel
+	ColumnIngressVRFID
+	ColumnEgressVRFID
 
 	// ColumnLast points to after the last static column, custom dictionaries
 	// (dynamic columns) come after ColumnLast
@@ -569,6 +571,8 @@ END`,
 				ClickHouseAlias:    "MPLSLabels[4]",
 				ParserType:         "uint",
 			},
+			{Key: ColumnIngressVRFID, Disabled: true, ParserType: "uint", ClickHouseType: "UInt32"},
+			{Key: ColumnEgressVRFID, Disabled: true, ParserType: "uint", ClickHouseType: "UInt32"},
 		},
 	}.finalize()
 }

--- a/common/schema/testdata/schema.yaml
+++ b/common/schema/testdata/schema.yaml
@@ -503,3 +503,11 @@
   clickhousetype: UInt32
   clickhousealias: MPLSLabels[4]
   clickhousemainonly: true
+- key: IngressVRFID
+  name: IngressVRFID
+  parsertype: uint
+  clickhousetype: UInt32
+- key: EgressVRFID
+  name: EgressVRFID
+  parsertype: uint
+  clickhousetype: UInt32

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -16,6 +16,7 @@ identified with a specific icon:
 - 🩹 *console*: avoid clipped labels in Sankey graphs
 - 🩹 *console*: fix empty widgets when toggling dark mode
 - 🌱 *outlet*: improve BMP RIB performance by switching to `bart.Fast`
+- ✨ *outlet*: add `IngressVRFID` and `EgressVRFID` as disabled by default columns
 - 🌱 *console*: allow `PacketSize` to be used as a dimension
 - 🌱 *console*: allow matching MAC addresses with `IN`/`NOTIN` in filters
 - 🌱 *console*: allow `IN`/`NOTIN` in filters for integer and protocol columns

--- a/outlet/flow/decoder/netflow/decode.go
+++ b/outlet/flow/decoder/netflow/decode.go
@@ -260,6 +260,12 @@ func (nd *Decoder) decodeRecord(version uint16, obsDomainID uint32, tao *templat
 					mplsLabels = append(mplsLabels, uint32(uv))
 				}
 
+			// VRF
+			case netflow.IPFIX_FIELD_ingressVRFID:
+				bf.AppendUint(schema.ColumnIngressVRFID, decodeUNumber(v))
+			case netflow.IPFIX_FIELD_egressVRFID:
+				bf.AppendUint(schema.ColumnEgressVRFID, decodeUNumber(v))
+
 			// Remaining
 			case netflow.IPFIX_FIELD_forwardingStatus:
 				bf.AppendUint(schema.ColumnForwardingStatus, decodeUNumber(v))

--- a/outlet/flow/decoder/netflow/root_test.go
+++ b/outlet/flow/decoder/netflow/root_test.go
@@ -152,6 +152,8 @@ func TestDecode(t *testing.T) {
 				schema.ColumnForwardingStatus: uint32(64),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
 				schema.ColumnTCPFlags:         uint16(16),
+				schema.ColumnIngressVRFID:     uint32(1610612738),
+				schema.ColumnEgressVRFID:      uint32(1610612738),
 			},
 		}, {
 			SamplingRate:    30000,
@@ -173,6 +175,8 @@ func TestDecode(t *testing.T) {
 				schema.ColumnForwardingStatus: uint32(64),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
 				schema.ColumnTCPFlags:         uint16(16),
+				schema.ColumnIngressVRFID:     uint32(1610612738),
+				schema.ColumnEgressVRFID:      uint32(1610612738),
 			},
 		}, {
 			SamplingRate:    30000,
@@ -194,6 +198,8 @@ func TestDecode(t *testing.T) {
 				schema.ColumnForwardingStatus: uint32(64),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
 				schema.ColumnTCPFlags:         uint16(16),
+				schema.ColumnIngressVRFID:     uint32(1610612738),
+				schema.ColumnEgressVRFID:      uint32(1610612736),
 			},
 		}, {
 			SamplingRate:    30000,
@@ -215,6 +221,8 @@ func TestDecode(t *testing.T) {
 				schema.ColumnForwardingStatus: uint32(64),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
 				schema.ColumnTCPFlags:         uint16(16),
+				schema.ColumnIngressVRFID:     uint32(1610612738),
+				schema.ColumnEgressVRFID:      uint32(1610612738),
 			},
 		},
 	}
@@ -375,6 +383,8 @@ func TestDecodeMultipleSamplingRates(t *testing.T) {
 				schema.ColumnTCPFlags:         uint16(16),
 				schema.ColumnEType:            uint32(constants.ETypeIPv6),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
+				schema.ColumnIngressVRFID:     uint32(1610612736),
+				schema.ColumnEgressVRFID:      uint32(1610612736),
 			},
 		},
 		{
@@ -399,6 +409,8 @@ func TestDecodeMultipleSamplingRates(t *testing.T) {
 				schema.ColumnIPv6FlowLabel:    uint32(570164),
 				schema.ColumnEType:            uint32(constants.ETypeIPv6),
 				schema.ColumnFlowDirection:    uint8(schema.DirectionIngress),
+				schema.ColumnIngressVRFID:     uint32(1610612736),
+				schema.ColumnEgressVRFID:      uint32(1610612736),
 			},
 		},
 	}
@@ -588,6 +600,7 @@ func TestDecodeMPLS(t *testing.T) {
 				schema.ColumnDstPort:          uint16(862),
 				schema.ColumnMPLSLabels:       []uint32{20005, 524250},
 				schema.ColumnFlowDirection:    uint8(schema.DirectionEgress),
+				schema.ColumnEgressVRFID:      uint32(1),
 			},
 		}, {
 			ExporterAddress: netip.MustParseAddr("::ffff:127.0.0.1"),
@@ -607,6 +620,7 @@ func TestDecodeMPLS(t *testing.T) {
 				schema.ColumnDstPort:          uint16(862),
 				schema.ColumnMPLSLabels:       []uint32{20006, 524275},
 				schema.ColumnFlowDirection:    uint8(schema.DirectionEgress),
+				schema.ColumnEgressVRFID:      uint32(1),
 			},
 		},
 	}
@@ -803,15 +817,16 @@ func TestDecodePhysicalInterfaces(t *testing.T) {
 			DstAddr:         netip.MustParseAddr("::ffff:212.82.101.24"),
 			NextHop:         netip.MustParseAddr("::"),
 			OtherColumns: map[schema.ColumnKey]any{
-				schema.ColumnSrcMAC:   uint64(0xc014fef6c365),
-				schema.ColumnDstMAC:   uint64(0xe8b6c24ae34c),
-				schema.ColumnPackets:  uint64(3),
-				schema.ColumnBytes:    uint64(4506),
-				schema.ColumnSrcPort:  uint16(55629),
-				schema.ColumnDstPort:  uint16(993),
-				schema.ColumnTCPFlags: uint16(0x10),
-				schema.ColumnEType:    uint32(constants.ETypeIPv4),
-				schema.ColumnProto:    uint32(constants.ProtoTCP),
+				schema.ColumnSrcMAC:       uint64(0xc014fef6c365),
+				schema.ColumnDstMAC:       uint64(0xe8b6c24ae34c),
+				schema.ColumnPackets:      uint64(3),
+				schema.ColumnBytes:        uint64(4506),
+				schema.ColumnSrcPort:      uint16(55629),
+				schema.ColumnDstPort:      uint16(993),
+				schema.ColumnTCPFlags:     uint16(0x10),
+				schema.ColumnEType:        uint32(constants.ETypeIPv4),
+				schema.ColumnProto:        uint32(constants.ProtoTCP),
+				schema.ColumnIngressVRFID: uint32(311),
 			},
 		},
 	}


### PR DESCRIPTION
Add support for decoding IPFIX VRF IDs into optional flow columns:

- ingressVRFID (234) -> IngressVRFID
- egressVRFID (235) -> EgressVRFID

The new columns are disabled by default and can be enabled through the schema
configuration, like other optional flow fields.

This covers the raw VRF ID fields from flow records. It does not implement
VRF-aware network classification or routing enrichment.

Refs #54

Tests:
- go test ./common/schema ./outlet/flow/decoder/netflow
- go test ./console/query