### PR TITLE
schema: add fixed-length /24 prefix dimensions (SrcNetPrefix24/DstNetPrefix24)

### DIFF
--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -154,6 +154,8 @@ const (
 	ColumnDstNetMask
 	ColumnSrcNetPrefix
 	ColumnDstNetPrefix
+	ColumnSrcNetPrefix24
+	ColumnDstNetPrefix24
 	ColumnSrcAS
 	ColumnDstAS
 	ColumnSrcVlan
@@ -294,6 +296,17 @@ func flows() Schema {
 				ClickHouseAlias: `CASE
  WHEN EType = 0x800 THEN concat(replaceRegexpOne(IPv6CIDRToRange(SrcAddr, (96 + SrcNetMask)::UInt8).1::String, '^::ffff:', ''), '/', SrcNetMask::String)
  WHEN EType = 0x86dd THEN concat(IPv6CIDRToRange(SrcAddr, SrcNetMask).1::String, '/', SrcNetMask::String)
+ ELSE ''
+END`,
+			},
+			{
+				Key:                        ColumnSrcNetPrefix24,
+				ParserType:                 "prefix",
+				ClickHouseMainOnly:         true,
+				ClickHouseType:             "String",
+				ClickHouseMaterializedType: "LowCardinality(String)",
+				ClickHouseAlias: `CASE
+ WHEN EType = 0x800 THEN concat(replaceRegexpOne(IPv6CIDRToRange(SrcAddr, (96 + 24)::UInt8).1::String, '^::ffff:', ''), '/24')
  ELSE ''
 END`,
 			},


### PR DESCRIPTION
## What

Adds two computed dimensions, `SrcNetPrefix24` and `DstNetPrefix24`, that aggregate the source/destination **IPv4** address to its containing **/24**.

## Why

`SrcNetPrefix`/`DstNetPrefix` use a variable prefix length taken from the routing table, so the same traffic can spread across rows of different lengths (a `/22` aggregate, its more-specifics, etc.). For inter-domain traffic engineering the natural unit is the **/24 — the minimum BGP announcement/balancing unit**. Bucketing to a fixed /24 puts each /24 on a single row with its true total, so an operator can decide at a glance whether to deaggregate/rebalance a given /24.

This is particularly useful for a **transit AS whose destinations include downstream customers' own prefixes** (their ASNs/IPs), where a static `networks` list doesn't scale — the /24 bucket is agnostic to who owns the prefix.

## Implementation

- Computed **alias** column (no storage cost), mirroring the existing `NetPrefix` column but with the mask fixed to `24`.
- Only the `Src` column is defined; the `Dst` variant is generated automatically via the existing `Src -> Dst` expansion.
- IPv4 only (`EType = 0x800`); IPv6 yields an empty string.

Happy to generalize this into a **configurable prefix length** (and/or an IPv6 counterpart such as /48) if that direction is preferred — this is the minimal version to start the discussion.
