### PR TITLE
common/sqlbuilder: introduce a Fluent-like SQL builder for ClickHouse

### DIFF
--- a/common/clickhousedb/tests.go
+++ b/common/clickhousedb/tests.go
@@ -41,31 +41,31 @@ func setupClickHouseDatabase(t *testing.T, servers []string, cluster string) str
 	if err != nil {
 		t.Fatalf("clickhouse.Open() error:\n%+v", err)
 	}
-	db := sb.QuoteIdentifier(database)
-	for _, query := range []string{
-		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", db),
-		"DROP TABLE IF EXISTS system.metric_log",
+	for _, statement := range []sb.Statement{
+		sb.CreateDatabase(database),
+		sb.DropTable(sb.Table("metric_log").In("system")),
 	} {
-		if cluster != "" {
-			query = TransformQueryOnCluster(query, cluster)
-		}
+		query := onClusterSQL(statement, cluster)
 		if err := conn.Exec(t.Context(), query); err != nil {
 			t.Fatalf("Exec(%q) error:\n%+v", query, err)
 		}
 	}
 	t.Cleanup(func() {
 		defer conn.Close()
-		query := fmt.Sprintf("DROP DATABASE IF EXISTS %s", db)
-		if cluster != "" {
-			query = TransformQueryOnCluster(query, cluster)
-		}
 		// This is important to NOT use t.Context() as it is already cancelled
 		// at this point.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		conn.Exec(ctx, query)
+		conn.Exec(ctx, onClusterSQL(sb.DropDatabase(database), cluster))
 	})
 	return database
+}
+
+// Servers returns the addresses of the ClickHouse servers the component talks
+// to. A query only goes to one of them, so this is for a test needing to reach
+// each server of a cluster on its own.
+func (c *Component) Servers() []string {
+	return c.config.Servers
 }
 
 // SetupClickHouse configures a client to use for testing. A random database is
@@ -78,9 +78,17 @@ func SetupClickHouse(t *testing.T, r *reporter.Reporter, cluster bool) *Componen
 			helpers.CheckExternalService(t, "ClickHouse", []string{"clickhouse:9000", "127.0.0.1:9000"}),
 		}
 	} else {
-		config.Servers = []string{
-			helpers.CheckExternalService(t, "ClickHouse cluster", []string{"clickhouse-3:9000", "127.0.0.1:9003"}),
+		// Each server of the test cluster, either from another container or
+		// from the host. See docker-compose-dev.yml.
+		servers := []string{}
+		for _, candidates := range [][]string{
+			{"clickhouse-1:9000", "127.0.0.1:9001"},
+			{"clickhouse-3:9000", "127.0.0.1:9003"},
+		} {
+			servers = append(servers,
+				helpers.CheckExternalService(t, "ClickHouse cluster", candidates))
 		}
+		config.Servers = servers
 		config.Cluster = "akvorado"
 	}
 	config.DialTimeout = 5 * time.Second

--- a/common/clickhousedb/tests.go
+++ b/common/clickhousedb/tests.go
@@ -19,6 +19,7 @@ import (
 	"akvorado/common/daemon"
 	"akvorado/common/helpers"
 	"akvorado/common/reporter"
+	sb "akvorado/common/sqlbuilder"
 )
 
 // SetupClickHouseDatabase creates a temporary ClickHouse database and returns
@@ -40,7 +41,7 @@ func setupClickHouseDatabase(t *testing.T, servers []string, cluster string) str
 	if err != nil {
 		t.Fatalf("clickhouse.Open() error:\n%+v", err)
 	}
-	db := QuoteIdentifier(database)
+	db := sb.QuoteIdentifier(database)
 	for _, query := range []string{
 		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", db),
 		"DROP TABLE IF EXISTS system.metric_log",

--- a/common/clickhousedb/utils.go
+++ b/common/clickhousedb/utils.go
@@ -8,23 +8,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	sb "akvorado/common/sqlbuilder"
 )
-
-// bareIdentifierRegexp tells which identifiers do not need to be quoted. See
-// https://clickhouse.com/docs/sql-reference/syntax#identifiers for the official
-// regex.
-var bareIdentifierRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-
-// QuoteIdentifier quotes a ClickHouse identifier (table name, column name,
-// database name, cluster name, etc.) using backtick escaping. Identifiers that
-// are already valid bare identifiers are returned unchanged. This is not 100%
-// complete as keywords also needs to be quoted!
-func QuoteIdentifier(name string) string {
-	if bareIdentifierRegexp.MatchString(name) {
-		return name
-	}
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
-}
 
 // ExecOnCluster executes a query on a cluster. It's a wrapper around Exec()
 // invoking TransformQueryOnCluster.
@@ -92,5 +78,5 @@ func TransformQueryOnCluster(query, cluster string) string {
 		return query
 	}
 
-	return fmt.Sprintf("%s ON CLUSTER %s%s", prefix, QuoteIdentifier(cluster), query[len(prefix):])
+	return fmt.Sprintf("%s ON CLUSTER %s%s", prefix, sb.QuoteIdentifier(cluster), query[len(prefix):])
 }

--- a/common/clickhousedb/utils.go
+++ b/common/clickhousedb/utils.go
@@ -5,78 +5,22 @@ package clickhousedb
 
 import (
 	"context"
-	"fmt"
-	"regexp"
-	"strings"
 
 	sb "akvorado/common/sqlbuilder"
 )
 
-// ExecOnCluster executes a query on a cluster. It's a wrapper around Exec()
-// invoking TransformQueryOnCluster.
-func (c *Component) ExecOnCluster(ctx context.Context, query string, args ...any) error {
-	if c.config.Cluster != "" {
-		query = TransformQueryOnCluster(query, c.config.Cluster)
-	}
-	return c.Exec(ctx, query, args...)
+// ExecOnCluster executes a statement. When a cluster is configured, the
+// statement gets an ON CLUSTER clause first, so ClickHouse runs it on every
+// server of the cluster.
+func (c *Component) ExecOnCluster(ctx context.Context, statement sb.Statement, args ...any) error {
+	return c.Exec(ctx, onClusterSQL(statement, c.config.Cluster), args...)
 }
 
-var (
-	spacesRegexp                   = regexp.MustCompile(`\s+`)
-	statementBeforeOnClusterRegexp = regexp.MustCompile(fmt.Sprintf("^((?i)%s)", strings.Join([]string{
-		`ALTER TABLE \S+`,
-		`ATTACH DICTIONARY \S+`,
-		`(ATTACH|CREATE) DATABASE( IF NOT EXISTS)? \S+`,
-		`(ATTACH|CREATE( OR REPLACE)?|REPLACE) DICTIONARY( IF NOT EXISTS)? \S+`,
-		`(ATTACH|CREATE) LIVE VIEW (IF NOT EXISTS)? \S+`,
-		`(ATTACH|CREATE) MATERIALIZED VIEW( IF NOT EXISTS)? \S+`,
-		`(ATTACH|CREATE( OR REPLACE)?|REPLACE)( TEMPORARY)? TABLE( IF NOT EXISTS)? \S+`,
-		`(DETACH|DROP) DATABASE( IF EXISTS)? \S+`,
-		`(DETACH|DROP) (DICTIONARY|(TEMPORARY )?TABLE|VIEW)( IF EXISTS?) \S+`,
-		`KILL MUTATION`,
-		`OPTIMIZE TABLE \S+`,
-		`RENAME TABLE \S+ TO \S+`, // this is incomplete
-		`TRUNCATE( TEMPORARY)?( TABLE)?( IF EXISTS)? \S+`,
-		// not part of the grammar
-		`SYSTEM RELOAD DICTIONARIES`,
-		`SYSTEM RELOAD DICTIONARY`,
-	}, "|")))
-)
-
-// TransformQueryOnCluster turns a ClickHouse query into its equivalent to be
-// run on a cluster by adding the ON CLUSTER directive.
-func TransformQueryOnCluster(query, cluster string) string {
-	// From utils/antlr/ClickHouseParser.g4:
-	//
-	// ALTER TABLE tableIdentifier clusterClause? alterTableClause (COMMA alterTableClause)*
-	// ATTACH DICTIONARY tableIdentifier clusterClause?
-	// (ATTACH | CREATE) DATABASE (IF NOT EXISTS)? databaseIdentifier clusterClause? engineExpr?
-	// (ATTACH | CREATE (OR REPLACE)? | REPLACE) DICTIONARY (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? dictionarySchemaClause dictionaryEngineClause
-	// (ATTACH | CREATE) LIVE VIEW (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? (WITH TIMEOUT DECIMAL_LITERAL?)? destinationClause? tableSchemaClause? subqueryClause
-	// (ATTACH | CREATE) MATERIALIZED VIEW (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? tableSchemaClause? (destinationClause | engineClause POPULATE?) subqueryClause
-	// (ATTACH | CREATE (OR REPLACE)? | REPLACE) TEMPORARY? TABLE (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? tableSchemaClause? engineClause? subqueryClause?
-	// (ATTACH | CREATE) (OR REPLACE)? VIEW (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? tableSchemaClause? subqueryClause
-	// (DETACH | DROP) DATABASE (IF EXISTS)? databaseIdentifier clusterClause?
-	// (DETACH | DROP) (DICTIONARY | TEMPORARY? TABLE | VIEW) (IF EXISTS)? tableIdentifier clusterClause? (NO DELAY)?
-	// KILL MUTATION clusterClause? whereClause (SYNC | ASYNC | TEST)?
-	// OPTIMIZE TABLE tableIdentifier clusterClause? partitionClause? FINAL? DEDUPLICATE?;
-	// RENAME TABLE tableIdentifier TO tableIdentifier (COMMA tableIdentifier TO tableIdentifier)* clusterClause?;
-	// TRUNCATE TEMPORARY? TABLE? (IF EXISTS)? tableIdentifier clusterClause?;
-
-	// In ClickHouse, an identifier uses the following syntax:
-	//
-	// IDENTIFIER
-	//     : (LETTER | UNDERSCORE) (LETTER | UNDERSCORE | DEC_DIGIT)*
-	//     | BACKQUOTE ( ~([\\`]) | (BACKSLASH .) | (BACKQUOTE BACKQUOTE) )* BACKQUOTE
-	//     | QUOTE_DOUBLE ( ~([\\"]) | (BACKSLASH .) | (QUOTE_DOUBLE QUOTE_DOUBLE) )* QUOTE_DOUBLE
-	//     ;
-	//
-	// Since we don't have to accept everything, we simplify it to \S+.
-	query = strings.TrimSpace(spacesRegexp.ReplaceAllString(query, " "))
-	prefix := statementBeforeOnClusterRegexp.FindString(query)
-	if prefix == "" {
-		return query
+// onClusterSQL renders a statement as SQL, adding the ON CLUSTER clause when a
+// cluster is provided.
+func onClusterSQL(statement sb.Statement, cluster string) string {
+	if cluster == "" {
+		return statement.String()
 	}
-
-	return fmt.Sprintf("%s ON CLUSTER %s%s", prefix, sb.QuoteIdentifier(cluster), query[len(prefix):])
+	return statement.OnCluster(cluster).String()
 }

--- a/common/clickhousedb/utils_test.go
+++ b/common/clickhousedb/utils_test.go
@@ -6,89 +6,33 @@ package clickhousedb
 import (
 	"testing"
 
-	"akvorado/common/helpers"
+	"go.uber.org/mock/gomock"
+
+	"akvorado/common/reporter"
+	sb "akvorado/common/sqlbuilder"
 )
 
-func TestTransformQueryOnCluster(t *testing.T) {
-	cases := []struct {
-		Pos      helpers.Pos
-		Input    string
-		Cluster  string
-		Expected string
-	}{
-		{helpers.Mark(), "SYSTEM RELOAD DICTIONARIES", "akvorado", "SYSTEM RELOAD DICTIONARIES ON CLUSTER akvorado"},
-		{helpers.Mark(), "system reload dictionaries", "akvorado", "system reload dictionaries ON CLUSTER akvorado"},
-		{helpers.Mark(), "  system reload  dictionaries ", "akvorado", "system reload dictionaries ON CLUSTER akvorado"},
-		{helpers.Mark(), "DROP DATABASE IF EXISTS 02028_db", "akvorado", "DROP DATABASE IF EXISTS 02028_db ON CLUSTER akvorado"},
-		{
-			helpers.Mark(),
-			"CREATE TABLE test_01148_atomic.rmt2 (n int, PRIMARY KEY n) ENGINE=ReplicatedMergeTree",
-			"akvorado",
-			"CREATE TABLE test_01148_atomic.rmt2 ON CLUSTER akvorado (n int, PRIMARY KEY n) ENGINE=ReplicatedMergeTree",
-		},
-		{
-			helpers.Mark(),
-			"DROP TABLE IF EXISTS test_repl NO DELAY",
-			"akvorado",
-			"DROP TABLE IF EXISTS test_repl ON CLUSTER akvorado NO DELAY",
-		},
-		{
-			helpers.Mark(),
-			"ALTER TABLE 02577_keepermap_delete_update UPDATE value2 = value2 * 10 + 2 WHERE value2 < 100",
-			"akvorado",
-			"ALTER TABLE 02577_keepermap_delete_update ON CLUSTER akvorado UPDATE value2 = value2 * 10 + 2 WHERE value2 < 100",
-		},
-		{
-			helpers.Mark(), "ATTACH DICTIONARY db_01018.dict1",
-			"akvorado",
-			"ATTACH DICTIONARY db_01018.dict1 ON CLUSTER akvorado",
-		},
-		{
-			helpers.Mark(),
-			`CREATE DICTIONARY default.asns
-(
-    asn UInt32 INJECTIVE,
-    name String
-)
-PRIMARY KEY asn
-SOURCE(HTTP(URL 'http://akvorado-orchestrator:8080/api/v0/orchestrator/clickhouse/asns.csv' FORMAT 'CSVWithNames'))
-LIFETIME(MIN 0 MAX 3600)
-LAYOUT(HASHED())
-SETTINGS(format_csv_allow_single_quotes = 0)`,
-			"akvorado",
-			`CREATE DICTIONARY default.asns ON CLUSTER akvorado ( asn UInt32 INJECTIVE, name String ) PRIMARY KEY asn SOURCE(HTTP(URL 'http://akvorado-orchestrator:8080/api/v0/orchestrator/clickhouse/asns.csv' FORMAT 'CSVWithNames')) LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED()) SETTINGS(format_csv_allow_single_quotes = 0)`,
-		},
-		{
-			helpers.Mark(),
-			`
-CREATE TABLE queue (
-    timestamp UInt64,
-    level String,
-    message String
-  ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow')
-`,
-			"akvorado",
-			`CREATE TABLE queue ON CLUSTER akvorado ( timestamp UInt64, level String, message String ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow')`,
-		},
-		{
-			helpers.Mark(),
-			`
-CREATE MATERIALIZED VIEW consumer TO daily
-AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() as total
-FROM queue GROUP BY day, level
-`,
-			"akvorado",
-			`CREATE MATERIALIZED VIEW consumer ON CLUSTER akvorado TO daily AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() as total FROM queue GROUP BY day, level`,
-		},
-		// Cluster name needing quoting
-		{helpers.Mark(), "SYSTEM RELOAD DICTIONARIES", "my-cluster", "SYSTEM RELOAD DICTIONARIES ON CLUSTER `my-cluster`"},
-		// Not modified
-		{helpers.Mark(), "SELECT 1", "akvorado", "SELECT 1"},
-	}
-	for _, tc := range cases {
-		got := TransformQueryOnCluster(tc.Input, tc.Cluster)
-		if diff := helpers.Diff(got, tc.Expected); diff != "" {
-			t.Errorf("%sTransformQueryOnCluster() (-got +want):\n%s", tc.Pos, diff)
+func TestExecOnCluster(t *testing.T) {
+	t.Run("without cluster", func(t *testing.T) {
+		r := reporter.NewMock(t)
+		c, mock := NewMock(t, r)
+		mock.EXPECT().
+			Exec(gomock.Any(), sb.SQLMatcher(t, "DROP TABLE IF EXISTS flows SYNC")).
+			Return(nil)
+		if err := c.ExecOnCluster(t.Context(), sb.DropTable(sb.Table("flows"))); err != nil {
+			t.Fatalf("ExecOnCluster() error:\n%+v", err)
 		}
-	}
+	})
+
+	t.Run("with cluster", func(t *testing.T) {
+		r := reporter.NewMock(t)
+		c, mock := NewMock(t, r)
+		c.config.Cluster = "akvorado"
+		mock.EXPECT().
+			Exec(gomock.Any(), sb.SQLMatcher(t, "DROP TABLE IF EXISTS flows ON CLUSTER akvorado SYNC")).
+			Return(nil)
+		if err := c.ExecOnCluster(t.Context(), sb.DropTable(sb.Table("flows"))); err != nil {
+			t.Fatalf("ExecOnCluster() error:\n%+v", err)
+		}
+	})
 }

--- a/common/clickhousedb/utils_test.go
+++ b/common/clickhousedb/utils_test.go
@@ -9,29 +9,6 @@ import (
 	"akvorado/common/helpers"
 )
 
-func TestQuoteIdentifier(t *testing.T) {
-	cases := []struct {
-		Pos      helpers.Pos
-		Input    string
-		Expected string
-	}{
-		{helpers.Mark(), "akvorado", "akvorado"},
-		{helpers.Mark(), "simple_name", "simple_name"},
-		{helpers.Mark(), "_leading", "_leading"},
-		{helpers.Mark(), "my`cluster", "`my``cluster`"},
-		{helpers.Mark(), "with spaces", "`with spaces`"},
-		{helpers.Mark(), "with-dash", "`with-dash`"},
-		{helpers.Mark(), "123start", "`123start`"},
-		{helpers.Mark(), "", "``"},
-	}
-	for _, tc := range cases {
-		got := QuoteIdentifier(tc.Input)
-		if diff := helpers.Diff(got, tc.Expected); diff != "" {
-			t.Errorf("%sQuoteIdentifier(%q) (-got, +want):\n%s", tc.Pos, tc.Input, diff)
-		}
-	}
-}
-
 func TestTransformQueryOnCluster(t *testing.T) {
 	cases := []struct {
 		Pos      helpers.Pos

--- a/common/sqlbuilder/ddl.go
+++ b/common/sqlbuilder/ddl.go
@@ -6,6 +6,7 @@ package sqlbuilder
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/AfterShip/clickhouse-sql-parser/parser"
 )
@@ -40,6 +41,15 @@ func (t TableName) node() *parser.TableIdentifier {
 	return identifier
 }
 
+// Statement is a complete SQL statement, whatever it was built from.
+type Statement interface {
+	// String renders the statement as SQL.
+	String() string
+	// OnCluster adds an ON CLUSTER clause to the statement. The statement it
+	// is called on is modified, not copied.
+	OnCluster(cluster string) Statement
+}
+
 // statement is embedded in the statement builders below. It carries how a
 // statement is rendered and compared.
 type statement struct {
@@ -63,6 +73,38 @@ func (s statement) Matches(sql string) bool {
 	}
 	theirs, ok := canonical(sql)
 	return ok && mine == theirs
+}
+
+// OnCluster adds an ON CLUSTER clause to the statement, so ClickHouse runs it on
+// every server of the cluster. The statement is modified, not copied. A
+// statement not accepting the clause, like SELECT, is left as is.
+func (s statement) OnCluster(cluster string) Statement {
+	withCluster(s.node, cluster)
+	return s
+}
+
+// withCluster sets the ON CLUSTER clause of a node. The node is modified. A
+// node without such a field, like SELECT, is left as is.
+func withCluster(node parser.Expr, cluster string) {
+	const clusterField = "OnCluster"
+
+	// The SYSTEM statements carry the clause on the node below.
+	if system, ok := node.(*parser.SystemStmt); ok {
+		withCluster(system.Expr, cluster)
+		return
+	}
+
+	// Look for the cluster field for any other node.
+	value := reflect.ValueOf(node)
+	if value.Kind() != reflect.Pointer || value.Elem().Kind() != reflect.Struct {
+		return
+	}
+	field := value.Elem().FieldByName(clusterField)
+	if !field.IsValid() || field.Type() != reflect.TypeFor[*parser.ClusterClause]() {
+		return
+	}
+
+	field.Set(reflect.ValueOf(&parser.ClusterClause{Expr: ident(cluster)}))
 }
 
 // columnType is a ClickHouse type written as is. Types come from the schema as
@@ -496,5 +538,32 @@ func DropTable(name TableName) DropTableStatement {
 		Name:       name.node(),
 		IfExists:   true,
 		Modifier:   "SYNC",
+	}}}
+}
+
+// CreateDatabase builds a "CREATE DATABASE IF NOT EXISTS" statement.
+func CreateDatabase(name string) Statement {
+	return statement{node: &parser.CreateDatabase{
+		Name:        ident(name),
+		IfNotExists: true,
+	}}
+}
+
+// DropDatabase builds a "DROP DATABASE IF EXISTS … SYNC" statement. SYNC makes
+// ClickHouse wait for the database to be really gone, so it can be created
+// again right after.
+func DropDatabase(name string) Statement {
+	return statement{node: &parser.DropDatabase{
+		Name:     ident(name),
+		IfExists: true,
+		Modifier: "SYNC",
+	}}
+}
+
+// SystemReloadDictionary builds a "SYSTEM RELOAD DICTIONARY" statement.
+func SystemReloadDictionary(name TableName) Statement {
+	return statement{node: &parser.SystemStmt{Expr: &parser.SystemReloadExpr{
+		Type:       "DICTIONARY",
+		Dictionary: name.node(),
 	}}}
 }

--- a/common/sqlbuilder/ddl.go
+++ b/common/sqlbuilder/ddl.go
@@ -1,0 +1,500 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// TableName is the name of a table, a view or a dictionary.
+type TableName struct {
+	database string
+	name     string
+}
+
+// Table names a table in the current database.
+func Table(name string) TableName {
+	return TableName{name: name}
+}
+
+// In sets the database holding the table.
+func (t TableName) In(database string) TableName {
+	t.database = database
+	return t
+}
+
+// String returns the name as written in SQL.
+func (t TableName) String() string {
+	return parser.Format(t.node())
+}
+
+func (t TableName) node() *parser.TableIdentifier {
+	identifier := &parser.TableIdentifier{Table: ident(t.name)}
+	if t.database != "" {
+		identifier.Database = ident(t.database)
+	}
+	return identifier
+}
+
+// statement is embedded in the statement builders below. It carries how a
+// statement is rendered and compared.
+type statement struct {
+	node parser.Expr
+}
+
+// String renders the statement as indented, multi-line SQL.
+func (s statement) String() string {
+	formatter := parser.NewFormatter().WithBeautify()
+	formatter.WriteExpr(s.node)
+	return formatter.String()
+}
+
+// Matches tells if the provided SQL means the same as the statement. Only the
+// meaning is compared: layout and identifier quoting do not matter. SQL that
+// cannot be parsed never matches.
+func (s statement) Matches(sql string) bool {
+	mine, ok := canonical(parser.Format(s.node))
+	if !ok {
+		return false
+	}
+	theirs, ok := canonical(sql)
+	return ok && mine == theirs
+}
+
+// columnType is a ClickHouse type written as is. Types come from the schema as
+// text, they are not built here.
+type columnType string
+
+func (t columnType) Pos() parser.Pos {
+	return 0
+}
+func (t columnType) End() parser.Pos {
+	return 0
+}
+func (t columnType) Type() string {
+	return string(t)
+}
+func (t columnType) Accept(_ parser.ASTVisitor) error {
+	return nil
+}
+func (t columnType) FormatSQL(formatter *parser.Formatter) {
+	formatter.WriteString(string(t))
+}
+
+// ColumnDef is the definition of a column, as written between the parentheses
+// of a CREATE TABLE statement.
+type ColumnDef struct {
+	node *parser.ColumnDef
+}
+
+// NewColumnDef builds the definition of a column of the provided ClickHouse
+// type. The name is always quoted, like ClickHouse writes it back and like the
+// definitions coming from the schema.
+func NewColumnDef(name, typeName string) ColumnDef {
+	return ColumnDef{node: &parser.ColumnDef{
+		Name: &parser.NestedIdentifier{
+			Ident: &parser.Ident{Name: name, QuoteType: parser.BackTicks},
+		},
+		Type: columnType(typeName),
+	}}
+}
+
+// ParseColumnDefs parses a comma-separated list of column definitions, for
+// example "`SrcAddr` IPv6 CODEC(ZSTD(1)), `SrcNetMask` UInt8". Definitions come
+// from the schema as text, so they are parsed instead of being built.
+func ParseColumnDefs(sql string) ([]ColumnDef, error) {
+	statements, err := parse(fmt.Sprintf("CREATE TABLE t (%s)", sql))
+	if err != nil {
+		return nil, err
+	}
+	if len(statements) != 1 {
+		return nil, fmt.Errorf("expected one list of columns, got %d", len(statements))
+	}
+	create, ok := statements[0].(*parser.CreateTable)
+	if !ok || create.TableSchema == nil {
+		return nil, errors.New("not a list of columns")
+	}
+	defs := make([]ColumnDef, 0, len(create.TableSchema.Columns))
+	for _, column := range create.TableSchema.Columns {
+		def, ok := column.(*parser.ColumnDef)
+		if !ok {
+			return nil, fmt.Errorf("%q is not a column definition", parser.Format(column))
+		}
+		defs = append(defs, ColumnDef{node: def})
+	}
+	return defs, nil
+}
+
+// ParseColumnDef parses a single column definition.
+func ParseColumnDef(sql string) (ColumnDef, error) {
+	defs, err := ParseColumnDefs(sql)
+	if err != nil {
+		return ColumnDef{}, err
+	}
+	if len(defs) != 1 {
+		return ColumnDef{}, fmt.Errorf("expected one column, got %d", len(defs))
+	}
+	return defs[0], nil
+}
+
+// Engine is the engine of a table, with its parameters.
+type Engine struct {
+	name string
+	args []Expr
+}
+
+// NewEngine builds a table engine.
+func NewEngine(name string, args ...Expr) Engine {
+	return Engine{name: name, args: args}
+}
+
+// keyExpr turns a list of keys into what follows ORDER BY or PRIMARY KEY. A
+// single key needs no parentheses, this is also how ClickHouse writes it back.
+func keyExpr(exprs []Expr) parser.Expr {
+	if len(exprs) == 1 {
+		return exprs[0].node
+	}
+	return Tuple(exprs...).node
+}
+
+// CreateTableStatement builds a CREATE TABLE statement.
+type CreateTableStatement struct {
+	statement
+	create *parser.CreateTable
+}
+
+// CreateTable starts a CREATE TABLE statement.
+func CreateTable(name TableName) *CreateTableStatement {
+	create := &parser.CreateTable{Name: name.node()}
+	return &CreateTableStatement{statement{node: create}, create}
+}
+
+// OrReplace replaces the table when it already exists.
+func (s *CreateTableStatement) OrReplace() *CreateTableStatement {
+	s.create.OrReplace = true
+	return s
+}
+
+// Columns sets the columns of the table.
+func (s *CreateTableStatement) Columns(defs ...ColumnDef) *CreateTableStatement {
+	columns := make([]parser.Expr, len(defs))
+	for i, def := range defs {
+		columns[i] = def.node
+	}
+	s.create.TableSchema = &parser.TableSchemaClause{Columns: columns}
+	return s
+}
+
+// engine returns the engine clause, which also carries the clauses below it.
+func (s *CreateTableStatement) engine() *parser.EngineExpr {
+	if s.create.Engine == nil {
+		s.create.Engine = &parser.EngineExpr{}
+	}
+	return s.create.Engine
+}
+
+// Engine sets the engine of the table.
+func (s *CreateTableStatement) Engine(engine Engine) *CreateTableStatement {
+	node := s.engine()
+	node.Name = engine.name
+	node.Params = nil
+	if len(engine.args) > 0 {
+		node.Params = &parser.ParamExprList{
+			Items: &parser.ColumnExprList{Items: nodes(engine.args)},
+		}
+	}
+	return s
+}
+
+// PartitionBy sets the PARTITION BY clause.
+func (s *CreateTableStatement) PartitionBy(expr Expr) *CreateTableStatement {
+	s.engine().PartitionBy = &parser.PartitionByClause{Expr: expr.node}
+	return s
+}
+
+// PrimaryKey sets the PRIMARY KEY clause.
+func (s *CreateTableStatement) PrimaryKey(exprs ...Expr) *CreateTableStatement {
+	s.engine().PrimaryKey = &parser.PrimaryKeyClause{Expr: keyExpr(exprs)}
+	return s
+}
+
+// OrderBy sets the ORDER BY clause.
+func (s *CreateTableStatement) OrderBy(exprs ...Expr) *CreateTableStatement {
+	s.engine().OrderBy = &parser.OrderByClause{Items: []parser.Expr{keyExpr(exprs)}}
+	return s
+}
+
+// TTL sets the TTL clause.
+func (s *CreateTableStatement) TTL(expr Expr) *CreateTableStatement {
+	s.engine().TTL = &parser.TTLClause{Items: []*parser.TTLExpr{{Expr: expr.node}}}
+	return s
+}
+
+// Setting adds one entry to the SETTINGS clause.
+func (s *CreateTableStatement) Setting(name string, value Expr) *CreateTableStatement {
+	node := s.engine()
+	if node.Settings == nil {
+		node.Settings = &parser.SettingsClause{}
+	}
+	node.Settings.Items = append(node.Settings.Items,
+		&parser.SettingExpr{Name: ident(name), Expr: value.node})
+	return s
+}
+
+// CreateViewStatement builds a CREATE MATERIALIZED VIEW statement.
+type CreateViewStatement struct {
+	statement
+	view *parser.CreateMaterializedView
+}
+
+// CreateMaterializedView starts a CREATE MATERIALIZED VIEW statement feeding
+// the destination table with the result of the query.
+func CreateMaterializedView(name, destination TableName, query *Query) *CreateViewStatement {
+	view := &parser.CreateMaterializedView{
+		Name:        name.node(),
+		Destination: &parser.DestinationClause{TableIdentifier: destination.node()},
+		SubQuery:    &parser.SubQuery{Select: query.query},
+	}
+	return &CreateViewStatement{statement{node: view}, view}
+}
+
+// CreateDictionaryStatement builds a CREATE DICTIONARY statement.
+type CreateDictionaryStatement struct {
+	statement
+	dictionary *parser.CreateDictionary
+}
+
+// CreateDictionary starts a CREATE DICTIONARY statement.
+func CreateDictionary(name TableName) *CreateDictionaryStatement {
+	dictionary := &parser.CreateDictionary{
+		Name:   name.node(),
+		Schema: &parser.DictionarySchemaClause{},
+		Engine: &parser.DictionaryEngineClause{},
+	}
+	return &CreateDictionaryStatement{statement{node: dictionary}, dictionary}
+}
+
+// OrReplace replaces the dictionary when it already exists.
+func (s *CreateDictionaryStatement) OrReplace() *CreateDictionaryStatement {
+	s.dictionary.OrReplace = true
+	return s
+}
+
+// Attributes sets the attributes of the dictionary.
+func (s *CreateDictionaryStatement) Attributes(attributes ...DictionaryAttribute) *CreateDictionaryStatement {
+	s.dictionary.Schema.Attributes = make([]*parser.DictionaryAttribute, len(attributes))
+	for i, attribute := range attributes {
+		s.dictionary.Schema.Attributes[i] = attribute.node
+	}
+	return s
+}
+
+// PrimaryKey sets the primary key of the dictionary.
+func (s *CreateDictionaryStatement) PrimaryKey(keys ...Expr) *CreateDictionaryStatement {
+	s.dictionary.Engine.PrimaryKey = &parser.DictionaryPrimaryKeyClause{
+		Keys: &parser.ColumnExprList{Items: nodes(keys)},
+	}
+	return s
+}
+
+// Source sets where the dictionary reads its content from.
+func (s *CreateDictionaryStatement) Source(name string, params ...SourceParam) *CreateDictionaryStatement {
+	s.dictionary.Engine.Source = &parser.DictionarySourceClause{
+		Source: ident(name),
+		Args:   sourceParams(params),
+	}
+	return s
+}
+
+// Lifetime sets the range, in seconds, for how long the content stays valid.
+// ClickHouse picks a random value in it, so the dictionaries do not all reload
+// at the same time.
+func (s *CreateDictionaryStatement) Lifetime(shortest, longest uint64) *CreateDictionaryStatement {
+	s.dictionary.Engine.Lifetime = &parser.DictionaryLifetimeClause{
+		Min: &parser.NumberLiteral{Literal: fmt.Sprintf("%d", shortest)},
+		Max: &parser.NumberLiteral{Literal: fmt.Sprintf("%d", longest)},
+	}
+	return s
+}
+
+// Layout sets how the content is kept in memory.
+func (s *CreateDictionaryStatement) Layout(name string) *CreateDictionaryStatement {
+	s.dictionary.Engine.Layout = &parser.DictionaryLayoutClause{Layout: ident(name)}
+	return s
+}
+
+// Setting adds one entry to the SETTINGS clause.
+func (s *CreateDictionaryStatement) Setting(name string, value Expr) *CreateDictionaryStatement {
+	if s.dictionary.Engine.Settings == nil {
+		s.dictionary.Engine.Settings = &parser.SettingsClause{}
+	}
+	s.dictionary.Engine.Settings.Items = append(s.dictionary.Engine.Settings.Items,
+		&parser.SettingExpr{Name: ident(name), Expr: value.node})
+	return s
+}
+
+// DictionaryAttribute is one attribute of a dictionary.
+type DictionaryAttribute struct {
+	node *parser.DictionaryAttribute
+}
+
+// Attribute builds an attribute of the provided ClickHouse type.
+func Attribute(name, typeName string) DictionaryAttribute {
+	return DictionaryAttribute{node: &parser.DictionaryAttribute{
+		Name: ident(name),
+		Type: columnType(typeName),
+	}}
+}
+
+// Injective tells that two different keys never share the same value.
+func (a DictionaryAttribute) Injective() DictionaryAttribute {
+	a.node.Injective = true
+	return a
+}
+
+// Default sets the value used when the key is not found.
+func (a DictionaryAttribute) Default(value string) DictionaryAttribute {
+	a.node.Default = &parser.StringLiteral{Literal: stringEscaper.Replace(value)}
+	return a
+}
+
+// SourceParam is one parameter of the source of a dictionary.
+type SourceParam struct {
+	node *parser.DictionaryArgExpr
+}
+
+// Param builds a source parameter, as in "URL 'http://…'".
+func Param(name string, value Expr) SourceParam {
+	return SourceParam{node: &parser.DictionaryArgExpr{
+		Name:  ident(name),
+		Value: value.node,
+	}}
+}
+
+// ParamGroup builds a source parameter holding other parameters, as in
+// "CREDENTIALS(user 'u' password 'p')".
+func ParamGroup(name string, params ...SourceParam) SourceParam {
+	return SourceParam{node: &parser.DictionaryArgExpr{
+		Name: ident(name),
+		Args: sourceParams(params),
+		// The parentheses are only written when this position is set.
+		LParenPos: 1,
+	}}
+}
+
+func sourceParams(params []SourceParam) []*parser.DictionaryArgExpr {
+	args := make([]*parser.DictionaryArgExpr, len(params))
+	for i, param := range params {
+		args[i] = param.node
+	}
+	return args
+}
+
+// AlterTableStatement builds an ALTER TABLE statement. Several changes can be
+// gathered in a single statement, so ClickHouse applies them at once.
+type AlterTableStatement struct {
+	statement
+	alter *parser.AlterTable
+	// settings is the MODIFY SETTING clause, which holds every setting at
+	// once. ClickHouse does not accept it more than once in a statement.
+	settings *parser.AlterTableModifySetting
+}
+
+// AlterTable starts an ALTER TABLE statement with no change yet.
+func AlterTable(name TableName) *AlterTableStatement {
+	alter := &parser.AlterTable{TableIdentifier: name.node()}
+	return &AlterTableStatement{statement: statement{node: alter}, alter: alter}
+}
+
+// Len returns how many changes the statement carries.
+func (s *AlterTableStatement) Len() int {
+	return len(s.alter.AlterExprs)
+}
+
+func (s *AlterTableStatement) add(clause parser.AlterTableClause) *AlterTableStatement {
+	s.alter.AlterExprs = append(s.alter.AlterExprs, clause)
+	return s
+}
+
+// AddColumn adds a column after the one named. An empty name adds it first.
+func (s *AlterTableStatement) AddColumn(def ColumnDef, after string) *AlterTableStatement {
+	clause := &parser.AlterTableAddColumn{Column: def.node}
+	if after != "" {
+		clause.After = &parser.NestedIdentifier{Ident: ident(after)}
+	}
+	return s.add(clause)
+}
+
+// ModifyColumn changes the definition of an existing column.
+func (s *AlterTableStatement) ModifyColumn(def ColumnDef) *AlterTableStatement {
+	return s.add(&parser.AlterTableModifyColumn{Column: def.node})
+}
+
+// DropColumn removes a column.
+func (s *AlterTableStatement) DropColumn(name string) *AlterTableStatement {
+	return s.add(&parser.AlterTableDropColumn{
+		ColumnName: &parser.NestedIdentifier{Ident: ident(name)},
+	})
+}
+
+// ModifyOrderBy changes the sorting key of the table.
+func (s *AlterTableStatement) ModifyOrderBy(exprs ...Expr) *AlterTableStatement {
+	return s.add(&parser.AlterTableModifyOrderBy{OrderBy: Tuple(exprs...).node})
+}
+
+// ModifyTTL changes for how long the rows are kept.
+func (s *AlterTableStatement) ModifyTTL(expr Expr) *AlterTableStatement {
+	return s.add(&parser.AlterTableModifyTTL{
+		TTL: &parser.TTLClause{Items: []*parser.TTLExpr{{Expr: expr.node}}},
+	})
+}
+
+// ModifySetting changes one setting of the table. All the settings end up in a
+// single clause.
+func (s *AlterTableStatement) ModifySetting(name string, value Expr) *AlterTableStatement {
+	if s.settings == nil {
+		s.settings = &parser.AlterTableModifySetting{}
+		s.add(s.settings)
+	}
+	s.settings.Settings = append(s.settings.Settings,
+		&parser.SettingExpr{Name: ident(name), Expr: value.node})
+	return s
+}
+
+// AddIndex adds a skip index on a column.
+func (s *AlterTableStatement) AddIndex(name string, column, indexType Expr, granularity uint64) *AlterTableStatement {
+	return s.add(&parser.AlterTableAddIndex{Index: &parser.TableIndex{
+		Name:        &parser.NestedIdentifier{Ident: ident(name)},
+		ColumnExpr:  &parser.ColumnExpr{Expr: column.node},
+		ColumnType:  indexType.node,
+		Granularity: &parser.NumberLiteral{Literal: fmt.Sprintf("%d", granularity)},
+	}})
+}
+
+// DropIndex removes a skip index.
+func (s *AlterTableStatement) DropIndex(name string) *AlterTableStatement {
+	return s.add(&parser.AlterTableDropIndex{
+		IndexName: &parser.NestedIdentifier{Ident: ident(name)},
+	})
+}
+
+// DropTableStatement builds a DROP TABLE statement.
+type DropTableStatement struct {
+	statement
+}
+
+// DropTable builds a "DROP TABLE IF EXISTS … SYNC" statement. It also works on
+// a view. SYNC makes ClickHouse wait for the table to be really gone, so it can
+// be created again right after.
+func DropTable(name TableName) DropTableStatement {
+	return DropTableStatement{statement{node: &parser.DropStmt{
+		DropTarget: "TABLE",
+		Name:       name.node(),
+		IfExists:   true,
+		Modifier:   "SYNC",
+	}}}
+}

--- a/common/sqlbuilder/ddl.go
+++ b/common/sqlbuilder/ddl.go
@@ -107,23 +107,24 @@ func withCluster(node parser.Expr, cluster string) {
 	field.Set(reflect.ValueOf(&parser.ClusterClause{Expr: ident(cluster)}))
 }
 
-// columnType is a ClickHouse type written as is. Types come from the schema as
-// text, they are not built here.
-type columnType string
+// rawType is a ClickHouse type written as is. Types come from the schema as
+// text, they are not built here. They are not identifiers either: something
+// like "Array(UInt64)" would not survive quoting.
+type rawType string
 
-func (t columnType) Pos() parser.Pos {
+func (t rawType) Pos() parser.Pos {
 	return 0
 }
-func (t columnType) End() parser.Pos {
+func (t rawType) End() parser.Pos {
 	return 0
 }
-func (t columnType) Type() string {
+func (t rawType) Type() string {
 	return string(t)
 }
-func (t columnType) Accept(_ parser.ASTVisitor) error {
+func (t rawType) Accept(_ parser.ASTVisitor) error {
 	return nil
 }
-func (t columnType) FormatSQL(formatter *parser.Formatter) {
+func (t rawType) FormatSQL(formatter *parser.Formatter) {
 	formatter.WriteString(string(t))
 }
 
@@ -138,10 +139,8 @@ type ColumnDef struct {
 // definitions coming from the schema.
 func NewColumnDef(name, typeName string) ColumnDef {
 	return ColumnDef{node: &parser.ColumnDef{
-		Name: &parser.NestedIdentifier{
-			Ident: &parser.Ident{Name: name, QuoteType: parser.BackTicks},
-		},
-		Type: columnType(typeName),
+		Name: &parser.NestedIdentifier{Ident: backquotedIdent(name)},
+		Type: rawType(typeName),
 	}}
 }
 
@@ -388,7 +387,7 @@ type DictionaryAttribute struct {
 func Attribute(name, typeName string) DictionaryAttribute {
 	return DictionaryAttribute{node: &parser.DictionaryAttribute{
 		Name: ident(name),
-		Type: columnType(typeName),
+		Type: rawType(typeName),
 	}}
 }
 

--- a/common/sqlbuilder/ddl_test.go
+++ b/common/sqlbuilder/ddl_test.go
@@ -4,6 +4,7 @@
 package sqlbuilder_test
 
 import (
+	"strings"
 	"testing"
 
 	"akvorado/common/helpers"
@@ -85,6 +86,20 @@ func TestCreateTableOrReplace(t *testing.T) {
 	expected := "CREATE OR REPLACE TABLE flows (`TimeReceived` DateTime) ENGINE = Null"
 	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
 		t.Errorf("CreateTable() (-got, +want):\n%s", diff)
+	}
+}
+
+// TestCreateTableColumnEscaping checks the backticks of a column name are
+// doubled before the name is put between backticks. The parser stops on the
+// first backtick and cannot read such a name back, so the statement is only
+// checked as text.
+func TestCreateTableColumnEscaping(t *testing.T) {
+	got := sb.CreateTable(sb.Table("flows")).
+		Columns(sb.NewColumnDef("Src`Addr", "IPv6")).
+		Engine(sb.NewEngine("Null")).
+		String()
+	if !strings.Contains(got, "`Src``Addr` IPv6") {
+		t.Errorf("CreateTable() did not escape the column name:\n%s", got)
 	}
 }
 
@@ -434,7 +449,9 @@ func TestCreateDistributedTable(t *testing.T) {
 	sb.CheckStatement(t, got)
 }
 
-func TestQuoteIdentifier(t *testing.T) {
+// TestNameQuoting checks a name gets backticks only when it needs them. A table
+// name and a column name are written the same way.
+func TestNameQuoting(t *testing.T) {
 	cases := []struct {
 		Pos      helpers.Pos
 		Input    string
@@ -450,13 +467,11 @@ func TestQuoteIdentifier(t *testing.T) {
 		{helpers.Mark(), "", "``"},
 	}
 	for _, tc := range cases {
-		got := sb.QuoteIdentifier(tc.Input)
-		if diff := helpers.Diff(got, tc.Expected); diff != "" {
-			t.Errorf("%sQuoteIdentifier(%q) (-got, +want):\n%s", tc.Pos, tc.Input, diff)
-		}
-		// A table name is written the same way.
 		if diff := helpers.Diff(sb.Table(tc.Input).String(), tc.Expected); diff != "" {
 			t.Errorf("%sTable(%q).String() (-got, +want):\n%s", tc.Pos, tc.Input, diff)
+		}
+		if diff := helpers.Diff(sb.Column(tc.Input).String(), tc.Expected); diff != "" {
+			t.Errorf("%sColumn(%q).String() (-got, +want):\n%s", tc.Pos, tc.Input, diff)
 		}
 	}
 }

--- a/common/sqlbuilder/ddl_test.go
+++ b/common/sqlbuilder/ddl_test.go
@@ -216,6 +216,105 @@ func TestDropTable(t *testing.T) {
 	sb.CheckStatement(t, got)
 }
 
+func TestCreateDatabase(t *testing.T) {
+	got := sb.CreateDatabase("akvorado").String()
+	if diff := helpers.Diff(got, "CREATE DATABASE IF NOT EXISTS akvorado"); diff != "" {
+		t.Errorf("CreateDatabase() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestDropDatabase(t *testing.T) {
+	got := sb.DropDatabase("my db").String()
+	if diff := helpers.Diff(got, "DROP DATABASE IF EXISTS `my db` SYNC"); diff != "" {
+		t.Errorf("DropDatabase() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestSystemReloadDictionary(t *testing.T) {
+	got := sb.SystemReloadDictionary(sb.Table("asns").In("akvorado")).String()
+	if diff := helpers.Diff(got, "SYSTEM RELOAD DICTIONARY akvorado.asns"); diff != "" {
+		t.Errorf("SystemReloadDictionary() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestOnCluster(t *testing.T) {
+	cases := []struct {
+		Pos       helpers.Pos
+		Statement sb.Statement
+		Cluster   string
+		Expected  string
+	}{
+		{
+			helpers.Mark(),
+			sb.CreateTable(sb.Table("flows").In("akvorado")).
+				Columns(sb.NewColumnDef("TimeReceived", "DateTime")).
+				Engine(sb.NewEngine("Null")),
+			"akvorado",
+			"CREATE TABLE akvorado.flows ON CLUSTER akvorado (`TimeReceived` DateTime) ENGINE = Null",
+		}, {
+			helpers.Mark(),
+			sb.CreateMaterializedView(sb.Table("exporters_consumer"), sb.Table("exporters"),
+				sb.Select(sb.Column("TimeReceived")).From(sb.Table("flows"))),
+			"akvorado",
+			"CREATE MATERIALIZED VIEW exporters_consumer ON CLUSTER akvorado TO exporters " +
+				"AS SELECT TimeReceived FROM flows",
+		}, {
+			helpers.Mark(),
+			sb.CreateDictionary(sb.Table("asns")).
+				Attributes(sb.Attribute("asn", "UInt32")).
+				PrimaryKey(sb.Column("asn")).
+				Source("HTTP", sb.Param("URL", sb.String("http://127.0.0.1:8080/asns.csv"))).
+				Lifetime(0, 3600).
+				Layout("HASHED"),
+			"akvorado",
+			"CREATE DICTIONARY asns ON CLUSTER akvorado (asn UInt32) PRIMARY KEY asn " +
+				"SOURCE(HTTP(URL 'http://127.0.0.1:8080/asns.csv')) " +
+				"LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED())",
+		}, {
+			helpers.Mark(),
+			sb.AlterTable(sb.Table("flows")).DropColumn("SrcVlan"),
+			"akvorado",
+			"ALTER TABLE flows ON CLUSTER akvorado DROP COLUMN SrcVlan",
+		}, {
+			helpers.Mark(),
+			sb.DropTable(sb.Table("flows")),
+			"akvorado",
+			"DROP TABLE IF EXISTS flows ON CLUSTER akvorado SYNC",
+		}, {
+			helpers.Mark(),
+			sb.CreateDatabase("akvorado"),
+			"akvorado",
+			"CREATE DATABASE IF NOT EXISTS akvorado ON CLUSTER akvorado",
+		}, {
+			helpers.Mark(),
+			sb.DropDatabase("akvorado"),
+			"akvorado",
+			"DROP DATABASE IF EXISTS akvorado ON CLUSTER akvorado SYNC",
+		}, {
+			// For the SYSTEM statements, the clause comes before the name.
+			helpers.Mark(),
+			sb.SystemReloadDictionary(sb.Table("asns").In("akvorado")),
+			"akvorado",
+			"SYSTEM RELOAD DICTIONARY ON CLUSTER akvorado akvorado.asns",
+		}, {
+			// The cluster name is quoted like any other identifier.
+			helpers.Mark(),
+			sb.DropTable(sb.Table("flows")),
+			"my-cluster",
+			"DROP TABLE IF EXISTS flows ON CLUSTER `my-cluster` SYNC",
+		},
+	}
+	for _, tc := range cases {
+		got := tc.Statement.OnCluster(tc.Cluster)
+		if diff := helpers.Diff(got.String(), sb.Normalize(t, tc.Expected)); diff != "" {
+			t.Errorf("%sOnCluster() (-got, +want):\n%s", tc.Pos, diff)
+		}
+	}
+}
+
 func TestParseColumnDefsErrors(t *testing.T) {
 	cases := []string{
 		"SELECT 1",

--- a/common/sqlbuilder/ddl_test.go
+++ b/common/sqlbuilder/ddl_test.go
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder_test
+
+import (
+	"testing"
+
+	"akvorado/common/helpers"
+	sb "akvorado/common/sqlbuilder"
+)
+
+func TestTableName(t *testing.T) {
+	cases := []struct {
+		Description string
+		Table       sb.TableName
+		Expected    string
+	}{
+		{
+			Description: "bare name",
+			Table:       sb.Table("flows"),
+			Expected:    "flows",
+		}, {
+			Description: "with a database",
+			Table:       sb.Table("flows").In("akvorado"),
+			Expected:    "akvorado.flows",
+		}, {
+			Description: "name needing quotes",
+			Table:       sb.Table("flows-1").In("my db"),
+			Expected:    "`my db`.`flows-1`",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(tc.Table.String(), tc.Expected); diff != "" {
+				t.Errorf("String() (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateTable(t *testing.T) {
+	columns, err := sb.ParseColumnDefs(
+		"`TimeReceived` DateTime CODEC(DoubleDelta, LZ4),\n" +
+			"`ExporterAddress` LowCardinality(IPv6),\n" +
+			"`SrcNetPrefix` String ALIAS IPv6CIDRToRange(SrcAddr, SrcNetMask).1::String")
+	if err != nil {
+		t.Fatalf("ParseColumnDefs() error:\n%+v", err)
+	}
+	got := sb.CreateTable(sb.Table("flows").In("akvorado")).
+		Columns(columns...).
+		Engine(sb.NewEngine("SummingMergeTree", sb.Tuple(sb.Columns("Bytes", "Packets")...))).
+		PartitionBy(sb.Function("toYYYYMMDDhhmmss",
+			sb.Function("toStartOfInterval", sb.Column("TimeReceived"),
+				sb.Interval(sb.Uint(86400), "second")))).
+		PrimaryKey(sb.Function("toStartOfFiveMinutes", sb.Column("TimeReceived"))).
+		OrderBy(sb.Columns("TimeReceived", "ExporterAddress")...).
+		TTL(sb.Op(sb.Column("TimeReceived"), "+", sb.Function("toIntervalDay", sb.Uint(15)))).
+		Setting("index_granularity", sb.Uint(8192)).
+		String()
+	expected := `CREATE TABLE akvorado.flows
+(
+  ` + "`TimeReceived`" + ` DateTime CODEC(DoubleDelta, LZ4),
+  ` + "`ExporterAddress`" + ` LowCardinality(IPv6),
+  ` + "`SrcNetPrefix`" + ` String ALIAS IPv6CIDRToRange(SrcAddr, SrcNetMask).1::String
+)
+ENGINE = SummingMergeTree((Bytes, Packets))
+ORDER BY (TimeReceived, ExporterAddress)
+PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL 86400 second))
+PRIMARY KEY toStartOfFiveMinutes(TimeReceived)
+TTL TimeReceived + toIntervalDay(15)
+SETTINGS index_granularity=8192`
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("CreateTable() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestCreateTableOrReplace(t *testing.T) {
+	got := sb.CreateTable(sb.Table("flows")).
+		Columns(sb.NewColumnDef("TimeReceived", "DateTime")).
+		Engine(sb.NewEngine("Null")).
+		OrReplace().
+		String()
+	expected := "CREATE OR REPLACE TABLE flows (`TimeReceived` DateTime) ENGINE = Null"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("CreateTable() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestCreateMaterializedView(t *testing.T) {
+	query := sb.Select(
+		sb.Column("TimeReceived"),
+		sb.Alias(sb.Index(sb.Array(sb.Column("InIfName"), sb.Column("OutIfName")),
+			sb.Column("num")), "IfName")).
+		From(sb.Table("flows").In("akvorado")).
+		ArrayJoin(sb.Alias(sb.Function("arrayEnumerate",
+			sb.Array(sb.Uint(1), sb.Uint(2))), "num"))
+	view := sb.CreateMaterializedView(
+		sb.Table("exporters_consumer"), sb.Table("exporters"), query)
+	expected := `CREATE MATERIALIZED VIEW exporters_consumer TO exporters
+AS SELECT TimeReceived, [InIfName, OutIfName][num] AS IfName
+FROM akvorado.flows ARRAY JOIN arrayEnumerate([1, 2]) AS num`
+	if diff := helpers.Diff(view.String(), sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("CreateMaterializedView() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, view.String())
+}
+
+func TestCreateDictionary(t *testing.T) {
+	got := sb.CreateDictionary(sb.Table("asns").In("akvorado")).
+		Attributes(
+			sb.Attribute("asn", "UInt32").Injective(),
+			sb.Attribute("name", "String").Default("None")).
+		PrimaryKey(sb.Column("asn")).
+		Source("HTTP",
+			sb.Param("URL", sb.String("http://127.0.0.1:8080/asns.csv")),
+			sb.Param("FORMAT", sb.String("CSVWithNames")),
+			sb.ParamGroup("CREDENTIALS",
+				sb.Param("user", sb.String("alfred")),
+				sb.Param("password", sb.String("it's a secret")))).
+		Lifetime(0, 3600).
+		Layout("HASHED").
+		Setting("format_csv_allow_single_quotes", sb.Uint(0)).
+		String()
+	expected := `CREATE DICTIONARY akvorado.asns (asn UInt32 INJECTIVE, name String DEFAULT 'None')
+PRIMARY KEY asn
+SOURCE(HTTP(URL 'http://127.0.0.1:8080/asns.csv' FORMAT 'CSVWithNames' CREDENTIALS(user 'alfred' password 'it\'s a secret')))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED())
+SETTINGS(format_csv_allow_single_quotes = 0)`
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("CreateDictionary() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestAlterTable(t *testing.T) {
+	added, err := sb.ParseColumnDef("`SrcVlan` UInt16")
+	if err != nil {
+		t.Fatalf("ParseColumnDef() error:\n%+v", err)
+	}
+	modified, err := sb.ParseColumnDef("`SrcAS` UInt32 CODEC(ZSTD(1))")
+	if err != nil {
+		t.Fatalf("ParseColumnDef() error:\n%+v", err)
+	}
+	alter := sb.AlterTable(sb.Table("flows"))
+	if diff := helpers.Diff(alter.Len(), 0); diff != "" {
+		t.Errorf("Len() (-got, +want):\n%s", diff)
+	}
+	got := alter.
+		AddColumn(added, "SrcAddr").
+		ModifyColumn(modified).
+		DropColumn("DstVlan").
+		AddIndex("idx_srcas", sb.Column("SrcAS"), sb.MustParseExpr("set(100)"), 4).
+		DropIndex("idx_dstas").
+		ModifyOrderBy(sb.Columns("TimeReceived", "ExporterAddress")...).
+		String()
+	expected := "ALTER TABLE flows ADD COLUMN `SrcVlan` UInt16 AFTER SrcAddr, " +
+		"MODIFY COLUMN `SrcAS` UInt32 CODEC(ZSTD(1)), " +
+		"DROP COLUMN DstVlan, " +
+		"ADD INDEX idx_srcas SrcAS TYPE set(100) GRANULARITY 4, " +
+		"DROP INDEX idx_dstas, " +
+		"MODIFY ORDER BY (TimeReceived, ExporterAddress)"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("AlterTable() (-got, +want):\n%s", diff)
+	}
+	if diff := helpers.Diff(alter.Len(), 6); diff != "" {
+		t.Errorf("Len() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestAlterTableSettings(t *testing.T) {
+	// ClickHouse takes MODIFY SETTING only once, with every setting in it.
+	got := sb.AlterTable(sb.Table("flows")).
+		ModifySetting("index_granularity", sb.Uint(8192)).
+		ModifySetting("ttl_only_drop_parts", sb.Uint(1)).
+		String()
+	expected := "ALTER TABLE flows MODIFY SETTING index_granularity = 8192, ttl_only_drop_parts = 1"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("AlterTable() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestAlterTableTTL(t *testing.T) {
+	got := sb.AlterTable(sb.Table("flows")).
+		ModifyTTL(sb.Op(sb.Column("TimeReceived"), "+",
+			sb.Function("toIntervalSecond", sb.Uint(3600)))).
+		String()
+	expected := "ALTER TABLE flows MODIFY TTL TimeReceived + toIntervalSecond(3600)"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("AlterTable() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestAlterTableAddFirstColumn(t *testing.T) {
+	def, err := sb.ParseColumnDef("`TimeReceived` DateTime")
+	if err != nil {
+		t.Fatalf("ParseColumnDef() error:\n%+v", err)
+	}
+	got := sb.AlterTable(sb.Table("flows")).AddColumn(def, "").String()
+	expected := "ALTER TABLE flows ADD COLUMN `TimeReceived` DateTime"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("AlterTable() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestDropTable(t *testing.T) {
+	got := sb.DropTable(sb.Table("flows_consumer")).String()
+	if diff := helpers.Diff(got, "DROP TABLE IF EXISTS flows_consumer SYNC"); diff != "" {
+		t.Errorf("DropTable() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestParseColumnDefsErrors(t *testing.T) {
+	cases := []string{
+		"SELECT 1",
+		"`SrcAddr` IPv6(",
+		"INDEX idx_srcas SrcAS TYPE set(100) GRANULARITY 4",
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			if _, err := sb.ParseColumnDefs(tc); err == nil {
+				t.Errorf("ParseColumnDefs(%q) did not error", tc)
+			}
+		})
+	}
+	if _, err := sb.ParseColumnDef("`a` UInt8, `b` UInt8"); err == nil {
+		t.Error("ParseColumnDef() with two columns did not error")
+	}
+}
+
+func TestParseExprs(t *testing.T) {
+	exprs, err := sb.ParseExprs([]string{"SrcAS", "c_DstASPath AS DstASPath"})
+	if err != nil {
+		t.Fatalf("ParseExprs() error:\n%+v", err)
+	}
+	got := []string{exprs[0].String(), exprs[1].String()}
+	if diff := helpers.Diff(got, []string{"SrcAS", "c_DstASPath AS DstASPath"}); diff != "" {
+		t.Errorf("ParseExprs() (-got, +want):\n%s", diff)
+	}
+	if _, err := sb.ParseExprs([]string{"SrcAS", "toIPv6('::1'"}); err == nil {
+		t.Error("ParseExprs() did not error")
+	}
+}
+
+func TestMatches(t *testing.T) {
+	create := sb.CreateTable(sb.Table("flows").In("akvorado")).
+		Columns(sb.NewColumnDef("TimeReceived", "DateTime")).
+		Engine(sb.NewEngine("MergeTree")).
+		OrderBy(sb.Column("TimeReceived"))
+	cases := []struct {
+		Description string
+		SQL         string
+		Expected    bool
+	}{
+		{
+			Description: "same statement, another layout and quoting",
+			SQL:         "CREATE TABLE `akvorado`.`flows` (`TimeReceived` DateTime)\nENGINE = MergeTree\nORDER BY TimeReceived",
+			Expected:    true,
+		}, {
+			Description: "clauses in the order ClickHouse writes them",
+			SQL:         "CREATE TABLE akvorado.flows (`TimeReceived` DateTime) ENGINE = MergeTree ORDER BY TimeReceived",
+			Expected:    true,
+		}, {
+			Description: "another column type",
+			SQL:         "CREATE TABLE akvorado.flows (`TimeReceived` DateTime64) ENGINE = MergeTree ORDER BY TimeReceived",
+			Expected:    false,
+		}, {
+			Description: "another database",
+			SQL:         "CREATE TABLE other.flows (`TimeReceived` DateTime) ENGINE = MergeTree ORDER BY TimeReceived",
+			Expected:    false,
+		}, {
+			Description: "does not parse",
+			SQL:         "CREATE TABLE akvorado.flows (`TimeReceived` DateTime) ENGINE",
+			Expected:    false,
+		}, {
+			Description: "empty",
+			SQL:         "",
+			Expected:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(create.Matches(tc.SQL), tc.Expected); diff != "" {
+				t.Errorf("Matches(%q) (-got, +want):\n%s", tc.SQL, diff)
+			}
+		})
+	}
+}
+
+func TestMatchesQuery(t *testing.T) {
+	query := sb.Select(sb.Column("SrcAS")).From(sb.Table("flows").In("akvorado"))
+	if !query.Matches("SELECT SrcAS\nFROM `akvorado`.`flows`") {
+		t.Error("Matches() did not match the same query")
+	}
+	if query.Matches("SELECT DstAS FROM akvorado.flows") {
+		t.Error("Matches() matched another query")
+	}
+}
+
+// TestMatchesAliasColumn checks the shape ClickHouse writes back for the flows
+// table: a "::" cast in an ALIAS comes back as a CAST call.
+func TestMatchesAliasColumn(t *testing.T) {
+	columns, err := sb.ParseColumnDefs(
+		"`SrcNetPrefix` String ALIAS IPv6CIDRToRange(SrcAddr, (96 + SrcNetMask)::UInt8).1::String")
+	if err != nil {
+		t.Fatalf("ParseColumnDefs() error:\n%+v", err)
+	}
+	create := sb.CreateTable(sb.Table("flows")).Columns(columns...)
+	if create.Matches("CREATE TABLE flows (`SrcNetPrefix` String ALIAS CAST((IPv6CIDRToRange(SrcAddr, CAST(96 + SrcNetMask, 'UInt8'))).1, 'String'))") {
+		t.Error("Matches() matched a different alias")
+	}
+	if !create.Matches("CREATE TABLE flows (`SrcNetPrefix` String ALIAS IPv6CIDRToRange(SrcAddr, (96 + SrcNetMask)::UInt8).1::String)") {
+		t.Error("Matches() did not match the same alias")
+	}
+}
+
+func TestCreateDistributedTable(t *testing.T) {
+	got := sb.CreateTable(sb.Table("flows").In("akvorado")).
+		Columns(sb.NewColumnDef("TimeReceived", "DateTime")).
+		Engine(sb.NewEngine("Distributed",
+			sb.String("cluster"), sb.String("akvorado"), sb.String("flows_local"),
+			sb.Function("rand"))).
+		String()
+	expected := "CREATE TABLE akvorado.flows (`TimeReceived` DateTime)\n" +
+		"ENGINE = Distributed('cluster', 'akvorado', 'flows_local', rand())"
+	if diff := helpers.Diff(got, sb.Normalize(t, expected)); diff != "" {
+		t.Errorf("CreateTable() (-got, +want):\n%s", diff)
+	}
+	sb.CheckStatement(t, got)
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	cases := []struct {
+		Pos      helpers.Pos
+		Input    string
+		Expected string
+	}{
+		{helpers.Mark(), "akvorado", "akvorado"},
+		{helpers.Mark(), "simple_name", "simple_name"},
+		{helpers.Mark(), "_leading", "_leading"},
+		{helpers.Mark(), "my`cluster", "`my``cluster`"},
+		{helpers.Mark(), "with spaces", "`with spaces`"},
+		{helpers.Mark(), "with-dash", "`with-dash`"},
+		{helpers.Mark(), "123start", "`123start`"},
+		{helpers.Mark(), "", "``"},
+	}
+	for _, tc := range cases {
+		got := sb.QuoteIdentifier(tc.Input)
+		if diff := helpers.Diff(got, tc.Expected); diff != "" {
+			t.Errorf("%sQuoteIdentifier(%q) (-got, +want):\n%s", tc.Pos, tc.Input, diff)
+		}
+		// A table name is written the same way.
+		if diff := helpers.Diff(sb.Table(tc.Input).String(), tc.Expected); diff != "" {
+			t.Errorf("%sTable(%q).String() (-got, +want):\n%s", tc.Pos, tc.Input, diff)
+		}
+	}
+}

--- a/common/sqlbuilder/expr.go
+++ b/common/sqlbuilder/expr.go
@@ -211,6 +211,16 @@ func Array(items ...Expr) Expr {
 	})
 }
 
+// Index reads one element of an array, as in "[a, b][num]".
+func Index(array, index Expr) Expr {
+	return wrap(&parser.ObjectParams{
+		Object: array.node,
+		Params: &parser.ArrayParamList{
+			Items: &parser.ColumnExprList{Items: nodes([]Expr{index})},
+		},
+	})
+}
+
 // Between returns a BETWEEN condition.
 func Between(expr, low, high Expr) Expr {
 	return wrap(&parser.BetweenClause{Expr: expr.node, Between: low.node, And: high.node})

--- a/common/sqlbuilder/expr.go
+++ b/common/sqlbuilder/expr.go
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package sqlbuilder builds ClickHouse SQL as a syntax tree instead of text. It
+// is a thin layer on top of github.com/AfterShip/clickhouse-sql-parser: the
+// constructors here return nodes of its AST and the final SQL comes from its
+// formatter.
+//
+// A package needing its own building blocks defines them as transforms and
+// passes them to Expr.Apply or Query.Apply.
+package sqlbuilder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// Expr is a SQL expression. Its zero value means there is no expression and the
+// helpers below skip it instead of producing invalid SQL.
+type Expr struct {
+	node parser.Expr
+}
+
+// wrap builds an expression from a parser node.
+func wrap(node parser.Expr) Expr {
+	return Expr{node: node}
+}
+
+// nodes unwraps a list of expressions.
+func nodes(exprs []Expr) []parser.Expr {
+	result := make([]parser.Expr, len(exprs))
+	for i, expr := range exprs {
+		result[i] = expr.node
+	}
+	return result
+}
+
+// IsZero tells if there is no expression.
+func (e Expr) IsZero() bool {
+	return e.node == nil
+}
+
+// Apply passes the expression through the provided transforms, in order. Other
+// packages use it to add their own building blocks on top of this package. The
+// same expression can appear in several places of a query, so a transform has
+// to build a new expression around the one it gets.
+func (e Expr) Apply(transforms ...func(Expr) Expr) Expr {
+	for _, transform := range transforms {
+		e = transform(e)
+	}
+	return e
+}
+
+// String renders the expression as a single line of SQL.
+func (e Expr) String() string {
+	if e.IsZero() {
+		return ""
+	}
+	return parser.Format(e.node)
+}
+
+// pretty renders the expression as indented, multi-line SQL.
+func (e Expr) pretty() string {
+	if e.IsZero() {
+		return ""
+	}
+	formatter := parser.NewFormatter().WithBeautify()
+	formatter.WriteExpr(e.node)
+	return formatter.String()
+}
+
+// Column returns a reference to a column.
+func Column(name string) Expr {
+	return wrap(&parser.Ident{Name: name})
+}
+
+// Columns returns references to several columns.
+func Columns(names ...string) []Expr {
+	exprs := make([]Expr, len(names))
+	for i, name := range names {
+		exprs[i] = Column(name)
+	}
+	return exprs
+}
+
+var stringEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+
+// String returns a string literal. The value is escaped, so it is safe to use
+// with data coming from a user.
+func String(value string) Expr {
+	return wrap(&parser.StringLiteral{Literal: stringEscaper.Replace(value)})
+}
+
+// Uint returns an unsigned integer literal.
+func Uint(value uint64) Expr {
+	return wrap(&parser.NumberLiteral{Literal: fmt.Sprintf("%d", value)})
+}
+
+// Int returns a signed integer literal.
+func Int(value int64) Expr {
+	return wrap(&parser.NumberLiteral{Literal: fmt.Sprintf("%d", value)})
+}
+
+// Number returns a numeric literal written as is, for example a hexadecimal
+// one.
+func Number(literal string) Expr {
+	return wrap(&parser.NumberLiteral{Literal: literal})
+}
+
+// Function returns a call to the named function.
+func Function(name string, args ...Expr) Expr {
+	return wrap(&parser.FunctionExpr{
+		Name:   &parser.Ident{Name: name},
+		Params: &parser.ParamExprList{Items: &parser.ColumnExprList{Items: nodes(args)}},
+	})
+}
+
+// Lambda returns a lambda function, as in "c -> bitAnd(c, 0xffff)".
+func Lambda(parameter string, body Expr) Expr {
+	return Op(Column(parameter), "->", body)
+}
+
+// Op combines two expressions with a binary operator, for example "=", "<",
+// "LIKE" or "IN". A "NOT " prefix on the operator is understood.
+func Op(left Expr, operator string, right Expr) Expr {
+	hasNot := false
+	if rest, found := strings.CutPrefix(operator, "NOT "); found {
+		hasNot = true
+		operator = rest
+	}
+	return wrap(&parser.BinaryOperation{
+		LeftExpr:  left.node,
+		Operation: parser.TokenKind(operator),
+		RightExpr: right.node,
+		HasNot:    hasNot,
+	})
+}
+
+// Cast returns the expression cast to the provided ClickHouse type, using the
+// postfix "::" form.
+func Cast(expr Expr, typeName string) Expr {
+	return Op(expr, "::", Column(typeName))
+}
+
+// And combines expressions with AND. Empty expressions are ignored. An operand
+// which is an OR gets parentheses, as OR binds less tightly.
+func And(exprs ...Expr) Expr {
+	return combine("AND", exprs)
+}
+
+// Or combines expressions with OR. Empty expressions are ignored.
+func Or(exprs ...Expr) Expr {
+	return combine("OR", exprs)
+}
+
+func combine(operator string, exprs []Expr) Expr {
+	var result Expr
+	for _, expr := range exprs {
+		if expr.IsZero() {
+			continue
+		}
+		if operator == "AND" {
+			expr = parenthesizeOr(expr)
+		}
+		if result.IsZero() {
+			result = expr
+			continue
+		}
+		result = Op(result, operator, expr)
+	}
+	return result
+}
+
+// parenthesizeOr wraps an OR expression in parentheses. Anything else is left
+// alone.
+func parenthesizeOr(expr Expr) Expr {
+	if binary, ok := expr.node.(*parser.BinaryOperation); ok && binary.Operation == parser.TokenKind("OR") {
+		return Parens(expr)
+	}
+	return expr
+}
+
+// Not negates an expression. A compound expression gets parentheses.
+func Not(expr Expr) Expr {
+	switch expr.node.(type) {
+	case *parser.BinaryOperation, *parser.BetweenClause, *parser.UnaryExpr:
+		expr = Parens(expr)
+	}
+	return wrap(&parser.UnaryExpr{Kind: parser.TokenKind("NOT"), Expr: expr.node})
+}
+
+// Parens wraps an expression in parentheses.
+func Parens(expr Expr) Expr {
+	return Tuple(expr)
+}
+
+// Tuple returns a parenthesized list of expressions. With a single item, this
+// is the same as Parens.
+func Tuple(items ...Expr) Expr {
+	return wrap(&parser.ParamExprList{
+		Items: &parser.ColumnExprList{Items: nodes(items)},
+	})
+}
+
+// Array returns an array literal.
+func Array(items ...Expr) Expr {
+	return wrap(&parser.ArrayParamList{
+		Items: &parser.ColumnExprList{Items: nodes(items)},
+	})
+}
+
+// Between returns a BETWEEN condition.
+func Between(expr, low, high Expr) Expr {
+	return wrap(&parser.BetweenClause{Expr: expr.node, Between: low.node, And: high.node})
+}
+
+// NotBetween returns a NOT BETWEEN condition.
+func NotBetween(expr, low, high Expr) Expr {
+	return wrap(&parser.BetweenClause{
+		Expr: expr.node, Not: true, Between: low.node, And: high.node,
+	})
+}
+
+// Interval returns an INTERVAL expression, for example "INTERVAL 60 second".
+func Interval(value Expr, unit string) Expr {
+	// IntervalPos must not be zero, otherwise the INTERVAL keyword is dropped.
+	return wrap(&parser.IntervalExpr{
+		IntervalPos: 1, Expr: value.node, Unit: &parser.Ident{Name: unit},
+	})
+}
+
+// Alias names an expression with AS.
+func Alias(expr Expr, name string) Expr {
+	return wrap(&parser.AliasExpr{Expr: expr.node, Alias: &parser.Ident{Name: name}})
+}
+
+// Star returns the "*" of "SELECT *".
+func Star() Expr {
+	return Column("*")
+}
+
+// Modifier changes what a select item covers, like the "EXCEPT (a, b)" of
+// "SELECT * EXCEPT (a, b)".
+type Modifier struct {
+	node *parser.FunctionExpr
+}
+
+func modifier(name string, items []Expr) Modifier {
+	return Modifier{node: &parser.FunctionExpr{
+		Name:   &parser.Ident{Name: name},
+		Params: &parser.ParamExprList{Items: &parser.ColumnExprList{Items: nodes(items)}},
+	}}
+}
+
+// Replace is the REPLACE modifier of "SELECT * REPLACE (…)". Each item should
+// be an aliased expression.
+func Replace(items ...Expr) Modifier {
+	return modifier("REPLACE", items)
+}
+
+// Except is the EXCEPT modifier of "SELECT * EXCEPT (…)".
+func Except(columns ...string) Modifier {
+	return modifier("EXCEPT", Columns(columns...))
+}

--- a/common/sqlbuilder/expr.go
+++ b/common/sqlbuilder/expr.go
@@ -73,7 +73,7 @@ func (e Expr) pretty() string {
 
 // Column returns a reference to a column.
 func Column(name string) Expr {
-	return wrap(&parser.Ident{Name: name})
+	return wrap(ident(name))
 }
 
 // Columns returns references to several columns.
@@ -112,7 +112,7 @@ func Number(literal string) Expr {
 // Function returns a call to the named function.
 func Function(name string, args ...Expr) Expr {
 	return wrap(&parser.FunctionExpr{
-		Name:   &parser.Ident{Name: name},
+		Name:   ident(name),
 		Params: &parser.ParamExprList{Items: &parser.ColumnExprList{Items: nodes(args)}},
 	})
 }
@@ -141,7 +141,7 @@ func Op(left Expr, operator string, right Expr) Expr {
 // Cast returns the expression cast to the provided ClickHouse type, using the
 // postfix "::" form.
 func Cast(expr Expr, typeName string) Expr {
-	return Op(expr, "::", Column(typeName))
+	return Op(expr, "::", wrap(rawType(typeName)))
 }
 
 // And combines expressions with AND. Empty expressions are ignored. An operand
@@ -237,18 +237,18 @@ func NotBetween(expr, low, high Expr) Expr {
 func Interval(value Expr, unit string) Expr {
 	// IntervalPos must not be zero, otherwise the INTERVAL keyword is dropped.
 	return wrap(&parser.IntervalExpr{
-		IntervalPos: 1, Expr: value.node, Unit: &parser.Ident{Name: unit},
+		IntervalPos: 1, Expr: value.node, Unit: ident(unit),
 	})
 }
 
 // Alias names an expression with AS.
 func Alias(expr Expr, name string) Expr {
-	return wrap(&parser.AliasExpr{Expr: expr.node, Alias: &parser.Ident{Name: name}})
+	return wrap(&parser.AliasExpr{Expr: expr.node, Alias: ident(name)})
 }
 
 // Star returns the "*" of "SELECT *".
 func Star() Expr {
-	return Column("*")
+	return wrap(&parser.Ident{Name: "*"})
 }
 
 // Modifier changes what a select item covers, like the "EXCEPT (a, b)" of
@@ -259,7 +259,7 @@ type Modifier struct {
 
 func modifier(name string, items []Expr) Modifier {
 	return Modifier{node: &parser.FunctionExpr{
-		Name:   &parser.Ident{Name: name},
+		Name:   ident(name),
 		Params: &parser.ParamExprList{Items: &parser.ColumnExprList{Items: nodes(items)}},
 	}}
 }

--- a/common/sqlbuilder/expr.go
+++ b/common/sqlbuilder/expr.go
@@ -122,13 +122,104 @@ func Lambda(parameter string, body Expr) Expr {
 	return Op(Column(parameter), "->", body)
 }
 
+// How tightly the operators bind, from the loosest to the tightest. See
+// https://clickhouse.com/docs/sql-reference/operators.
+const (
+	// precUnknown is for an operator this package does not know about. It binds
+	// the loosest, so it gets parentheses rather than silently changing the
+	// meaning of a query.
+	precUnknown = iota
+	precLambda
+	precOr
+	precAnd
+	precNot
+	precComparison
+	precConcat
+	precAddition
+	precMultiplication
+	precCast
+	// precAtom is for what is not an operator at all: a literal, a column, a
+	// function call, a parenthesized expression… It never needs parentheses.
+	precAtom
+)
+
+var precedences = map[string]int{
+	"->":     precLambda,
+	"OR":     precOr,
+	"AND":    precAnd,
+	"=":      precComparison,
+	"==":     precComparison,
+	"!=":     precComparison,
+	"<>":     precComparison,
+	"<":      precComparison,
+	"<=":     precComparison,
+	">":      precComparison,
+	">=":     precComparison,
+	"IN":     precComparison,
+	"LIKE":   precComparison,
+	"ILIKE":  precComparison,
+	"REGEXP": precComparison,
+	"IS":     precComparison,
+	"||":     precConcat,
+	"+":      precAddition,
+	"-":      precAddition,
+	"*":      precMultiplication,
+	"/":      precMultiplication,
+	"%":      precMultiplication,
+	"::":     precCast,
+}
+
+// associative lists the operators where "a OP (b OP c)" and "(a OP b) OP c"
+// mean the same, so a right operand using the same operator needs no
+// parentheses. The arithmetic ones are left out on purpose: regrouping them
+// changes the result with floating point numbers.
+var associative = map[string]bool{
+	"AND": true,
+	"OR":  true,
+}
+
+// operatorName normalizes an operator for the two tables above. The parser
+// keeps the case an operator was written with, and it keeps the "NOT " prefix
+// inside the operator while Op() takes it apart. The prefix does not change how
+// tightly an operator binds.
+func operatorName(operation parser.TokenKind) string {
+	return strings.TrimPrefix(strings.ToUpper(string(operation)), "NOT ")
+}
+
+// precedence tells how tightly a node binds, so an operand can be parenthesized
+// when the operator above it binds tighter.
+func precedence(node parser.Expr) int {
+	switch node := node.(type) {
+	case *parser.BinaryOperation:
+		return precedences[operatorName(node.Operation)]
+	case *parser.UnaryExpr:
+		return precNot
+	case *parser.BetweenClause:
+		return precComparison
+	}
+	return precAtom
+}
+
 // Op combines two expressions with a binary operator, for example "=", "<",
-// "LIKE" or "IN". A "NOT " prefix on the operator is understood.
+// "LIKE" or "IN". A "NOT " prefix on the operator is understood. An operand
+// binding less tightly than the operator gets parentheses, so the SQL says what
+// the tree says.
 func Op(left Expr, operator string, right Expr) Expr {
 	hasNot := false
 	if rest, found := strings.CutPrefix(operator, "NOT "); found {
 		hasNot = true
 		operator = rest
+	}
+	name := operatorName(parser.TokenKind(operator))
+	prec := precedences[name]
+	// The left operand already reads the way the operators associate: "a - b -
+	// c" is "(a - b) - c", so it needs nothing when both bind the same.
+	if precedence(left.node) < prec {
+		left = Parens(left)
+	}
+	if operand := precedence(right.node); operand < prec ||
+		(operand == prec && !associative[name]) {
+		right = Parens(right)
 	}
 	return wrap(&parser.BinaryOperation{
 		LeftExpr:  left.node,
@@ -144,8 +235,7 @@ func Cast(expr Expr, typeName string) Expr {
 	return Op(expr, "::", wrap(rawType(typeName)))
 }
 
-// And combines expressions with AND. Empty expressions are ignored. An operand
-// which is an OR gets parentheses, as OR binds less tightly.
+// And combines expressions with AND. Empty expressions are ignored.
 func And(exprs ...Expr) Expr {
 	return combine("AND", exprs)
 }
@@ -155,14 +245,13 @@ func Or(exprs ...Expr) Expr {
 	return combine("OR", exprs)
 }
 
+// combine chains expressions with the same operator. Op() takes care of the
+// parentheses an operand may need.
 func combine(operator string, exprs []Expr) Expr {
 	var result Expr
 	for _, expr := range exprs {
 		if expr.IsZero() {
 			continue
-		}
-		if operator == "AND" {
-			expr = parenthesizeOr(expr)
 		}
 		if result.IsZero() {
 			result = expr
@@ -173,16 +262,7 @@ func combine(operator string, exprs []Expr) Expr {
 	return result
 }
 
-// parenthesizeOr wraps an OR expression in parentheses. Anything else is left
-// alone.
-func parenthesizeOr(expr Expr) Expr {
-	if binary, ok := expr.node.(*parser.BinaryOperation); ok && binary.Operation == parser.TokenKind("OR") {
-		return Parens(expr)
-	}
-	return expr
-}
-
-// Not negates an expression. A compound expression gets parentheses.
+// Not negates an expression.
 func Not(expr Expr) Expr {
 	switch expr.node.(type) {
 	case *parser.BinaryOperation, *parser.BetweenClause, *parser.UnaryExpr:

--- a/common/sqlbuilder/identifier.go
+++ b/common/sqlbuilder/identifier.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// bareIdentifier matches the identifiers ClickHouse writes without backticks.
+// See https://clickhouse.com/docs/sql-reference/syntax#identifiers. This is not
+// complete, as keywords also have to be quoted, but for our purpose, it's enough.
+var bareIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// QuoteIdentifier quotes an identifier (table name, column name, database name,
+// cluster name, etc.) the way ClickHouse writes it: with backticks only when it
+// needs them. It is meant for the SQL not built with this package.
+func QuoteIdentifier(name string) string {
+	if bareIdentifier.MatchString(name) {
+		return name
+	}
+	return fmt.Sprintf("`%s`", escapeIdentifier(name))
+}
+
+// escapeIdentifier doubles the backticks of a name, so it can be put between
+// backticks.
+func escapeIdentifier(name string) string {
+	return strings.ReplaceAll(name, "`", "``")
+}
+
+// quoteType tells how ClickHouse writes an identifier: with backticks only when
+// it has to.
+func quoteType(name string) int {
+	if bareIdentifier.MatchString(name) {
+		return parser.Unquoted
+	}
+	return parser.BackTicks
+}
+
+// ident builds an identifier, backquoted only when it has to be. The formatter
+// writes the name as is between the backticks, so it is escaped here.
+func ident(name string) *parser.Ident {
+	if bareIdentifier.MatchString(name) {
+		return &parser.Ident{Name: name, QuoteType: parser.Unquoted}
+	}
+	return &parser.Ident{Name: escapeIdentifier(name), QuoteType: parser.BackTicks}
+}

--- a/common/sqlbuilder/identifier.go
+++ b/common/sqlbuilder/identifier.go
@@ -4,7 +4,6 @@
 package sqlbuilder
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -15,16 +14,6 @@ import (
 // See https://clickhouse.com/docs/sql-reference/syntax#identifiers. This is not
 // complete, as keywords also have to be quoted, but for our purpose, it's enough.
 var bareIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-
-// QuoteIdentifier quotes an identifier (table name, column name, database name,
-// cluster name, etc.) the way ClickHouse writes it: with backticks only when it
-// needs them. It is meant for the SQL not built with this package.
-func QuoteIdentifier(name string) string {
-	if bareIdentifier.MatchString(name) {
-		return name
-	}
-	return fmt.Sprintf("`%s`", escapeIdentifier(name))
-}
 
 // escapeIdentifier doubles the backticks of a name, so it can be put between
 // backticks.
@@ -47,5 +36,11 @@ func ident(name string) *parser.Ident {
 	if bareIdentifier.MatchString(name) {
 		return &parser.Ident{Name: name, QuoteType: parser.Unquoted}
 	}
+	return backquotedIdent(name)
+}
+
+// backquotedIdent builds an identifier always written between backticks, the
+// way ClickHouse writes the columns of a table back.
+func backquotedIdent(name string) *parser.Ident {
 	return &parser.Ident{Name: escapeIdentifier(name), QuoteType: parser.BackTicks}
 }

--- a/common/sqlbuilder/internal_test.go
+++ b/common/sqlbuilder/internal_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder
+
+import (
+	"testing"
+
+	"akvorado/common/helpers"
+)
+
+func TestCanonical(t *testing.T) {
+	cases := []struct {
+		Description string
+		SQL         string
+		Expected    string
+	}{
+		{
+			Description: "quotes dropped where ClickHouse does not use them",
+			SQL:         "CREATE TABLE `db`.`flows` (`SrcAddr` IPv6 CODEC(ZSTD(1))) ENGINE = MergeTree ORDER BY SrcAddr",
+			Expected:    "CREATE TABLE db.flows (SrcAddr IPv6 CODEC(ZSTD(1))) ENGINE = MergeTree ORDER BY SrcAddr",
+		}, {
+			Description: "quotes kept where they are needed",
+			SQL:         "CREATE TABLE `my db`.`flows-1` (`Src Addr` IPv6) ENGINE = Null",
+			Expected:    "CREATE TABLE `my db`.`flows-1` (`Src Addr` IPv6) ENGINE = Null",
+		}, {
+			Description: "layout dropped",
+			SQL:         "SELECT\n  SrcAS,\n  DstAS\nFROM   flows\nWHERE  SrcAS = 65000",
+			Expected:    "SELECT SrcAS, DstAS FROM flows WHERE SrcAS = 65000",
+		}, {
+			Description: "engine name unquoted",
+			SQL:         "CREATE TABLE flows (`SrcAS` UInt32) ENGINE = `Null`",
+			Expected:    "CREATE TABLE flows (SrcAS UInt32) ENGINE = Null",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got, ok := canonical(tc.SQL)
+			if !ok {
+				t.Fatalf("canonical(%q) could not parse", tc.SQL)
+			}
+			if diff := helpers.Diff(got, tc.Expected); diff != "" {
+				t.Errorf("canonical(%q) (-got, +want):\n%s", tc.SQL, diff)
+			}
+		})
+	}
+}
+
+// TestCanonicalCompare checks what two statements are compared on. This is what
+// tells if a table in ClickHouse still matches the one we would create.
+func TestCanonicalCompare(t *testing.T) {
+	cases := []struct {
+		Description string
+		First       string
+		Second      string
+		Expected    bool
+	}{
+		{
+			Description: "same statement, other quoting",
+			First:       "CREATE TABLE `db`.`flows` (`SrcAS` UInt32) ENGINE = Null",
+			Second:      "CREATE TABLE db.flows (SrcAS UInt32) ENGINE = Null",
+			Expected:    true,
+		}, {
+			Description: "same statement, clauses in the order ClickHouse writes them",
+			First:       "CREATE TABLE flows (`SrcAS` UInt32) ENGINE = MergeTree PARTITION BY toYYYYMM(TimeReceived) ORDER BY SrcAS",
+			Second:      "CREATE TABLE flows (`SrcAS` UInt32) ENGINE = MergeTree ORDER BY SrcAS PARTITION BY toYYYYMM(TimeReceived)",
+			Expected:    true,
+		}, {
+			Description: "same dictionary, attributes quoted by ClickHouse only",
+			First:       "CREATE DICTIONARY db.asns (`asn` UInt32 INJECTIVE, `name` String) PRIMARY KEY asn SOURCE(HTTP(URL 'http://x' FORMAT 'CSVWithNames')) LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED())",
+			Second:      "CREATE DICTIONARY db.asns (asn UInt32 INJECTIVE, name String) PRIMARY KEY asn SOURCE(HTTP(URL 'http://x' FORMAT 'CSVWithNames')) LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED())",
+			Expected:    true,
+		}, {
+			Description: "another column type",
+			First:       "CREATE TABLE flows (`SrcAS` UInt32) ENGINE = Null",
+			Second:      "CREATE TABLE flows (`SrcAS` UInt64) ENGINE = Null",
+			Expected:    false,
+		}, {
+			Description: "another database",
+			First:       "CREATE TABLE db.flows (`SrcAS` UInt32) ENGINE = Null",
+			Second:      "CREATE TABLE other.flows (`SrcAS` UInt32) ENGINE = Null",
+			Expected:    false,
+		}, {
+			Description: "a quoted name is not the same column as a bare one",
+			First:       "CREATE TABLE flows (`Src Addr` IPv6) ENGINE = Null",
+			Second:      "CREATE TABLE flows (Src Addr) ENGINE = Null",
+			Expected:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			first, ok := canonical(tc.First)
+			if !ok {
+				t.Fatalf("canonical(%q) could not parse", tc.First)
+			}
+			second, ok := canonical(tc.Second)
+			if !ok {
+				t.Fatalf("canonical(%q) could not parse", tc.Second)
+			}
+			if diff := helpers.Diff(first == second, tc.Expected); diff != "" {
+				t.Errorf("comparison of the two statements (-got, +want):\n%s\nfirst:  %s\nsecond: %s",
+					diff, first, second)
+			}
+		})
+	}
+}
+
+func TestCanonicalErrors(t *testing.T) {
+	cases := []struct {
+		Description string
+		SQL         string
+	}{
+		{
+			Description: "not SQL at all",
+			SQL:         "hello world",
+		}, {
+			Description: "truncated statement",
+			SQL:         "CREATE TABLE flows (`SrcAS` UInt32",
+		}, {
+			Description: "truncated alias expression",
+			SQL:         "CREATE TABLE flows (`SrcAS` UInt32 ALIAS toUInt32(",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if _, ok := canonical(tc.SQL); ok {
+				t.Errorf("canonical(%q) parsed", tc.SQL)
+			}
+		})
+	}
+}

--- a/common/sqlbuilder/internal_test.go
+++ b/common/sqlbuilder/internal_test.go
@@ -105,6 +105,16 @@ func TestCanonicalCompare(t *testing.T) {
 	}
 }
 
+// TestOnClusterUnsupported checks a statement taking no ON CLUSTER clause is
+// left as is. No builder produces one, so the node is wrapped by hand.
+func TestOnClusterUnsupported(t *testing.T) {
+	query := Select(Column("SrcAS")).From(Table("flows"))
+	got := statement{node: query.query}.OnCluster("akvorado")
+	if diff := helpers.Diff(got.String(), query.String()); diff != "" {
+		t.Errorf("OnCluster() (-got, +want):\n%s", diff)
+	}
+}
+
 func TestCanonicalErrors(t *testing.T) {
 	cases := []struct {
 		Description string

--- a/common/sqlbuilder/parse.go
+++ b/common/sqlbuilder/parse.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// ParseExpr parses a SQL expression. The parser only accepts complete
+// statements, so the expression is parsed as the select list of a SELECT. This
+// is used in widgets, so we need to keep this function accessible outside of
+// tests.
+func ParseExpr(sql string) (Expr, error) {
+	statements, err := parser.NewParser(fmt.Sprintf("SELECT %s", sql)).ParseStmts()
+	if err != nil {
+		return Expr{}, err
+	}
+	if len(statements) != 1 {
+		return Expr{}, fmt.Errorf("expected one statement, got %d", len(statements))
+	}
+	query, ok := statements[0].(*parser.SelectQuery)
+	if !ok {
+		return Expr{}, errors.New("not an expression")
+	}
+	if len(query.SelectItems) != 1 {
+		return Expr{}, fmt.Errorf("expected one expression, got %d", len(query.SelectItems))
+	}
+	if !onlySelectItems(query) {
+		return Expr{}, errors.New("trailing text after the expression")
+	}
+	item := query.SelectItems[0]
+	if item.Alias != nil {
+		return wrap(&parser.AliasExpr{Expr: item.Expr, Alias: item.Alias}), nil
+	}
+	return wrap(item.Expr), nil
+}
+
+// onlySelectItems tells if a SELECT carries nothing but its select list.
+// Anything written after the expression lands in one of the other clauses,
+// where it would be dropped without notice. Fields are walked instead of being
+// listed one by one, so a new clause in the parser cannot slip through.
+func onlySelectItems(query *parser.SelectQuery) bool {
+	value := reflect.ValueOf(*query)
+	for i := range value.NumField() {
+		switch value.Type().Field(i).Name {
+		case "SelectPos", "StatementEnd", "SelectItems":
+			continue
+		}
+		if !value.Field(i).IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+// MustParseExpr parses a SQL expression written in the code. It panics when the
+// expression is invalid. Never use it on user input, use ParseExpr instead.
+func MustParseExpr(sql string) Expr {
+	expr, err := ParseExpr(sql)
+	if err != nil {
+		panic(fmt.Sprintf("invalid SQL expression %q: %s", sql, err))
+	}
+	return expr
+}

--- a/common/sqlbuilder/parse.go
+++ b/common/sqlbuilder/parse.go
@@ -11,12 +11,48 @@ import (
 	"github.com/AfterShip/clickhouse-sql-parser/parser"
 )
 
+// parse turns SQL into statements. The underlying parser panics on a few
+// inputs instead of reporting an error. As some of the SQL parsed here comes
+// from ClickHouse itself, a panic is turned into an error.
+func parse(sql string) (statements []parser.Expr, err error) {
+	defer func() {
+		if problem := recover(); problem != nil {
+			statements, err = nil, fmt.Errorf("cannot parse SQL: %v", problem)
+		}
+	}()
+	return parser.NewParser(sql).ParseStmts()
+}
+
+// canonical rewrites SQL into a single form, so two statements written
+// differently can be compared. It also tells if the SQL could be parsed.
+func canonical(sql string) (string, bool) {
+	statements, err := parse(sql)
+	if err != nil {
+		return "", false
+	}
+	formatter := parser.NewFormatter()
+	for _, statement := range statements {
+		// Parsing keeps the quotes an identifier was written with, so the same
+		// statement with and without them does not compare equal. ClickHouse
+		// does not quote in the same places as we do, so every identifier is
+		// rewritten the way ClickHouse writes it.
+		parser.Walk(statement, func(node parser.Expr) bool {
+			if identifier, ok := node.(*parser.Ident); ok {
+				identifier.QuoteType = quoteType(identifier.Name)
+			}
+			return true
+		})
+		formatter.WriteExpr(statement)
+	}
+	return formatter.String(), true
+}
+
 // ParseExpr parses a SQL expression. The parser only accepts complete
 // statements, so the expression is parsed as the select list of a SELECT. This
 // is used in widgets, so we need to keep this function accessible outside of
 // tests.
 func ParseExpr(sql string) (Expr, error) {
-	statements, err := parser.NewParser(fmt.Sprintf("SELECT %s", sql)).ParseStmts()
+	statements, err := parse(fmt.Sprintf("SELECT %s", sql))
 	if err != nil {
 		return Expr{}, err
 	}
@@ -56,6 +92,19 @@ func onlySelectItems(query *parser.SelectQuery) bool {
 		}
 	}
 	return true
+}
+
+// ParseExprs parses several SQL expressions.
+func ParseExprs(sqls []string) ([]Expr, error) {
+	exprs := make([]Expr, len(sqls))
+	for i, sql := range sqls {
+		expr, err := ParseExpr(sql)
+		if err != nil {
+			return nil, err
+		}
+		exprs[i] = expr
+	}
+	return exprs, nil
 }
 
 // MustParseExpr parses a SQL expression written in the code. It panics when the

--- a/common/sqlbuilder/select.go
+++ b/common/sqlbuilder/select.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder
+
+import (
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// Query is a SELECT statement under construction. Its methods return the query
+// itself, so they can be chained.
+type Query struct {
+	query *parser.SelectQuery
+}
+
+// Select starts a SELECT statement with the provided items.
+func Select(items ...Expr) *Query {
+	q := &Query{query: &parser.SelectQuery{}}
+	for _, item := range items {
+		q.Item(item)
+	}
+	return q
+}
+
+// Apply passes the query through the provided transforms, in order. Other
+// packages use it to add their own building blocks on top of this package.
+func (q *Query) Apply(transforms ...func(*Query) *Query) *Query {
+	for _, transform := range transforms {
+		q = transform(q)
+	}
+	return q
+}
+
+// Item appends one item to the select list. Modifiers apply to that item, for
+// example Replace() on a Star().
+func (q *Query) Item(expr Expr, modifiers ...Modifier) *Query {
+	item := &parser.SelectItem{Expr: expr.node}
+	for _, modifier := range modifiers {
+		item.Modifiers = append(item.Modifiers, modifier.node)
+	}
+	q.query.SelectItems = append(q.query.SelectItems, item)
+	return q
+}
+
+// From reads from the named table.
+func (q *Query) From(table string) *Query {
+	q.query.From = &parser.FromClause{
+		Expr: &parser.TableExpr{
+			Expr: &parser.TableIdentifier{Table: &parser.Ident{Name: table}},
+		},
+	}
+	return q
+}
+
+// FromSelect reads from a subquery.
+func (q *Query) FromSelect(sub *Query) *Query {
+	q.query.From = &parser.FromClause{
+		Expr: &parser.TableExpr{
+			Expr: &parser.SubQuery{HasParen: true, Select: sub.query},
+		},
+	}
+	return q
+}
+
+// Where sets the WHERE clause. An empty expression removes it.
+func (q *Query) Where(expr Expr) *Query {
+	if expr.IsZero() {
+		q.query.Where = nil
+		return q
+	}
+	q.query.Where = &parser.WhereClause{Expr: expr.node}
+	return q
+}
+
+// GroupBy sets the GROUP BY clause.
+func (q *Query) GroupBy(exprs ...Expr) *Query {
+	if len(exprs) == 0 {
+		q.query.GroupBy = nil
+		return q
+	}
+	q.query.GroupBy = &parser.GroupByClause{
+		Expr: &parser.ColumnExprList{Items: nodes(exprs)},
+	}
+	return q
+}
+
+// OrderBy sets the ORDER BY clause.
+func (q *Query) OrderBy(items ...OrderItem) *Query {
+	if len(items) == 0 {
+		q.query.OrderBy = nil
+		return q
+	}
+	exprs := make([]parser.Expr, len(items))
+	for i, item := range items {
+		exprs[i] = item.node()
+	}
+	q.query.OrderBy = &parser.OrderByClause{Items: exprs}
+	return q
+}
+
+// Interpolate adds an item to the INTERPOLATE clause of the ORDER BY. It only
+// makes sense together with a WITH FILL, so OrderBy must be called first.
+func (q *Query) Interpolate(column string, expr Expr) *Query {
+	if q.query.OrderBy.Interpolate == nil {
+		q.query.OrderBy.Interpolate = &parser.InterpolateClause{}
+	}
+	q.query.OrderBy.Interpolate.Items = append(q.query.OrderBy.Interpolate.Items,
+		&parser.InterpolateItem{Column: &parser.Ident{Name: column}, Expr: expr.node})
+	return q
+}
+
+// Limit sets the LIMIT clause.
+func (q *Query) Limit(limit int) *Query {
+	q.query.Limit = &parser.LimitClause{Limit: Int(int64(limit)).node}
+	return q
+}
+
+// Setting adds one entry to the SETTINGS clause.
+func (q *Query) Setting(name string, value Expr) *Query {
+	if q.query.Settings == nil {
+		q.query.Settings = &parser.SettingsClause{}
+	}
+	q.query.Settings.Items = append(q.query.Settings.Items, &parser.SettingExpr{
+		Name: &parser.Ident{Name: name},
+		Expr: value.node,
+	})
+	return q
+}
+
+// With adds a named CTE, as in "WITH name AS (SELECT …)".
+func (q *Query) With(name string, sub *Query) *Query {
+	return q.addCTE(&parser.CTEStmt{
+		Expr:  &parser.Ident{Name: name},
+		Alias: sub.query,
+	})
+}
+
+// WithScalar adds a scalar CTE, as in "WITH (SELECT …) AS name".
+func (q *Query) WithScalar(sub *Query, name string) *Query {
+	return q.addCTE(&parser.CTEStmt{
+		Expr:  &parser.SubQuery{HasParen: true, Select: sub.query},
+		Alias: &parser.Ident{Name: name},
+	})
+}
+
+func (q *Query) addCTE(cte *parser.CTEStmt) *Query {
+	if q.query.With == nil {
+		q.query.With = &parser.WithClause{}
+	}
+	q.query.With.CTEs = append(q.query.With.CTEs, cte)
+	return q
+}
+
+// UnionAll appends another query with UNION ALL. Only the first query of the
+// union carries the WITH clause, the others read its CTEs.
+func (q *Query) UnionAll(other *Query) *Query {
+	last := q.query
+	for last.UnionAll != nil {
+		last = last.UnionAll
+	}
+	last.UnionAll = other.query
+	return q
+}
+
+// Subquery returns the query wrapped in parentheses, for use as an expression.
+func (q *Query) Subquery() Expr {
+	return wrap(&parser.SubQuery{HasParen: true, Select: q.query})
+}
+
+// String renders the query as indented, multi-line SQL.
+func (q *Query) String() string {
+	return wrap(q.query).pretty()
+}
+
+// OrderItem is one item of an ORDER BY clause.
+type OrderItem struct {
+	expr       Expr
+	descending bool
+	fill       bool
+	from, to   Expr
+	step       Expr
+}
+
+// Order sorts on an expression, in ascending order.
+func Order(expr Expr) OrderItem {
+	return OrderItem{expr: expr}
+}
+
+// Desc switches the item to descending order.
+func (o OrderItem) Desc() OrderItem {
+	o.descending = true
+	return o
+}
+
+// Fill adds a WITH FILL clause to the item.
+func (o OrderItem) Fill(from, to, step Expr) OrderItem {
+	o.fill = true
+	o.from = from
+	o.to = to
+	o.step = step
+	return o
+}
+
+func (o OrderItem) node() parser.Expr {
+	order := &parser.OrderExpr{
+		Expr:      o.expr.node,
+		Direction: parser.OrderDirectionNone,
+	}
+	if o.descending {
+		order.Direction = parser.OrderDirectionDesc
+	}
+	if o.fill {
+		order.Fill = &parser.Fill{From: o.from.node, To: o.to.node, Step: o.step.node}
+	}
+	return order
+}

--- a/common/sqlbuilder/select.go
+++ b/common/sqlbuilder/select.go
@@ -112,7 +112,7 @@ func (q *Query) Interpolate(column string, expr Expr) *Query {
 		q.query.OrderBy.Interpolate = &parser.InterpolateClause{}
 	}
 	q.query.OrderBy.Interpolate.Items = append(q.query.OrderBy.Interpolate.Items,
-		&parser.InterpolateItem{Column: &parser.Ident{Name: column}, Expr: expr.node})
+		&parser.InterpolateItem{Column: ident(column), Expr: expr.node})
 	return q
 }
 
@@ -128,7 +128,7 @@ func (q *Query) Setting(name string, value Expr) *Query {
 		q.query.Settings = &parser.SettingsClause{}
 	}
 	q.query.Settings.Items = append(q.query.Settings.Items, &parser.SettingExpr{
-		Name: &parser.Ident{Name: name},
+		Name: ident(name),
 		Expr: value.node,
 	})
 	return q
@@ -137,7 +137,7 @@ func (q *Query) Setting(name string, value Expr) *Query {
 // With adds a named CTE, as in "WITH name AS (SELECT …)".
 func (q *Query) With(name string, sub *Query) *Query {
 	return q.addCTE(&parser.CTEStmt{
-		Expr:  &parser.Ident{Name: name},
+		Expr:  ident(name),
 		Alias: sub.query,
 	})
 }
@@ -146,7 +146,7 @@ func (q *Query) With(name string, sub *Query) *Query {
 func (q *Query) WithScalar(sub *Query, name string) *Query {
 	return q.addCTE(&parser.CTEStmt{
 		Expr:  &parser.SubQuery{HasParen: true, Select: sub.query},
-		Alias: &parser.Ident{Name: name},
+		Alias: ident(name),
 	})
 }
 
@@ -155,7 +155,7 @@ func (q *Query) WithScalar(sub *Query, name string) *Query {
 func (q *Query) WithAlias(expr Expr, name string) *Query {
 	return q.addCTE(&parser.CTEStmt{
 		Expr:  expr.node,
-		Alias: &parser.Ident{Name: name},
+		Alias: ident(name),
 	})
 }
 

--- a/common/sqlbuilder/select.go
+++ b/common/sqlbuilder/select.go
@@ -43,11 +43,9 @@ func (q *Query) Item(expr Expr, modifiers ...Modifier) *Query {
 }
 
 // From reads from the named table.
-func (q *Query) From(table string) *Query {
+func (q *Query) From(table TableName) *Query {
 	q.query.From = &parser.FromClause{
-		Expr: &parser.TableExpr{
-			Expr: &parser.TableIdentifier{Table: &parser.Ident{Name: table}},
-		},
+		Expr: &parser.TableExpr{Expr: table.node()},
 	}
 	return q
 }
@@ -58,6 +56,15 @@ func (q *Query) FromSelect(sub *Query) *Query {
 		Expr: &parser.TableExpr{
 			Expr: &parser.SubQuery{HasParen: true, Select: sub.query},
 		},
+	}
+	return q
+}
+
+// ArrayJoin unrolls an array into rows. From must be called first.
+func (q *Query) ArrayJoin(expr Expr) *Query {
+	q.query.From.Expr = &parser.JoinExpr{
+		Left:  q.query.From.Expr,
+		Right: &parser.JoinExpr{Modifiers: []string{"ARRAY", "JOIN"}, Left: expr.node},
 	}
 	return q
 }
@@ -143,6 +150,15 @@ func (q *Query) WithScalar(sub *Query, name string) *Query {
 	})
 }
 
+// WithAlias names an expression in the WITH clause, as in
+// "WITH arrayCompact(DstASPath) AS c_DstASPath".
+func (q *Query) WithAlias(expr Expr, name string) *Query {
+	return q.addCTE(&parser.CTEStmt{
+		Expr:  expr.node,
+		Alias: &parser.Ident{Name: name},
+	})
+}
+
 func (q *Query) addCTE(cte *parser.CTEStmt) *Query {
 	if q.query.With == nil {
 		q.query.With = &parser.WithClause{}
@@ -170,6 +186,13 @@ func (q *Query) Subquery() Expr {
 // String renders the query as indented, multi-line SQL.
 func (q *Query) String() string {
 	return wrap(q.query).pretty()
+}
+
+// Matches tells if the provided SQL means the same as the query. Only the
+// meaning is compared: layout and identifier quoting do not matter. SQL that
+// cannot be parsed never matches.
+func (q *Query) Matches(sql string) bool {
+	return statement{node: q.query}.Matches(sql)
 }
 
 // OrderItem is one item of an ORDER BY clause.

--- a/common/sqlbuilder/sqlbuilder_test.go
+++ b/common/sqlbuilder/sqlbuilder_test.go
@@ -148,6 +148,52 @@ func TestExpr(t *testing.T) {
 	}
 }
 
+// TestIdentifierQuoting checks a name needing backticks gets them. Column names
+// come from the schema and from the custom dictionaries, so they are not all
+// bare identifiers. It also checks what is not a name keeps its own form.
+func TestIdentifierQuoting(t *testing.T) {
+	cases := []struct {
+		Description string
+		Expr        sb.Expr
+		Expected    string
+	}{
+		{
+			Description: "column with a space",
+			Expr:        sb.Column("Src Addr"),
+			Expected:    "`Src Addr`",
+		}, {
+			Description: "column with a backtick",
+			Expr:        sb.Column("Src`Addr"),
+			Expected:    "`Src``Addr`",
+		}, {
+			Description: "column starting with a digit",
+			Expr:        sb.Column("1stAS"),
+			Expected:    "`1stAS`",
+		}, {
+			Description: "alias with a space",
+			Expr:        sb.Alias(sb.Column("SrcAS"), "my alias"),
+			Expected:    "SrcAS AS `my alias`",
+		}, {
+			// A type is not an identifier, it keeps its parentheses.
+			Description: "cast to a parameterized type",
+			Expr:        sb.Cast(sb.Column("SrcAS"), "Array(UInt64)"),
+			Expected:    "SrcAS::Array(UInt64)",
+		}, {
+			// The star is not a column named "*".
+			Description: "star",
+			Expr:        sb.Star(),
+			Expected:    "*",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(tc.Expr.String(), tc.Expected); diff != "" {
+				t.Errorf("String() (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestSelect(t *testing.T) {
 	source := sb.Select(sb.Star()).
 		From(sb.Table("flows")).

--- a/common/sqlbuilder/sqlbuilder_test.go
+++ b/common/sqlbuilder/sqlbuilder_test.go
@@ -135,7 +135,7 @@ func TestExpr(t *testing.T) {
 		}, {
 			Description: "in a subquery",
 			Expr: sb.Op(sb.Column("SrcAS"), "IN",
-				sb.Select(sb.Column("asn")).From("asns").Subquery()),
+				sb.Select(sb.Column("asn")).From(sb.Table("asns")).Subquery()),
 			Expected: "SrcAS IN (SELECT asn FROM asns)",
 		},
 	}
@@ -150,10 +150,10 @@ func TestExpr(t *testing.T) {
 
 func TestSelect(t *testing.T) {
 	source := sb.Select(sb.Star()).
-		From("flows").
+		From(sb.Table("flows")).
 		Setting("asterisk_include_alias_columns", sb.Uint(1))
 	rows := sb.Select(sb.Column("ExporterName")).
-		From("source").
+		From(sb.Table("source")).
 		GroupBy(sb.Column("ExporterName")).
 		OrderBy(sb.Order(sb.MustParseExpr("SUM(Bytes)")).Desc()).
 		Limit(10)
@@ -161,7 +161,7 @@ func TestSelect(t *testing.T) {
 		sb.Alias(sb.Column("TimeReceived"), "time"),
 		sb.Alias(sb.MustParseExpr("SUM(Bytes)/60"), "xps"),
 	).
-		From("source").
+		From(sb.Table("source")).
 		Where(sb.Between(sb.Column("TimeReceived"),
 			sb.Function("toDateTime", sb.String("2022-04-10 15:45:00")),
 			sb.Function("toDateTime", sb.String("2022-04-11 15:45:00")))).
@@ -217,7 +217,7 @@ FROM
 // work with, so a caller does not have to test for that itself.
 func TestSelectEmptyClauses(t *testing.T) {
 	got := sb.Select(sb.Star()).
-		From("flows").
+		From(sb.Table("flows")).
 		Where(sb.Op(sb.Column("SrcAS"), "=", sb.Uint(12322))).
 		GroupBy(sb.Columns("SrcAS", "DstAS")...).
 		OrderBy(sb.Order(sb.Column("SrcAS"))).
@@ -243,7 +243,7 @@ func TestSelectStarReplace(t *testing.T) {
 				sb.Function("IPv6CIDRToRange",
 					sb.Column("SrcAddr"), sb.Uint(48)),
 				sb.Uint(1)), "SrcAddr"))).
-		From("flows").
+		From(sb.Table("flows")).
 		String()
 	expected := `SELECT
   * REPLACE(tupleElement(IPv6CIDRToRange(SrcAddr, 48), 1) AS SrcAddr)
@@ -257,7 +257,7 @@ FROM
 func TestSelectStarExcept(t *testing.T) {
 	got := sb.Select().
 		Item(sb.Star(), sb.Except("SrcCommunities", "DstCommunities")).
-		From("flows").
+		From(sb.Table("flows")).
 		String()
 	expected := `SELECT
   * EXCEPT(SrcCommunities, DstCommunities)
@@ -269,9 +269,9 @@ FROM
 }
 
 func TestSelectUnionAll(t *testing.T) {
-	first := sb.Select(sb.Alias(sb.Uint(1), "axis")).From("flows")
-	second := sb.Select(sb.Alias(sb.Uint(2), "axis")).From("flows")
-	third := sb.Select(sb.Alias(sb.Uint(3), "axis")).From("flows")
+	first := sb.Select(sb.Alias(sb.Uint(1), "axis")).From(sb.Table("flows"))
+	second := sb.Select(sb.Alias(sb.Uint(2), "axis")).From(sb.Table("flows"))
+	third := sb.Select(sb.Alias(sb.Uint(3), "axis")).From(sb.Table("flows"))
 	got := first.UnionAll(second).UnionAll(third).String()
 	expected := `SELECT
   1 AS axis
@@ -293,10 +293,10 @@ FROM
 }
 
 func TestSelectScalarCTE(t *testing.T) {
-	period := sb.Select(sb.MustParseExpr("MAX(TimeReceived) - MIN(TimeReceived)")).From("source")
+	period := sb.Select(sb.MustParseExpr("MAX(TimeReceived) - MIN(TimeReceived)")).From(sb.Table("source"))
 	got := sb.Select(sb.Alias(sb.MustParseExpr("SUM(Bytes)/range"), "xps")).
 		WithScalar(period, "range").
-		From("source").
+		From(sb.Table("source")).
 		String()
 	expected := `WITH
   (SELECT
@@ -336,7 +336,7 @@ func TestApply(t *testing.T) {
 			return q.Limit(limit)
 		}
 	}
-	gotQuery := sb.Select(sb.Star()).From("flows").Apply(limited(5)).String()
+	gotQuery := sb.Select(sb.Star()).From(sb.Table("flows")).Apply(limited(5)).String()
 	expectedQuery := `SELECT
   *
 FROM

--- a/common/sqlbuilder/sqlbuilder_test.go
+++ b/common/sqlbuilder/sqlbuilder_test.go
@@ -148,6 +148,80 @@ func TestExpr(t *testing.T) {
 	}
 }
 
+// TestOpPrecedence checks an operand binding less tightly than the operator
+// above it gets parentheses, and that an operand which does not need them keeps
+// none. Without this, the SQL would not say what the tree says.
+func TestOpPrecedence(t *testing.T) {
+	a, b, c := sb.Column("a"), sb.Column("b"), sb.Column("c")
+	cases := []struct {
+		Description string
+		Expr        sb.Expr
+		Expected    string
+	}{
+		{
+			Description: "addition below a multiplication",
+			Expr:        sb.Op(sb.Op(a, "+", b), "*", c),
+			Expected:    "(a + b) * c",
+		}, {
+			Description: "addition below a cast",
+			Expr:        sb.Cast(sb.Op(a, "+", b), "UInt128"),
+			Expected:    "(a + b)::UInt128",
+		}, {
+			// Subtraction is not associative, so the tree has to be kept.
+			Description: "subtraction on the right of a subtraction",
+			Expr:        sb.Op(a, "-", sb.Op(b, "-", c)),
+			Expected:    "a - (b - c)",
+		}, {
+			Description: "or below an and",
+			Expr:        sb.Op(sb.Or(a, b), "AND", c),
+			Expected:    "(a OR b) AND c",
+		}, {
+			// The operators associate to the left, so this reads as written.
+			Description: "subtraction then addition",
+			Expr:        sb.Op(sb.Op(a, "-", b), "+", c),
+			Expected:    "a - b + c",
+		}, {
+			Description: "multiplication then division",
+			Expr:        sb.Op(sb.Op(a, "*", b), "/", c),
+			Expected:    "a * b / c",
+		}, {
+			// AND is associative, so no parentheses are needed. A filter is
+			// combined with the time range this way.
+			Description: "and on the right of an and",
+			Expr:        sb.Op(a, "AND", sb.Op(b, "AND", c)),
+			Expected:    "a AND b AND c",
+		}, {
+			Description: "or on the right of an or",
+			Expr:        sb.Op(a, "OR", sb.Op(b, "OR", c)),
+			Expected:    "a OR b OR c",
+		}, {
+			Description: "comparison below an and",
+			Expr:        sb.Op(sb.Op(a, "=", b), "AND", c),
+			Expected:    "a = b AND c",
+		}, {
+			Description: "addition below a comparison",
+			Expr:        sb.Op(a, "=", sb.Op(b, "+", c)),
+			Expected:    "a = b + c",
+		}, {
+			// NOT binds tighter than AND.
+			Description: "negation below an and",
+			Expr:        sb.Op(sb.Not(sb.Op(a, "=", b)), "AND", c),
+			Expected:    "NOT (a = b) AND c",
+		}, {
+			Description: "negation below a comparison",
+			Expr:        sb.Op(sb.Not(a), "=", b),
+			Expected:    "(NOT a) = b",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(tc.Expr.String(), tc.Expected); diff != "" {
+				t.Errorf("String() (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
 // TestIdentifierQuoting checks a name needing backticks gets them. Column names
 // come from the schema and from the custom dictionaries, so they are not all
 // bare identifiers. It also checks what is not a name keeps its own form.

--- a/common/sqlbuilder/sqlbuilder_test.go
+++ b/common/sqlbuilder/sqlbuilder_test.go
@@ -1,0 +1,432 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sqlbuilder_test
+
+import (
+	"testing"
+
+	"akvorado/common/helpers"
+	sb "akvorado/common/sqlbuilder"
+)
+
+func TestExpr(t *testing.T) {
+	cases := []struct {
+		Description string
+		Expr        sb.Expr
+		Expected    string
+	}{
+		{
+			Description: "column",
+			Expr:        sb.Column("SrcAddr"),
+			Expected:    "SrcAddr",
+		}, {
+			Description: "string with a quote",
+			Expr:        sb.String(`it's`),
+			Expected:    `'it\'s'`,
+		}, {
+			Description: "string with a backslash",
+			Expr:        sb.String(`a\b`),
+			Expected:    `'a\\b'`,
+		}, {
+			Description: "function",
+			Expr:        sb.Function("toIPv6", sb.String("::1")),
+			Expected:    `toIPv6('::1')`,
+		}, {
+			Description: "comparison",
+			Expr:        sb.Op(sb.Column("SrcAS"), "=", sb.Uint(65000)),
+			Expected:    "SrcAS = 65000",
+		}, {
+			Description: "negated operator",
+			Expr: sb.Op(sb.Column("ExporterName"), "NOT LIKE",
+				sb.String("th%")),
+			Expected: "ExporterName NOT LIKE 'th%'",
+		}, {
+			Description: "cast",
+			Expr:        sb.Cast(sb.Uint(65000), "UInt128"),
+			Expected:    "65000::UInt128",
+		}, {
+			Description: "and",
+			Expr: sb.And(
+				sb.Op(sb.Column("a"), "=", sb.Uint(1)),
+				sb.Op(sb.Column("b"), "=", sb.Uint(2)),
+				sb.Op(sb.Column("c"), "=", sb.Uint(3))),
+			Expected: "a = 1 AND b = 2 AND c = 3",
+		}, {
+			Description: "and skips empty expressions",
+			Expr: sb.And(
+				sb.Expr{},
+				sb.Op(sb.Column("a"), "=", sb.Uint(1)),
+				sb.Expr{}),
+			Expected: "a = 1",
+		}, {
+			// OR binds less tightly, so it needs parentheses inside an AND.
+			Description: "or inside and",
+			Expr: sb.And(
+				sb.Op(sb.Column("a"), "=", sb.Uint(1)),
+				sb.Or(
+					sb.Op(sb.Column("b"), "=", sb.Uint(2)),
+					sb.Op(sb.Column("c"), "=", sb.Uint(3)))),
+			Expected: "a = 1 AND (b = 2 OR c = 3)",
+		}, {
+			Description: "and inside or",
+			Expr: sb.Or(
+				sb.Op(sb.Column("a"), "=", sb.Uint(1)),
+				sb.And(
+					sb.Op(sb.Column("b"), "=", sb.Uint(2)),
+					sb.Op(sb.Column("c"), "=", sb.Uint(3)))),
+			Expected: "a = 1 OR b = 2 AND c = 3",
+		}, {
+			Description: "not",
+			Expr: sb.Not(sb.Op(sb.Column("a"), "=",
+				sb.Uint(1))),
+			Expected: "NOT (a = 1)",
+		}, {
+			Description: "between",
+			Expr: sb.Between(sb.Column("SrcAddr"),
+				sb.Function("toIPv6", sb.String("::1")),
+				sb.Function("toIPv6", sb.String("::2"))),
+			Expected: `SrcAddr BETWEEN toIPv6('::1') AND toIPv6('::2')`,
+		}, {
+			Description: "in a tuple",
+			Expr: sb.Op(sb.Column("Proto"), "IN",
+				sb.Tuple(sb.Uint(6), sb.Uint(17))),
+			Expected: "Proto IN (6, 17)",
+		}, {
+			Description: "array",
+			Expr:        sb.Array(sb.String("a"), sb.String("b")),
+			Expected:    `['a', 'b']`,
+		}, {
+			Description: "interval arithmetic",
+			Expr: sb.Op(sb.Column("TimeReceived"), "+",
+				sb.Interval(sb.Uint(60), "second")),
+			Expected: "TimeReceived + INTERVAL 60 second",
+		}, {
+			Description: "alias",
+			Expr:        sb.Alias(sb.Column("TimeReceived"), "time"),
+			Expected:    "TimeReceived AS time",
+		}, {
+			Description: "raw expression",
+			Expr:        sb.MustParseExpr("SUM(Bytes*SamplingRate*8)"),
+			Expected:    "SUM(Bytes * SamplingRate * 8)",
+		}, {
+			Description: "raw expression with a lambda",
+			Expr:        sb.MustParseExpr("arrayMap(c -> bitAnd(c, 0xffff), SrcCommunities)"),
+			Expected:    "arrayMap(c -> bitAnd(c, 0xffff), SrcCommunities)",
+		}, {
+			Description: "no expression",
+			Expr:        sb.Expr{},
+			Expected:    "",
+		}, {
+			Description: "hexadecimal number",
+			Expr:        sb.Number("0xffff"),
+			Expected:    "0xffff",
+		}, {
+			Description: "lambda",
+			Expr: sb.Lambda("c",
+				sb.Function("bitAnd", sb.Column("c"), sb.Number("0xffff"))),
+			Expected: "c -> bitAnd(c, 0xffff)",
+		}, {
+			Description: "not between",
+			Expr: sb.NotBetween(sb.Column("SrcAddr"),
+				sb.Function("toIPv6", sb.String("::1")),
+				sb.Function("toIPv6", sb.String("::2"))),
+			Expected: `SrcAddr NOT BETWEEN toIPv6('::1') AND toIPv6('::2')`,
+		}, {
+			Description: "in a subquery",
+			Expr: sb.Op(sb.Column("SrcAS"), "IN",
+				sb.Select(sb.Column("asn")).From("asns").Subquery()),
+			Expected: "SrcAS IN (SELECT asn FROM asns)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(tc.Expr.String(), tc.Expected); diff != "" {
+				t.Errorf("String() (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSelect(t *testing.T) {
+	source := sb.Select(sb.Star()).
+		From("flows").
+		Setting("asterisk_include_alias_columns", sb.Uint(1))
+	rows := sb.Select(sb.Column("ExporterName")).
+		From("source").
+		GroupBy(sb.Column("ExporterName")).
+		OrderBy(sb.Order(sb.MustParseExpr("SUM(Bytes)")).Desc()).
+		Limit(10)
+	inner := sb.Select(
+		sb.Alias(sb.Column("TimeReceived"), "time"),
+		sb.Alias(sb.MustParseExpr("SUM(Bytes)/60"), "xps"),
+	).
+		From("source").
+		Where(sb.Between(sb.Column("TimeReceived"),
+			sb.Function("toDateTime", sb.String("2022-04-10 15:45:00")),
+			sb.Function("toDateTime", sb.String("2022-04-11 15:45:00")))).
+		GroupBy(sb.Column("time")).
+		OrderBy(sb.Order(sb.Column("time")).Fill(
+			sb.Function("toDateTime", sb.String("2022-04-10 15:45:00")),
+			sb.Function("toDateTime", sb.String("2022-04-11 15:45:00")),
+			sb.Uint(60))).
+		Interpolate("dimensions", sb.Function("emptyArrayString"))
+	got := sb.Select(sb.Alias(sb.Uint(1), "axis"), sb.Star()).
+		With("source", source).
+		With("rows", rows).
+		FromSelect(inner).
+		String()
+	expected := `WITH
+  source AS (SELECT
+    *
+  FROM
+    flows
+  SETTINGS
+    asterisk_include_alias_columns=1),
+  rows AS (SELECT
+    ExporterName
+  FROM
+    source
+  GROUP BY
+    ExporterName
+  ORDER BY
+    SUM(Bytes) DESC
+  LIMIT 10)
+SELECT
+  1 AS axis,
+  *
+FROM
+  (SELECT
+    TimeReceived AS time,
+    SUM(Bytes) / 60 AS xps
+  FROM
+    source
+  WHERE
+    TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00') AND toDateTime('2022-04-11 15:45:00')
+  GROUP BY
+    time
+  ORDER BY
+    time WITH FILL FROM toDateTime('2022-04-10 15:45:00') TO toDateTime('2022-04-11 15:45:00') STEP 60
+    INTERPOLATE (dimensions AS emptyArrayString()))`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+// TestSelectEmptyClauses checks a clause is dropped when it gets nothing to
+// work with, so a caller does not have to test for that itself.
+func TestSelectEmptyClauses(t *testing.T) {
+	got := sb.Select(sb.Star()).
+		From("flows").
+		Where(sb.Op(sb.Column("SrcAS"), "=", sb.Uint(12322))).
+		GroupBy(sb.Columns("SrcAS", "DstAS")...).
+		OrderBy(sb.Order(sb.Column("SrcAS"))).
+		// Building the same query without a filter, a grouping or a sort must
+		// remove the clauses again.
+		Where(sb.Expr{}).
+		GroupBy().
+		OrderBy().
+		String()
+	expected := `SELECT
+  *
+FROM
+  flows`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestSelectStarReplace(t *testing.T) {
+	got := sb.Select().
+		Item(sb.Star(), sb.Replace(
+			sb.Alias(sb.Function("tupleElement",
+				sb.Function("IPv6CIDRToRange",
+					sb.Column("SrcAddr"), sb.Uint(48)),
+				sb.Uint(1)), "SrcAddr"))).
+		From("flows").
+		String()
+	expected := `SELECT
+  * REPLACE(tupleElement(IPv6CIDRToRange(SrcAddr, 48), 1) AS SrcAddr)
+FROM
+  flows`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestSelectStarExcept(t *testing.T) {
+	got := sb.Select().
+		Item(sb.Star(), sb.Except("SrcCommunities", "DstCommunities")).
+		From("flows").
+		String()
+	expected := `SELECT
+  * EXCEPT(SrcCommunities, DstCommunities)
+FROM
+  flows`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestSelectUnionAll(t *testing.T) {
+	first := sb.Select(sb.Alias(sb.Uint(1), "axis")).From("flows")
+	second := sb.Select(sb.Alias(sb.Uint(2), "axis")).From("flows")
+	third := sb.Select(sb.Alias(sb.Uint(3), "axis")).From("flows")
+	got := first.UnionAll(second).UnionAll(third).String()
+	expected := `SELECT
+  1 AS axis
+FROM
+  flows
+UNION ALL
+SELECT
+  2 AS axis
+FROM
+  flows
+UNION ALL
+SELECT
+  3 AS axis
+FROM
+  flows`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestSelectScalarCTE(t *testing.T) {
+	period := sb.Select(sb.MustParseExpr("MAX(TimeReceived) - MIN(TimeReceived)")).From("source")
+	got := sb.Select(sb.Alias(sb.MustParseExpr("SUM(Bytes)/range"), "xps")).
+		WithScalar(period, "range").
+		From("source").
+		String()
+	expected := `WITH
+  (SELECT
+    MAX(TimeReceived) - MIN(TimeReceived)
+  FROM
+    source) AS range
+SELECT
+  SUM(Bytes) / range AS xps
+FROM
+  source`
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("String() (-got, +want):\n%s", diff)
+	}
+}
+
+// TestApply checks how another package would add its own building blocks on
+// top of this one.
+func TestApply(t *testing.T) {
+	truncate := func(bits uint64) func(sb.Expr) sb.Expr {
+		return func(expr sb.Expr) sb.Expr {
+			return sb.Function("tupleElement",
+				sb.Function("IPv6CIDRToRange", expr, sb.Uint(bits)),
+				sb.Uint(1))
+		}
+	}
+	toString := func(expr sb.Expr) sb.Expr {
+		return sb.Function("IPv6NumToString", expr)
+	}
+	got := sb.Column("SrcAddr").Apply(truncate(48), toString).String()
+	expected := "IPv6NumToString(tupleElement(IPv6CIDRToRange(SrcAddr, 48), 1))"
+	if diff := helpers.Diff(got, expected); diff != "" {
+		t.Errorf("Apply() (-got, +want):\n%s", diff)
+	}
+
+	limited := func(limit int) func(*sb.Query) *sb.Query {
+		return func(q *sb.Query) *sb.Query {
+			return q.Limit(limit)
+		}
+	}
+	gotQuery := sb.Select(sb.Star()).From("flows").Apply(limited(5)).String()
+	expectedQuery := `SELECT
+  *
+FROM
+  flows
+LIMIT 5`
+	if diff := helpers.Diff(gotQuery, expectedQuery); diff != "" {
+		t.Errorf("Apply() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestParseExprErrors(t *testing.T) {
+	cases := []string{
+		"SrcAddr, DstAddr",    // two expressions
+		"1 +",                 // incomplete
+		"toIPv6('::1'",        // unbalanced parenthesis
+		"SrcAS = 1; SELECT 2", // two statements
+		// The expression is parsed inside a SELECT, so anything written after
+		// it would be taken for a clause of that SELECT and dropped.
+		"SrcAS = 1 LIMIT 1",
+		"SrcAS = 1 FROM flows",
+		"SrcAS = 1 WHERE DstAS = 2",
+		"SrcAS = 1 SETTINGS max_threads = 1",
+		"SrcAS = 1 UNION ALL SELECT 1",
+		"SrcAS = 1 ORDER BY SrcAS",
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			if _, err := sb.ParseExpr(tc); err == nil {
+				t.Errorf("ParseExpr(%q) did not return an error", tc)
+			}
+		})
+	}
+}
+
+func TestMustParseExprPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("MustParseExpr() did not panic on an invalid expression")
+		}
+	}()
+	sb.MustParseExpr("1 +")
+}
+
+// TestNormalize checks two queries written differently compare equal once
+// normalized, while two different queries do not.
+func TestNormalize(t *testing.T) {
+	compact := `SELECT a, b FROM flows WHERE a=1 AND b=2 ORDER BY a DESC`
+	spread := `SELECT
+  a,
+  b
+FROM flows
+WHERE a = 1
+  AND b = 2
+ORDER BY a DESC`
+	if diff := helpers.Diff(sb.Normalize(t, compact), sb.Normalize(t, spread)); diff != "" {
+		t.Errorf("Normalize() (-compact, +spread):\n%s", diff)
+	}
+	if sb.Normalize(t, compact) == sb.Normalize(t, `SELECT a, b FROM flows WHERE a=1 OR b=2 ORDER BY a DESC`) {
+		t.Error("Normalize() made two different queries equal")
+	}
+	got := sb.NormalizeAll(t, []string{compact, spread})
+	if diff := helpers.Diff(got[0], got[1]); diff != "" {
+		t.Errorf("NormalizeAll() (-got, +want):\n%s", diff)
+	}
+}
+
+func TestSQLMatcher(t *testing.T) {
+	matcher := sb.SQLMatcher(t, `SELECT a FROM flows WHERE a=1`)
+	cases := []struct {
+		Description string
+		Input       any
+		Expected    bool
+	}{
+		{"same query, other layout", "SELECT\n  a\nFROM\n  flows\nWHERE\n  a = 1", true},
+		{"another query", "SELECT a FROM flows WHERE a = 2", false},
+		{"not SQL", "this is not SQL", false},
+		{"not a string", 42, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if diff := helpers.Diff(matcher.Matches(tc.Input), tc.Expected); diff != "" {
+				t.Errorf("Matches(%v) (-got, +want):\n%s", tc.Input, diff)
+			}
+		})
+	}
+	if matcher.String() == "" {
+		t.Error("String() is empty")
+	}
+}
+
+func TestCheckStatement(t *testing.T) {
+	sb.CheckStatement(t, `SELECT a FROM flows WHERE a = 1`)
+}

--- a/common/sqlbuilder/tests.go
+++ b/common/sqlbuilder/tests.go
@@ -17,7 +17,7 @@ import (
 // a database would accept.
 func CheckStatement(t testing.TB, sql string) {
 	t.Helper()
-	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
+	if _, err := parse(sql); err != nil {
 		t.Errorf("cannot parse SQL:\n%s\n\nerror:\n%+v", sql, err)
 	}
 }
@@ -26,7 +26,7 @@ func CheckStatement(t testing.TB, sql string) {
 // only differ by their layout give the same result.
 func Normalize(t testing.TB, sql string) string {
 	t.Helper()
-	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
+	if _, err := parse(sql); err != nil {
 		t.Fatalf("cannot parse SQL:\n%s\n\nerror:\n%+v", sql, err)
 	}
 	return normalize(sql)
@@ -45,7 +45,7 @@ func NormalizeAll(t testing.TB, sqls []string) []string {
 // normalize is Normalize with nothing to report an error to. A statement that
 // does not parse is returned as is.
 func normalize(sql string) string {
-	statements, err := parser.NewParser(sql).ParseStmts()
+	statements, err := parse(sql)
 	if err != nil {
 		return sql
 	}

--- a/common/sqlbuilder/tests.go
+++ b/common/sqlbuilder/tests.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !release
+
+package sqlbuilder
+
+import (
+	"testing"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+	"go.uber.org/mock/gomock"
+)
+
+// CheckStatement checks that a complete SQL statement parses. The builder
+// produces a syntax tree, so this tells if the formatter turns it back into SQL
+// a database would accept.
+func CheckStatement(t testing.TB, sql string) {
+	t.Helper()
+	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
+		t.Errorf("cannot parse SQL:\n%s\n\nerror:\n%+v", sql, err)
+	}
+}
+
+// Normalize parses a SQL statement and renders it again. Two statements that
+// only differ by their layout give the same result.
+func Normalize(t testing.TB, sql string) string {
+	t.Helper()
+	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
+		t.Fatalf("cannot parse SQL:\n%s\n\nerror:\n%+v", sql, err)
+	}
+	return normalize(sql)
+}
+
+// NormalizeAll is Normalize on several statements.
+func NormalizeAll(t testing.TB, sqls []string) []string {
+	t.Helper()
+	normalized := make([]string, len(sqls))
+	for i, sql := range sqls {
+		normalized[i] = Normalize(t, sql)
+	}
+	return normalized
+}
+
+// normalize is Normalize with nothing to report an error to. A statement that
+// does not parse is returned as is.
+func normalize(sql string) string {
+	statements, err := parser.NewParser(sql).ParseStmts()
+	if err != nil {
+		return sql
+	}
+	formatter := parser.NewFormatter().WithBeautify()
+	for _, statement := range statements {
+		formatter.WriteExpr(statement)
+	}
+	return formatter.String()
+}
+
+// SQLMatcher matches a SQL statement, whatever its layout. It is meant for the
+// mocked ClickHouse connection.
+func SQLMatcher(t testing.TB, sql string) gomock.Matcher {
+	t.Helper()
+	return sqlMatcher{expected: Normalize(t, sql)}
+}
+
+type sqlMatcher struct {
+	expected string
+}
+
+func (m sqlMatcher) Matches(x any) bool {
+	sql, ok := x.(string)
+	return ok && normalize(sql) == m.expected
+}
+
+func (m sqlMatcher) String() string {
+	return m.expected
+}

--- a/console/clickhouse.go
+++ b/console/clickhouse.go
@@ -4,12 +4,10 @@
 package console
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
 	"akvorado/console/query"
@@ -81,134 +79,117 @@ AND (engine LIKE '%MergeTree' OR engine = 'Distributed')
 	return nil
 }
 
-// inputContext is the intermeidate context provided by the input handler.
+// inputContext describes a time range, as requested by an input handler. It is
+// what the resolver needs to pick a table.
 type inputContext struct {
-	Start                  time.Time
-	End                    time.Time
-	StartForTableSelection *time.Time
-	MainTableRequired      bool
-	Points                 uint
-	Units                  string
+	Start             time.Time
+	End               time.Time
+	MainTableRequired bool
+	Points            uint
 }
 
-// context is the context to finalize the template.
-type context struct {
+// resolution is the table and the interval to use for a query. It depends on
+// the live table inventory. All axes of a query share the same resolution.
+type resolution struct {
+	// Table is the table the query should happen on.
+	Table string
+	// Interval is the number of seconds between two points.
+	Interval uint64
+	// TableInterval is the resolution of the table.
+	TableInterval time.Duration
+}
+
+// resolved is a resolution applied to one time range. Axes get one each: the
+// previous period covers an earlier range than the main one.
+type resolved struct {
 	Table             string
+	Interval          uint64
 	Timefilter        string
 	TimefilterStart   string
 	TimefilterEnd     string
-	Units             string
-	Interval          uint64
 	ToStartOfInterval string
 }
 
-// templateQuery holds a template string and its associated input context.
-type templateQuery struct {
-	Template string
-	Context  inputContext
-}
-
-// templateEscape escapes `{{` and `}}` from a string. In fact, only
-// the opening tag needs to be escaped.
-func templateEscape(input string) string {
-	return strings.ReplaceAll(input, `{{`, `{{"{{"}}`)
-}
-
-// templateWhere transforms a filter to a WHERE clause
-func templateWhere(qf query.Filter) string {
+// where turns a filter into a WHERE clause, restricted to the resolved time
+// range.
+func (r resolved) where(qf query.Filter) string {
 	if qf.Direct() == "" {
-		return `{{ .Timefilter }}`
+		return r.Timefilter
 	}
-	return fmt.Sprintf(`{{ .Timefilter }} AND (%s)`, templateEscape(qf.Direct()))
+	return fmt.Sprintf(`%s AND (%s)`, r.Timefilter, qf.Direct())
 }
 
-// finalizeTemplateQueries builds the finalized queries from a list of templateQuery.
-// Each template is processed with its associated context and combined with UNION ALL.
-func (c *Component) finalizeTemplateQueries(queries []templateQuery) string {
-	parts := make([]string, len(queries))
-	for i, q := range queries {
-		parts[i] = c.finalizeTemplateQuery(q)
-	}
-	return strings.Join(parts, "\nUNION ALL\n")
-}
-
-// finalizeTemplateQuery builds the finalized query for a single templateQuery
-func (c *Component) finalizeTemplateQuery(query templateQuery) string {
-	input := query.Context
-	table, computedInterval, targetInterval := c.computeTableAndInterval(query.Context)
-
-	// Make start/end match the computed interval (currently equal to the table resolution)
-	start := input.Start.Truncate(computedInterval)
-	end := input.End.Truncate(computedInterval)
-	// Adapt the computed interval to match the target one more closely
-	if targetInterval > computedInterval {
-		computedInterval = targetInterval.Truncate(computedInterval)
-	}
-	// Adapt end to ensure we get a full interval
-	end = start.Add(end.Sub(start).Truncate(computedInterval))
-	// Now, toStartOfInterval will provide an incorrect value. We
-	// compute a correction offset. Go's truncate seems to
-	// be different from what we expect.
-	computedIntervalOffset := start.UTC().Sub(
-		time.Unix(start.UTC().Unix()/
-			int64(computedInterval.Seconds())*
-			int64(computedInterval.Seconds()), 0))
-	diffOffset := uint64(computedInterval.Seconds()) - uint64(computedIntervalOffset.Seconds())
-
-	// Compute all strings
-	timefilterStart := fmt.Sprintf(`toDateTime('%s', 'UTC')`, start.UTC().Format("2006-01-02 15:04:05"))
-	timefilterEnd := fmt.Sprintf(`toDateTime('%s', 'UTC')`, end.UTC().Format("2006-01-02 15:04:05"))
-	timefilter := fmt.Sprintf(`TimeReceived BETWEEN %s AND %s`, timefilterStart, timefilterEnd)
-	var units string
-	switch input.Units {
-	case "fps":
-		units = `COUNT(*)`
-	case "pps":
-		units = `SUM(Packets*SamplingRate)`
-	case "l3bps":
-		units = `SUM(Bytes*SamplingRate*8)`
-	case "l2bps":
+// unitsExpr returns the aggregate expression matching the requested units.
+func unitsExpr(units string) string {
+	return map[string]string{
+		"fps":   `COUNT(*)`,
+		"pps":   `SUM(Packets*SamplingRate)`,
+		"l3bps": `SUM(Bytes*SamplingRate*8)`,
 		// For each packet, we add the Ethernet header (14 bytes), the FCS (4
 		// bytes), the preamble and start frame delimiter (8 bytes) and the IPG
 		// (~ 12 bytes). We don't include the VLAN header (4 bytes) as it is
 		// often not used with external entities. Both sFlow and IPFIX may have
 		// a better view of that, but we don't collect it yet.
-		units = `SUM((Bytes+38*Packets)*SamplingRate*8)`
-	case "inl2%":
+		"l2bps": `SUM((Bytes+38*Packets)*SamplingRate*8)`,
 		// That's like l2bps, but this time we use the interface speed to get a
 		// percent value
-		units = `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)`
-	case "outl2%":
+		"inl2%": `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)`,
 		// Same but using output interface as reference
-		units = `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)`
+		"outl2%": `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)`,
+	}[units]
+}
+
+// resolve picks the best table for the requested time range and the interval
+// between two points.
+func (c *Component) resolve(input inputContext) resolution {
+	table, tableInterval, targetInterval := c.computeTableAndInterval(input)
+
+	// Adapt the table interval to match the target one more closely
+	interval := tableInterval
+	if targetInterval > tableInterval {
+		interval = targetInterval.Truncate(tableInterval)
 	}
 
-	c.metrics.clickhouseQueries.WithLabelValues(table).Inc()
+	return resolution{
+		Table:         table,
+		Interval:      uint64(interval.Seconds()),
+		TableInterval: tableInterval,
+	}
+}
 
-	context := context{
-		Table:           table,
-		Timefilter:      timefilter,
+// forRange applies a resolution to a time range, aligning it on the interval.
+func (r resolution) forRange(start, end time.Time) resolved {
+	interval := time.Duration(r.Interval) * time.Second
+	// Make start/end match the table interval
+	start = start.Truncate(r.TableInterval)
+	end = end.Truncate(r.TableInterval)
+	// Adapt end to ensure we get a full interval
+	end = start.Add(end.Sub(start).Truncate(interval))
+	// Now, toStartOfInterval will provide an incorrect value. We compute a
+	// correction offset. Go's truncate seems to be different from what we
+	// expect.
+	intervalOffset := start.UTC().Sub(
+		time.Unix(start.UTC().Unix()/
+			int64(interval.Seconds())*
+			int64(interval.Seconds()), 0))
+	diffOffset := r.Interval - uint64(intervalOffset.Seconds())
+
+	timefilterStart := fmt.Sprintf(`toDateTime('%s', 'UTC')`, start.UTC().Format("2006-01-02 15:04:05"))
+	timefilterEnd := fmt.Sprintf(`toDateTime('%s', 'UTC')`, end.UTC().Format("2006-01-02 15:04:05"))
+
+	return resolved{
+		Table:           r.Table,
+		Interval:        r.Interval,
+		Timefilter:      fmt.Sprintf(`TimeReceived BETWEEN %s AND %s`, timefilterStart, timefilterEnd),
 		TimefilterStart: timefilterStart,
 		TimefilterEnd:   timefilterEnd,
-		Units:           units,
-		Interval:        uint64(computedInterval.Seconds()),
 		ToStartOfInterval: fmt.Sprintf(
 			`toStartOfInterval(%s + INTERVAL %d second, INTERVAL %d second) - INTERVAL %d second`,
 			"TimeReceived",
 			diffOffset,
-			uint64(computedInterval.Seconds()),
+			r.Interval,
 			diffOffset),
 	}
-
-	t := template.Must(template.New("query").
-		Option("missingkey=error").
-		Parse(strings.TrimSpace(query.Template)))
-	buf := bytes.NewBufferString("")
-	if err := t.Execute(buf, context); err != nil {
-		c.r.Err(err).Str("query", query.Template).Msg("invalid query")
-		panic(err)
-	}
-	return buf.String()
 }
 
 func (c *Component) computeTableAndInterval(input inputContext) (string, time.Duration, time.Duration) {
@@ -216,15 +197,10 @@ func (c *Component) computeTableAndInterval(input inputContext) (string, time.Du
 	targetInterval = max(targetInterval, time.Second)
 
 	// Select table
-	targetIntervalForTableSelection := targetInterval
 	if input.MainTableRequired {
 		return "flows", time.Second, targetInterval
 	}
-	startForTableSelection := input.Start
-	if input.StartForTableSelection != nil {
-		startForTableSelection = *input.StartForTableSelection
-	}
-	table, computedInterval := c.getBestTable(startForTableSelection, targetIntervalForTableSelection)
+	table, computedInterval := c.getBestTable(input.Start, targetInterval)
 	return table, computedInterval, targetInterval
 }
 
@@ -236,9 +212,8 @@ func (c *Component) getBestTable(start time.Time, targetInterval time.Duration) 
 	table := "flows"
 	computedInterval := time.Second
 	if len(c.flowsTables) > 0 {
-		// We can use the consolidated data. The first
-		// criteria is to find the tables matching the time
-		// criteria.
+		// We can use the consolidated data. The first criteria is to find the
+		// tables matching the time criteria.
 		candidates := []int{}
 		for idx, table := range c.flowsTables {
 			if start.After(table.Oldest.Add(table.Resolution)) {

--- a/console/clickhouse.go
+++ b/console/clickhouse.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -102,48 +103,94 @@ type resolution struct {
 // resolved is a resolution applied to one time range. Axes get one each: the
 // previous period covers an earlier range than the main one.
 type resolved struct {
-	Table             string
-	Interval          uint64
-	Timefilter        string
-	TimefilterStart   string
-	TimefilterEnd     string
-	ToStartOfInterval string
+	Table string
+	// Interval is the number of seconds between two points.
+	Interval uint64
+	// Start and End are the time range, aligned on the interval.
+	Start time.Time
+	End   time.Time
+	// Offset shifts the buckets of toStartOfInterval, which would otherwise not
+	// start on Start.
+	Offset uint64
 }
 
 // unionAll combines the per-axis queries into the single statement sent to
 // ClickHouse. Only the first axis carries the WITH clause, the others reference
 // its CTEs.
-func unionAll(queries []string) string {
-	return strings.Join(queries, "\nUNION ALL\n")
+func unionAll(queries []*sb.Query) string {
+	first := queries[0]
+	for _, other := range queries[1:] {
+		first.UnionAll(other)
+	}
+	return first.String()
+}
+
+// seconds returns an interval of the provided number of seconds.
+func seconds(count uint64) sb.Expr {
+	return sb.Interval(sb.Uint(count), "second")
+}
+
+// dateTime turns a timestamp into a UTC date-time.
+func dateTime(when time.Time) sb.Expr {
+	return sb.Function("toDateTime",
+		sb.String(when.UTC().Format("2006-01-02 15:04:05")),
+		sb.String("UTC"))
+}
+
+// timefilterStart is the beginning of the resolved time range.
+func (r resolved) timefilterStart() sb.Expr {
+	return dateTime(r.Start)
+}
+
+// timefilterEnd is the end of the resolved time range.
+func (r resolved) timefilterEnd() sb.Expr {
+	return dateTime(r.End)
+}
+
+// timefilter restricts a query to the resolved time range.
+func (r resolved) timefilter() sb.Expr {
+	return sb.Between(sb.Column("TimeReceived"),
+		r.timefilterStart(), r.timefilterEnd())
+}
+
+// toStartOfInterval puts TimeReceived into a bucket. The buckets are shifted so
+// that the first one starts at the beginning of the time range.
+func (r resolved) toStartOfInterval() sb.Expr {
+	return sb.Op(
+		sb.Function("toStartOfInterval",
+			sb.Op(sb.Column("TimeReceived"), "+", seconds(r.Offset)),
+			seconds(r.Interval)),
+		"-", seconds(r.Offset))
 }
 
 // where turns a filter into a WHERE clause, restricted to the resolved time
 // range.
-func (r resolved) where(qf query.Filter) string {
-	if qf.Direct() == "" {
-		return r.Timefilter
-	}
-	return fmt.Sprintf(`%s AND (%s)`, r.Timefilter, qf.Direct())
+func (r resolved) where(qf query.Filter) sb.Expr {
+	return sb.And(r.timefilter(), qf.Direct())
 }
 
 // unitsExpr returns the aggregate expression matching the requested units.
-func unitsExpr(units string) string {
-	return map[string]string{
-		"fps":   `COUNT(*)`,
-		"pps":   `SUM(Packets*SamplingRate)`,
-		"l3bps": `SUM(Bytes*SamplingRate*8)`,
-		// For each packet, we add the Ethernet header (14 bytes), the FCS (4
-		// bytes), the preamble and start frame delimiter (8 bytes) and the IPG
-		// (~ 12 bytes). We don't include the VLAN header (4 bytes) as it is
-		// often not used with external entities. Both sFlow and IPFIX may have
-		// a better view of that, but we don't collect it yet.
-		"l2bps": `SUM((Bytes+38*Packets)*SamplingRate*8)`,
-		// That's like l2bps, but this time we use the interface speed to get a
-		// percent value
-		"inl2%": `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)`,
-		// Same but using output interface as reference
-		"outl2%": `ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)`,
-	}[units]
+// These are fixed formulas, easier to read and to check as SQL than as a tree
+// of calls. They are parsed once, at startup.
+func unitsExpr(units string) sb.Expr {
+	return unitsExprs[units]
+}
+
+var unitsExprs = map[string]sb.Expr{
+	"fps":   sb.MustParseExpr(`COUNT(*)`),
+	"pps":   sb.MustParseExpr(`SUM(Packets*SamplingRate)`),
+	"l3bps": sb.MustParseExpr(`SUM(Bytes*SamplingRate*8)`),
+	// For each packet, we add the Ethernet header (14 bytes), the FCS (4
+	// bytes), the preamble and start frame delimiter (8 bytes) and the IPG
+	// (~ 12 bytes). We don't include the VLAN header (4 bytes) as it is
+	// often not used with external entities. Both sFlow and IPFIX may have
+	// a better view of that, but we don't collect it yet.
+	"l2bps": sb.MustParseExpr(`SUM((Bytes+38*Packets)*SamplingRate*8)`),
+	// That's like l2bps, but this time we use the interface speed to get a
+	// percent value
+	"inl2%": sb.MustParseExpr(`ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)`),
+	// Same but using output interface as reference
+	"outl2%": sb.MustParseExpr(`ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)`),
 }
 
 // resolve picks the best table for the requested time range and the interval
@@ -179,23 +226,13 @@ func (r resolution) forRange(start, end time.Time) resolved {
 		time.Unix(start.UTC().Unix()/
 			int64(interval.Seconds())*
 			int64(interval.Seconds()), 0))
-	diffOffset := r.Interval - uint64(intervalOffset.Seconds())
-
-	timefilterStart := fmt.Sprintf(`toDateTime('%s', 'UTC')`, start.UTC().Format("2006-01-02 15:04:05"))
-	timefilterEnd := fmt.Sprintf(`toDateTime('%s', 'UTC')`, end.UTC().Format("2006-01-02 15:04:05"))
 
 	return resolved{
-		Table:           r.Table,
-		Interval:        r.Interval,
-		Timefilter:      fmt.Sprintf(`TimeReceived BETWEEN %s AND %s`, timefilterStart, timefilterEnd),
-		TimefilterStart: timefilterStart,
-		TimefilterEnd:   timefilterEnd,
-		ToStartOfInterval: fmt.Sprintf(
-			`toStartOfInterval(%s + INTERVAL %d second, INTERVAL %d second) - INTERVAL %d second`,
-			"TimeReceived",
-			diffOffset,
-			r.Interval,
-			diffOffset),
+		Table:    r.Table,
+		Interval: r.Interval,
+		Start:    start,
+		End:      end,
+		Offset:   r.Interval - uint64(intervalOffset.Seconds()),
 	}
 }
 

--- a/console/clickhouse.go
+++ b/console/clickhouse.go
@@ -110,6 +110,13 @@ type resolved struct {
 	ToStartOfInterval string
 }
 
+// unionAll combines the per-axis queries into the single statement sent to
+// ClickHouse. Only the first axis carries the WITH clause, the others reference
+// its CTEs.
+func unionAll(queries []string) string {
+	return strings.Join(queries, "\nUNION ALL\n")
+}
+
 // where turns a filter into a WHERE clause, restricted to the resolved time
 // range.
 func (r resolved) where(qf query.Filter) string {

--- a/console/clickhouse.go
+++ b/console/clickhouse.go
@@ -219,21 +219,33 @@ func (r resolution) forRange(start, end time.Time) resolved {
 	end = end.Truncate(r.TableInterval)
 	// Adapt end to ensure we get a full interval
 	end = start.Add(end.Sub(start).Truncate(interval))
-	// Now, toStartOfInterval will provide an incorrect value. We compute a
-	// correction offset. Go's truncate seems to be different from what we
-	// expect.
-	intervalOffset := start.UTC().Sub(
-		time.Unix(start.UTC().Unix()/
-			int64(interval.Seconds())*
-			int64(interval.Seconds()), 0))
 
 	return resolved{
 		Table:    r.Table,
 		Interval: r.Interval,
 		Start:    start,
 		End:      end,
-		Offset:   r.Interval - uint64(intervalOffset.Seconds()),
+		Offset:   intervalOffset(start, r.Interval),
 	}
+}
+
+// shiftBack moves a resolved range back in time. Both ends move by the same
+// amount, so the range keeps its length and therefore its number of points.
+// This is how the previous period is drawn on the time axis of the main one.
+func (r resolved) shiftBack(offset time.Duration) resolved {
+	r.Start = r.Start.Add(-offset)
+	r.End = r.End.Add(-offset)
+	r.Offset = intervalOffset(r.Start, r.Interval)
+	return r
+}
+
+// intervalOffset returns by how much the buckets of toStartOfInterval have to
+// be shifted, as they would otherwise not start on the beginning of the range.
+// Not using Go's truncate, but I don't remember why...
+func intervalOffset(start time.Time, interval uint64) uint64 {
+	seconds := int64(interval)
+	aligned := time.Unix(start.UTC().Unix()/seconds*seconds, 0)
+	return interval - uint64(start.UTC().Sub(aligned).Seconds())
 }
 
 func (c *Component) computeTableAndInterval(input inputContext) (string, time.Duration, time.Duration) {

--- a/console/clickhouse_test.go
+++ b/console/clickhouse_test.go
@@ -4,7 +4,6 @@
 package console
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -86,17 +85,19 @@ var testResolution = resolution{
 // The exact SQL wording is pinned by the query tests, so this test can stay
 // about the arithmetic.
 func resolvedFor(r resolution, start, end string, offset uint64) resolved {
-	timefilterStart := fmt.Sprintf(`toDateTime('%s', 'UTC')`, start)
-	timefilterEnd := fmt.Sprintf(`toDateTime('%s', 'UTC')`, end)
+	parse := func(value string) time.Time {
+		when, err := time.ParseInLocation("2006-01-02 15:04:05", value, time.UTC)
+		if err != nil {
+			panic(err)
+		}
+		return when
+	}
 	return resolved{
-		Table:           r.Table,
-		Interval:        r.Interval,
-		Timefilter:      fmt.Sprintf("TimeReceived BETWEEN %s AND %s", timefilterStart, timefilterEnd),
-		TimefilterStart: timefilterStart,
-		TimefilterEnd:   timefilterEnd,
-		ToStartOfInterval: fmt.Sprintf(
-			"toStartOfInterval(TimeReceived + INTERVAL %d second, INTERVAL %d second) - INTERVAL %d second",
-			offset, r.Interval, offset),
+		Table:    r.Table,
+		Interval: r.Interval,
+		Start:    parse(start),
+		End:      parse(end),
+		Offset:   offset,
 	}
 }
 

--- a/console/clickhouse_test.go
+++ b/console/clickhouse_test.go
@@ -4,6 +4,7 @@
 package console
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -72,145 +73,144 @@ AND (engine LIKE '%MergeTree' OR engine = 'Distributed')
 	}
 }
 
-func TestFinalizeQuery(t *testing.T) {
+// testResolution is the resolution used by the query tests. It is fixed so
+// that the expected queries only differ by what the input changes.
+var testResolution = resolution{
+	Table:         "flows",
+	Interval:      60,
+	TableInterval: time.Minute,
+}
+
+// resolvedFor builds the expected value of forRange() out of the interesting
+// bits: the interval-aligned time range and the toStartOfInterval correction.
+// The exact SQL wording is pinned by the query tests, so this test can stay
+// about the arithmetic.
+func resolvedFor(r resolution, start, end string, offset uint64) resolved {
+	timefilterStart := fmt.Sprintf(`toDateTime('%s', 'UTC')`, start)
+	timefilterEnd := fmt.Sprintf(`toDateTime('%s', 'UTC')`, end)
+	return resolved{
+		Table:           r.Table,
+		Interval:        r.Interval,
+		Timefilter:      fmt.Sprintf("TimeReceived BETWEEN %s AND %s", timefilterStart, timefilterEnd),
+		TimefilterStart: timefilterStart,
+		TimefilterEnd:   timefilterEnd,
+		ToStartOfInterval: fmt.Sprintf(
+			"toStartOfInterval(TimeReceived + INTERVAL %d second, INTERVAL %d second) - INTERVAL %d second",
+			offset, r.Interval, offset),
+	}
+}
+
+func TestResolve(t *testing.T) {
 	cases := []struct {
 		Description string
 		Tables      []flowsTable
-		Query       string
 		Context     inputContext
-		Expected    string
+		Expected    resolved
 	}{
 		{
-			Description: "simple query without additional tables",
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Description: "no table known yet",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				Points: 86400,
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 1, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 1),
 		}, {
-			Description: "query with source port",
-			Query:       "SELECT TimeReceived, SrcPort FROM {{ .Table }} WHERE {{ .Timefilter }}",
+			Description: "main table required",
 			Context: inputContext{
 				Start:             time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:               time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				MainTableRequired: true,
 				Points:            86400,
 			},
-			Expected: "SELECT TimeReceived, SrcPort FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 1, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 1),
 		}, {
 			Description: "only flows table available",
 			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				Points: 86400,
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
-		}, {
-			Description: "timefilter.Start and timefilter.Stop",
-			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT {{ .TimefilterStart }}, {{ .TimefilterEnd }}",
-			Context: inputContext{
-				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 86400,
-			},
-			Expected: "SELECT toDateTime('2022-04-10 15:45:10', 'UTC'), toDateTime('2022-04-11 15:45:10', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 1, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 1),
 		}, {
 			Description: "only flows table and out of range request",
 			Tables:      []flowsTable{{"flows", 0, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)}},
-			Query:       "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				Points: 86400,
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 1, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 1),
 		}, {
 			Description: "select consolidated table",
 			Tables: []flowsTable{
 				{"flows", 0, time.Date(2022, 3, 10, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows_1m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') // 120",
+			Expected: resolvedFor(resolution{Table: "flows_1m0s", Interval: 120, TableInterval: time.Minute},
+				"2022-04-10 15:45:00", "2022-04-11 15:45:00", 60),
 		}, {
 			Description: "select consolidated table out of range",
 			Tables: []flowsTable{
 				{"flows", 0, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 720, // 2-minute resolution,
+				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows_1m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows_1m0s", Interval: 120, TableInterval: time.Minute},
+				"2022-04-10 15:45:00", "2022-04-11 15:45:00", 60),
 		}, {
 			Description: "select flows table out of range",
 			Tables: []flowsTable{
 				{"flows", 0, time.Date(2022, 4, 10, 16, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 720, // 2-minute resolution,
+				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 120, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 50),
 		}, {
-			Description: "use flows table for resolution (control for next case)",
+			Description: "use flows table for resolution",
 			Tables: []flowsTable{
 				{"flows", 0, time.Date(2022, 4, 10, 10, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 10, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
 				Points: 2880, // 30-second resolution
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC') // 30",
-		}, {
-			Description: "use flows table for resolution and for data",
-			Tables: []flowsTable{
-				{"flows", 0, time.Date(2022, 4, 10, 10, 45, 10, 0, time.UTC)},
-				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 10, 45, 10, 0, time.UTC)},
-			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
-			Context: inputContext{
-				Start: time.Date(2022, 3, 10, 15, 45, 10, 0, time.UTC),
-				End:   time.Date(2022, 3, 11, 15, 45, 10, 0, time.UTC),
-				StartForTableSelection: func() *time.Time {
-					t := time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
-					return &t
-				}(),
-				Points: 2880, // 30-second resolution
-			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-03-10 15:45:10', 'UTC') AND toDateTime('2022-03-11 15:45:10', 'UTC') // 30",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 30, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 20),
 		}, {
 			Description: "select flows table with better resolution",
 			Tables: []flowsTable{
 				{"flows", 0, time.Date(2022, 3, 10, 16, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 3, 10, 17, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 2880,
+				Points: 2880, // 30-second resolution
 			},
-			Expected: "SELECT 1 FROM flows WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:10', 'UTC') AND toDateTime('2022-04-11 15:45:10', 'UTC') // 30",
+			Expected: resolvedFor(resolution{Table: "flows", Interval: 30, TableInterval: time.Second},
+				"2022-04-10 15:45:10", "2022-04-11 15:45:10", 20),
 		}, {
 			Description: "select consolidated table with better resolution",
 			Tables: []flowsTable{
@@ -218,13 +218,13 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_5m0s", 5 * time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }} // {{ .Interval }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 720, // 2-minute resolution,
+				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows_1m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') // 120",
+			Expected: resolvedFor(resolution{Table: "flows_1m0s", Interval: 120, TableInterval: time.Minute},
+				"2022-04-10 15:45:00", "2022-04-11 15:45:00", 60),
 		}, {
 			Description: "select consolidated table with better range",
 			Tables: []flowsTable{
@@ -232,13 +232,13 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_5m0s", 5 * time.Minute, time.Date(2022, 4, 2, 22, 45, 10, 0, time.UTC)},
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 22, 45, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 46, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 46, 10, 0, time.UTC),
-				Points: 720, // 2-minute resolution,
+				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows_5m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows_5m0s", Interval: 300, TableInterval: 5 * time.Minute},
+				"2022-04-10 15:45:00", "2022-04-11 15:45:00", 300),
 		}, {
 			Description: "select best resolution when equality for oldest data",
 			Tables: []flowsTable{
@@ -246,54 +246,15 @@ func TestFinalizeQuery(t *testing.T) {
 				{"flows_1m0s", time.Minute, time.Date(2022, 4, 10, 22, 40, 0, 0, time.UTC)},
 				{"flows_1h0m0s", time.Hour, time.Date(2022, 4, 10, 22, 0, 10, 0, time.UTC)},
 			},
-			Query: "SELECT 1 FROM {{ .Table }} WHERE {{ .Timefilter }}",
 			Context: inputContext{
 				Start:  time.Date(2022, 4, 10, 15, 46, 10, 0, time.UTC),
 				End:    time.Date(2022, 4, 11, 15, 46, 10, 0, time.UTC),
-				Points: 720, // 2-minute resolution,
+				Points: 720, // 2-minute resolution
 			},
-			Expected: "SELECT 1 FROM flows_1m0s WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:46:00', 'UTC') AND toDateTime('2022-04-11 15:46:00', 'UTC')",
+			Expected: resolvedFor(resolution{Table: "flows_1m0s", Interval: 120, TableInterval: time.Minute},
+				"2022-04-10 15:46:00", "2022-04-11 15:46:00", 120),
 		}, {
-			Description: "query with escaped template",
-			Query:       `SELECT TimeReceived, SrcPort WHERE InIfDescription = '{{"{{"}} hello }}'`,
-			Context: inputContext{
-				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 86400,
-			},
-			Expected: `SELECT TimeReceived, SrcPort WHERE InIfDescription = '{{ hello }}'`,
-		}, {
-			Description: "use of ToStartOfInterval",
-			Query:       `{{ .ToStartOfInterval }}`,
-			Context: inputContext{
-				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 720,
-			},
-			Expected: `toStartOfInterval(TimeReceived + INTERVAL 50 second, INTERVAL 120 second) - INTERVAL 50 second`,
-		}, {
-			Description: "fps units",
-			Query:       `SELECT {{ .Units }} FROM {{ .Table }}`,
-			Context: inputContext{
-				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 86400,
-				Units:  "fps",
-			},
-			Expected: "SELECT COUNT(*) FROM flows",
-		}, {
-			Description: "pps units",
-			Query:       `SELECT {{ .Units }} FROM {{ .Table }}`,
-			Context: inputContext{
-				Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-				End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-				Points: 86400,
-				Units:  "pps",
-			},
-			Expected: "SELECT SUM(Packets*SamplingRate) FROM flows",
-		}, {
-			Description: "Small interval outside main table expiration",
-			Query:       "SELECT InIfProvider FROM {{ .Table }}",
+			Description: "small interval outside main table expiration",
 			Tables: []flowsTable{
 				{"flows", time.Duration(0), time.Date(2022, 11, 6, 12, 0, 0, 0, time.UTC)},
 				{"flows_1h0m0s", time.Hour, time.Date(2022, 4, 25, 18, 0, 0, 0, time.UTC)},
@@ -305,7 +266,8 @@ func TestFinalizeQuery(t *testing.T) {
 				End:    time.Date(2022, 10, 30, 12, 0, 0, 0, time.UTC),
 				Points: 200,
 			},
-			Expected: "SELECT InIfProvider FROM flows_5m0s",
+			Expected: resolvedFor(resolution{Table: "flows_5m0s", Interval: 300, TableInterval: 5 * time.Minute},
+				"2022-10-30 01:00:00", "2022-10-30 12:00:00", 300),
 		},
 	}
 
@@ -313,12 +275,9 @@ func TestFinalizeQuery(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Description, func(t *testing.T) {
 			c.flowsTables = tc.Tables
-			got := c.finalizeTemplateQuery(templateQuery{
-				Template: tc.Query,
-				Context:  tc.Context,
-			})
-			if diff := helpers.Diff(got, tc.Expected); diff != "" {
-				t.Fatalf("finalizeTemplateQuery(): (-got, +want):\n%s", diff)
+			got := c.resolve(tc.Context)
+			if diff := helpers.Diff(got.forRange(tc.Context.Start, tc.Context.End), tc.Expected); diff != "" {
+				t.Fatalf("resolve().forRange() (-got, +want):\n%s", diff)
 			}
 		})
 	}

--- a/console/config_test.go
+++ b/console/config_test.go
@@ -6,8 +6,62 @@ package console
 import (
 	"testing"
 
+	"github.com/benbjohnson/clock"
+
+	"akvorado/common/clickhousedb"
+	"akvorado/common/daemon"
 	"akvorado/common/helpers"
+	"akvorado/common/httpserver"
+	"akvorado/common/reporter"
+	"akvorado/common/schema"
+	"akvorado/console/authentication"
+	"akvorado/console/database"
 )
+
+// TestHomepageGraphFilter checks the filter is parsed when the console starts.
+// An invalid one has to be reported then, not on each request to the homepage.
+func TestHomepageGraphFilter(t *testing.T) {
+	cases := []struct {
+		Description string
+		Filter      string
+		Invalid     bool
+	}{
+		{Description: "no filter"},
+		{Description: "a condition", Filter: "InIfBoundary = 'external'"},
+		{Description: "incomplete condition", Filter: "InIfBoundary =", Invalid: true},
+		{Description: "two conditions", Filter: "InIfBoundary = 'external', SrcAS = 65000", Invalid: true},
+		{
+			// Anything after the expression lands in a clause of the SELECT it
+			// is parsed in, where it would be dropped without notice.
+			Description: "condition followed by a clause",
+			Filter:      "InIfBoundary = 'external' LIMIT 1",
+			Invalid:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			r := reporter.NewMock(t)
+			ch, _ := clickhousedb.NewMock(t, r)
+			config := DefaultConfiguration()
+			config.HomepageGraphFilter = tc.Filter
+			_, err := New(r, config, Dependencies{
+				Daemon:       daemon.NewMock(t),
+				HTTP:         httpserver.NewMock(t, r),
+				ClickHouseDB: ch,
+				Clock:        clock.NewMock(),
+				Auth:         authentication.NewMock(t, r),
+				Database:     database.NewMock(t, r, database.DefaultConfiguration()),
+				Schema:       schema.NewMock(t),
+			})
+			if tc.Invalid && err == nil {
+				t.Errorf("New() with filter %q did not return an error", tc.Filter)
+			}
+			if !tc.Invalid && err != nil {
+				t.Errorf("New() error:\n%+v", err)
+			}
+		})
+	}
+}
 
 func TestConfigHandler(t *testing.T) {
 	config := DefaultConfiguration()

--- a/console/data/docs/81-internals.md
+++ b/console/data/docs/81-internals.md
@@ -148,6 +148,14 @@ When inserting into ClickHouse, we rely on the low-level
 [ch-go](https://github.com/ClickHouse/ch-go/) library. Decoded flows are batched
 directly into the wire format that is used by ClickHouse.
 
+The console and the orchestrator build SQL queries with a Fluent-like builder
+API in `common/sqlbuilder`, which outputs a syntax tree based on
+[clickhouse-sql-parser](https://github.com/Aftership/clickhouse-sql-parser). The
+filter language is also translated to a syntax tree and combined with the syntax
+tree built by the console from the elements selected by the user. The
+orchestrator also leverages the parser to compare two SQL queries and check if
+an update is needed.
+
 Functional tests are run when a ClickHouse server is available under
 the name `clickhouse` or on `localhost`.
 
@@ -284,11 +292,11 @@ reference](52-console.md#filter-language). The grammar is in
 expression grammar. Such grammars are easier to write than context-free ones and
 they give better error messages.
 
-There is no intermediate syntax tree. Each rule carries a Go action returning
-the matching part of the ClickHouse `WHERE` clause, and the values are checked
-while parsing. For example, `ExporterAddress = 203.0.113.15` becomes
-`ExporterAddress = IPv6StringToNum('203.0.113.15')`, and a malformed address is
-rejected at this point.
+Each rule carries a Go action returning a piece of the syntax tree for the
+ClickHouse `WHERE` clause, and the values are checked while parsing. For
+example, `ExporterAddress = 203.0.113.15` becomes `ExporterAddress =
+IPv6StringToNum('203.0.113.15')`, and a malformed address is rejected at this
+point.
 
 The editor is [CodeMirror](https://codemirror.net/6/), with a second and simpler
 grammar for [Lezer](https://lezer.codemirror.net/) in

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -25,6 +25,7 @@ memory. Drop it on each cluster member once the new version runs:
 - ✨ *outlet*: optionally export decoded and enriched flows to a Kafka topic
 - ✨ *console*: allow filters to compare two columns, like `SrcPort < DstPort`,
   `DstAS != SrcAS` or `InIfConnectivity != OutIfConnectivity`
+- 🩹 *console*: fix the reverse direction of a filter on `SrcNetPrefix` or `DstNetPrefix`
 - 🩹 *orchestrator*: fix custom dictionaries with an IP prefix layout
 - 🌱 *docs*: reorganize the documentation with the Diátaxis framework
 - 🌱 *docs*: serve the documentation as Markdown when explicitely asked

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -26,6 +26,7 @@ memory. Drop it on each cluster member once the new version runs:
 - ✨ *console*: allow filters to compare two columns, like `SrcPort < DstPort`,
   `DstAS != SrcAS` or `InIfConnectivity != OutIfConnectivity`
 - 🩹 *console*: fix the reverse direction of a filter on `SrcNetPrefix` or `DstNetPrefix`
+- 🩹 *console*: fix `NOT` in front of a filter on `SrcNetPrefix` or `DstNetPrefix`
 - 🩹 *orchestrator*: fix custom dictionaries with an IP prefix layout
 - 🌱 *docs*: reorganize the documentation with the Diátaxis framework
 - 🌱 *docs*: serve the documentation as Markdown when explicitely asked

--- a/console/filter.go
+++ b/console/filter.go
@@ -15,6 +15,7 @@ import (
 	"akvorado/common/helpers"
 	"akvorado/common/httpserver"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/authentication"
 	"akvorado/console/database"
 	"akvorado/console/filter"
@@ -49,7 +50,7 @@ func (c *Component) filterValidateHandlerFunc(w http.ResponseWriter, req *http.R
 	if err == nil {
 		httpserver.WriteJSON(w, http.StatusOK, filterValidateHandlerOutput{
 			Message: "ok",
-			Parsed:  got.(string),
+			Parsed:  got.(sb.Expr).String(),
 		})
 		return
 	}

--- a/console/filter/helpers.go
+++ b/console/filter/helpers.go
@@ -140,6 +140,16 @@ func (c *current) getColumn(name string) schema.Column {
 	return schema.Column{}
 }
 
+// requireMainTable records that the main table is needed when one of the
+// provided columns only lives there.
+func (c *current) requireMainTable(cols ...schema.Column) {
+	for _, col := range cols {
+		if col.ClickHouseMainOnly {
+			c.globalStore["meta"].(*Meta).MainTableRequired = true
+		}
+	}
+}
+
 // parsePrefix parses a prefix to SQL by combining Src/DstAddr and
 // Src/DstNetmask. This function already uses the right direction.
 func (c *current) parsePrefix(col schema.Column, prefix string) ([]any, error) {
@@ -150,6 +160,7 @@ func (c *current) parsePrefix(col schema.Column, prefix string) ([]any, error) {
 	col = c.reverseColumn(col)
 	// If the prefix was materialized, we can directly access it
 	if col.ClickHouseMaterialized {
+		c.requireMainTable(col)
 		return []any{
 			col.Name, "=",
 			fmt.Sprintf("'%s'", net.String()),
@@ -159,13 +170,16 @@ func (c *current) parsePrefix(col schema.Column, prefix string) ([]any, error) {
 	if strings.HasPrefix(col.Name, "Src") {
 		direction = "Src"
 	}
-	// If the prefix is not materialized, we use the "between" operator
-	c.globalStore["meta"].(*Meta).MainTableRequired = true
+	// If the prefix is not materialized, we use the "between" operator on the
+	// address and the mask.
+	addr := fmt.Sprintf("%sAddr", direction)
+	mask := fmt.Sprintf("%sNetMask", direction)
+	c.requireMainTable(c.getColumn(addr), c.getColumn(mask))
 	return []any{
-		fmt.Sprintf("%sAddr", direction),
+		addr,
 		fmt.Sprintf("BETWEEN toIPv6('%s') AND toIPv6('%s') AND",
 			net.Masked().Addr().String(), lastIP(net).String()),
-		fmt.Sprintf("%sNetMask", direction), "=", net.Bits(),
+		mask, "=", net.Bits(),
 	}, nil
 }
 

--- a/console/filter/helpers.go
+++ b/console/filter/helpers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 )
 
 // Meta is used to inject/retrieve state from the parser.
@@ -24,10 +25,27 @@ type Meta struct {
 	MainTableRequired bool
 }
 
+// condition is the right side of a comparison: an operator and a value. It is
+// built before the left side is known, as the grammar matches the column first.
+type condition struct {
+	operator string
+	value    sb.Expr
+}
+
+// apply completes the condition with its left side.
+func (cond condition) apply(left sb.Expr) sb.Expr {
+	return sb.Op(left, cond.operator, cond.value)
+}
+
+// meta returns the parser state.
+func (c *current) meta() *Meta {
+	return c.globalStore["meta"].(*Meta)
+}
+
 // reverseColumn returns the column for the opposite direction when the filter
 // is parsed for the reverse direction. Otherwise, the column is returned as is.
 func (c *current) reverseColumn(col schema.Column) schema.Column {
-	meta := c.globalStore["meta"].(*Meta)
+	meta := c.meta()
 	if !meta.ReverseDirection {
 		return col
 	}
@@ -49,67 +67,70 @@ func (c *current) reverseColumn(col schema.Column) schema.Column {
 	return col
 }
 
-// flattenExpr takes an expression and flattens it to a slice of strings. It
-// also handles metadata for columns.
-func (c *current) flattenExpr(expr []any, meta *Meta) []string {
-	// Reverse direction and extract metadata.
-	metaColumn := func(col schema.Column) schema.Column {
-		col = c.reverseColumn(col)
-		if col.ClickHouseMainOnly {
-			meta.MainTableRequired = true
-		}
-		return col
+// column returns the expression for a column. The direction is reversed when
+// needed and a column living only in the main table is recorded as such.
+func (c *current) column(col schema.Column) sb.Expr {
+	col = c.reverseColumn(col)
+	if col.ClickHouseMainOnly {
+		c.meta().MainTableRequired = true
 	}
-	var result []string // flattened, pre-join
-	for i := range expr {
-		switch s := expr[i].(type) {
-		case schema.Column:
-			s = metaColumn(s)
-			result = append(result, s.Name)
-		case string:
-			result = append(result, s)
-		case []any:
-			result = append(result, c.flattenExpr(s, meta)...)
-		case uint8, uint16, uint32, uint64, uint, int8, int16, int32, int64, int:
-			result = append(result, fmt.Sprintf("%d", s))
-		default:
-			result = append(result, fmt.Sprintf("%s", s))
-		}
-	}
-	return result
+	return sb.Column(col.Name)
 }
 
-// compileExpr compile an expression to a SQL string. An expression is a nested
-// slices of elements. Some elements are schema.Column and are reverted if
-// needed and metadata-related information are extracted. Elements are flattened
-// and joined with spaces (with a few exceptions).
-func (c *current) compileExpr(expr []any, meta *Meta) string {
-	var b strings.Builder
-	sl := c.flattenExpr(expr, meta)
-	for i := range sl {
-		if sl[i] == "" {
-			continue
-		}
-		// Do we add a space between sl[i-1] and sl[i]?
-		if b.Len() == 0 {
-			b.WriteString(sl[i])
-			continue
-		}
-		last := b.String()[b.Len()-1:]
-		first := sl[i][:1]
-		if first != "," && first != ")" && first != " " && last != "(" && last != " " {
-			b.WriteString(" ")
-		}
-		b.WriteString(sl[i])
+// value turns a value matched by the grammar into an expression. A column on
+// the right side of a comparison is handled like any other column.
+func (c *current) value(v any) sb.Expr {
+	switch value := v.(type) {
+	case schema.Column:
+		return c.column(value)
+	case uint8:
+		return sb.Uint(uint64(value))
+	case uint16:
+		return sb.Uint(uint64(value))
+	case uint32:
+		return sb.Uint(uint64(value))
+	case uint64:
+		return sb.Uint(value)
+	case sb.Expr:
+		return value
 	}
-	return b.String()
+	// The grammar only produces the types above, including on its error paths.
+	panic(fmt.Sprintf("unexpected value %v in filter", v))
+}
+
+// values turns a list matched by the grammar into expressions.
+func (c *current) values(items []any) []sb.Expr {
+	exprs := make([]sb.Expr, len(items))
+	for i, item := range items {
+		exprs[i] = c.value(item)
+	}
+	return exprs
+}
+
+// asExpr returns the expression matched by the grammar. On an error path, the
+// parser hands back the partial match instead of an expression. The parse fails
+// anyway, so no expression is good enough.
+func asExpr(v any) sb.Expr {
+	expr, _ := v.(sb.Expr)
+	return expr
+}
+
+// combine joins the head expression with the tail matched by a repetition of
+// "operator expression". The expression is the last item of each match.
+func combine(join func(...sb.Expr) sb.Expr, head, rest any) sb.Expr {
+	exprs := []sb.Expr{asExpr(head)}
+	for _, item := range toSlice(rest) {
+		parts := toSlice(item)
+		exprs = append(exprs, asExpr(parts[len(parts)-1]))
+	}
+	return join(exprs...)
 }
 
 // acceptColumn normalizes and returns the matched column name. It should be
 // used in action code blocks.
 func (c *current) acceptColumn() (schema.Column, error) {
 	name := string(c.text)
-	sch := c.globalStore["meta"].(*Meta).Schema
+	sch := c.meta().Schema
 	for _, column := range sch.Columns() {
 		if strings.EqualFold(name, column.Name) {
 			return column, nil
@@ -122,7 +143,7 @@ func (c *current) acceptColumn() (schema.Column, error) {
 // should be used in predicate code blocks.
 func (c *current) columnIsOfType(name any, types ...string) (bool, error) {
 	columnName := name.(string)
-	sch := c.globalStore["meta"].(*Meta).Schema
+	sch := c.meta().Schema
 	for _, column := range sch.Columns() {
 		if strings.EqualFold(columnName, column.Name) {
 			return slices.Contains(types, column.ParserType), nil
@@ -133,7 +154,7 @@ func (c *current) columnIsOfType(name any, types ...string) (bool, error) {
 
 // getColumn gets a column by its name.
 func (c *current) getColumn(name string) schema.Column {
-	sch := c.globalStore["meta"].(*Meta).Schema
+	sch := c.meta().Schema
 	if column, ok := sch.LookupColumnByName(name); ok {
 		return *column
 	}
@@ -145,86 +166,128 @@ func (c *current) getColumn(name string) schema.Column {
 func (c *current) requireMainTable(cols ...schema.Column) {
 	for _, col := range cols {
 		if col.ClickHouseMainOnly {
-			c.globalStore["meta"].(*Meta).MainTableRequired = true
+			c.meta().MainTableRequired = true
 		}
 	}
 }
 
-// parsePrefix parses a prefix to SQL by combining Src/DstAddr and
-// Src/DstNetmask. This function already uses the right direction.
-func (c *current) parsePrefix(col schema.Column, prefix string) ([]any, error) {
-	net, err := netip.ParsePrefix(prefix)
-	if err != nil {
-		return []any{}, errors.New("expecting a prefix")
-	}
+// prefixCondition compares a column to a network prefix. When the prefix column
+// is materialized, this is a direct comparison. Otherwise, the address range and
+// the mask length are compared instead.
+func (c *current) prefixCondition(col schema.Column, prefix netip.Prefix) sb.Expr {
 	col = c.reverseColumn(col)
-	// If the prefix was materialized, we can directly access it
 	if col.ClickHouseMaterialized {
 		c.requireMainTable(col)
-		return []any{
-			col.Name, "=",
-			fmt.Sprintf("'%s'", net.String()),
-		}, nil
+		return sb.Op(sb.Column(col.Name), "=", sb.String(prefix.String()))
 	}
 	direction := "Dst"
 	if strings.HasPrefix(col.Name, "Src") {
 		direction = "Src"
 	}
-	// If the prefix is not materialized, we use the "between" operator on the
-	// address and the mask.
+	// Only the address and the mask are read, so only these two decide if the
+	// main table is needed.
 	addr := fmt.Sprintf("%sAddr", direction)
 	mask := fmt.Sprintf("%sNetMask", direction)
 	c.requireMainTable(c.getColumn(addr), c.getColumn(mask))
-	return []any{
-		addr,
-		fmt.Sprintf("BETWEEN toIPv6('%s') AND toIPv6('%s') AND",
-			net.Masked().Addr().String(), lastIP(net).String()),
-		mask, "=", net.Bits(),
-	}, nil
+	return sb.And(
+		betweenPrefix(sb.Column(addr), prefix, false),
+		sb.Op(sb.Column(mask), "=", sb.Uint(uint64(prefix.Bits()))),
+	)
 }
 
-// buildIPOrSubnetCondition constructs a SQL condition for IP columns with IN/NOTIN operators
-// that can handle both individual IPs and subnets.
-func buildIPOrSubnetCondition(column any, operator string, items []any) []any {
-	var ips []string
-	var subnets []string
-
-	// Separate IPs and subnets
+// ipOrSubnetCondition builds the condition for a list mixing addresses and
+// subnets. Addresses are gathered in a single IN, while each subnet needs its
+// own range comparison.
+func (c *current) ipOrSubnetCondition(col schema.Column, operator string, items []any) (sb.Expr, error) {
+	left := c.column(col)
+	addresses := []sb.Expr{}
+	conditions := []sb.Expr{}
 	for _, item := range items {
-		item := item.(string)
-		if strings.HasPrefix(item, "BETWEEN") {
-			subnets = append(subnets, item)
-		} else {
-			ips = append(ips, fmt.Sprintf("toIPv6('%s')", item))
+		switch value := item.(type) {
+		case netip.Addr:
+			addresses = append(addresses,
+				sb.Function("toIPv6", sb.String(value.String())))
+		case netip.Prefix:
+			conditions = append(conditions, betweenPrefix(left, value, false))
+		default:
+			return sb.Expr{}, errors.New("expecting an IP address or a subnet")
 		}
 	}
-
-	var parts []any
-	var hasOr bool
-
-	// Build IN clause for IPs
-	if len(ips) > 0 {
-		parts = append(parts, []any{column, "IN (", strings.Join(ips, ", "), ")"}...)
+	if len(addresses) > 0 {
+		conditions = append([]sb.Expr{
+			sb.Op(left, "IN", sb.Tuple(addresses...)),
+		}, conditions...)
 	}
-
-	// Build BETWEEN clauses for subnets
-	for i, net := range subnets {
-		if i > 0 || len(ips) > 0 {
-			parts = append(parts, "OR")
-			hasOr = true
-		}
-		parts = append(parts, []any{column, net})
-	}
-
-	// Handle NOT operator
+	expr := sb.Or(conditions...)
 	if operator == "NOT IN" {
-		parts = append([]any{"NOT ("}, parts...)
-		parts = append(parts, ")")
-	} else if hasOr {
-		parts = append([]any{"("}, parts...)
-		parts = append(parts, ")")
+		return sb.Not(expr), nil
 	}
-	return parts
+	if len(conditions) > 1 {
+		return sb.Parens(expr), nil
+	}
+	return expr, nil
+}
+
+// protocolName turns a protocol number into its name, so a filter can compare
+// it with a string. An unknown protocol becomes "???", like in the columns the
+// console displays.
+func protocolName(proto sb.Expr) sb.Expr {
+	return sb.Function("dictGetOrDefault",
+		sb.String(schema.DictionaryProtocols), sb.String("name"),
+		proto, sb.String("???"))
+}
+
+// macToNum turns a MAC address into its numeric form.
+func macToNum(mac any) sb.Expr {
+	return sb.Function("MACStringToNum", sb.String(toString(mac)))
+}
+
+// macList turns a list of MAC addresses into their numeric forms.
+func macList(items []any) []sb.Expr {
+	exprs := make([]sb.Expr, len(items))
+	for i, item := range items {
+		exprs[i] = macToNum(item)
+	}
+	return exprs
+}
+
+// stringList turns a list of matched strings into string literals.
+func stringList(items []any) []sb.Expr {
+	exprs := make([]sb.Expr, len(items))
+	for i, item := range items {
+		exprs[i] = sb.String(toString(item))
+	}
+	return exprs
+}
+
+// largeCommunity packs the three parts of a large community into the single
+// number stored in the database.
+func largeCommunity(value1, value2, value3 uint32) sb.Expr {
+	shift := func(value uint32, bits uint64) sb.Expr {
+		return sb.Function("bitShiftLeft",
+			sb.Cast(sb.Uint(uint64(value)), "UInt128"),
+			sb.Uint(bits))
+	}
+	return sb.Op(
+		sb.Op(shift(value1, 64), "+", shift(value2, 32)),
+		"+",
+		sb.Cast(sb.Uint(uint64(value3)), "UInt128"))
+}
+
+// largeCommunitiesColumn returns the large communities column matching a
+// communities column.
+func (c *current) largeCommunitiesColumn(col schema.Column) schema.Column {
+	return c.getColumn(strings.Replace(col.Name, "Communities", "LargeCommunities", 1))
+}
+
+// betweenPrefix compares a column to the address range covered by a prefix.
+func betweenPrefix(left sb.Expr, prefix netip.Prefix, not bool) sb.Expr {
+	low := sb.Function("toIPv6", sb.String(prefix.Masked().Addr().String()))
+	high := sb.Function("toIPv6", sb.String(lastIP(prefix).String()))
+	if not {
+		return sb.NotBetween(left, low, high)
+	}
+	return sb.Between(left, low, high)
 }
 
 func lastIP(subnet netip.Prefix) netip.Addr {
@@ -243,10 +306,6 @@ func lastIP(subnet netip.Prefix) netip.Addr {
 		return netip.AddrFrom16(a16).Unmap()
 	}
 	return netip.AddrFrom16(a16)
-}
-
-func quote(v any) string {
-	return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(toString(v)) + "'"
 }
 
 func unquote(v any) string {

--- a/console/filter/helpers.go
+++ b/console/filter/helpers.go
@@ -24,35 +24,37 @@ type Meta struct {
 	MainTableRequired bool
 }
 
+// reverseColumn returns the column for the opposite direction when the filter
+// is parsed for the reverse direction. Otherwise, the column is returned as is.
+func (c *current) reverseColumn(col schema.Column) schema.Column {
+	meta := c.globalStore["meta"].(*Meta)
+	if !meta.ReverseDirection {
+		return col
+	}
+	var candidate string
+	name := col.Name
+	switch {
+	case strings.HasPrefix(name, "Src"):
+		candidate = "Dst" + name[3:]
+	case strings.HasPrefix(name, "Dst"):
+		candidate = "Src" + name[3:]
+	case strings.HasPrefix(name, "In"):
+		candidate = "Out" + name[2:]
+	case strings.HasPrefix(name, "Out"):
+		candidate = "In" + name[3:]
+	}
+	if column, ok := meta.Schema.LookupColumnByName(candidate); ok {
+		return *column
+	}
+	return col
+}
+
 // flattenExpr takes an expression and flattens it to a slice of strings. It
 // also handles metadata for columns.
 func (c *current) flattenExpr(expr []any, meta *Meta) []string {
-	// Helpers for columns: reverse direction and extract metadata.
-	reverseColumn := func(col schema.Column) schema.Column {
-		name := col.Name
-		if meta.ReverseDirection {
-			var candidate string
-			sch := c.globalStore["meta"].(*Meta).Schema
-			if strings.HasPrefix(name, "Src") {
-				candidate = "Dst" + name[3:]
-			}
-			if strings.HasPrefix(name, "Dst") {
-				candidate = "Src" + name[3:]
-			}
-			if strings.HasPrefix(name, "In") {
-				candidate = "Out" + name[2:]
-			}
-			if strings.HasPrefix(name, "Out") {
-				candidate = "In" + name[3:]
-			}
-			if column, ok := sch.LookupColumnByName(candidate); ok {
-				return *column
-			}
-		}
-		return col
-	}
+	// Reverse direction and extract metadata.
 	metaColumn := func(col schema.Column) schema.Column {
-		col = reverseColumn(col)
+		col = c.reverseColumn(col)
 		if col.ClickHouseMainOnly {
 			meta.MainTableRequired = true
 		}
@@ -138,19 +140,24 @@ func (c *current) getColumn(name string) schema.Column {
 	return schema.Column{}
 }
 
-// parsePrefix parses a source or destination prefix to SQL.
-func (c *current) parsePrefix(direction, prefix string) ([]any, error) {
+// parsePrefix parses a prefix to SQL by combining Src/DstAddr and
+// Src/DstNetmask. This function already uses the right direction.
+func (c *current) parsePrefix(col schema.Column, prefix string) ([]any, error) {
 	net, err := netip.ParsePrefix(prefix)
 	if err != nil {
 		return []any{}, errors.New("expecting a prefix")
 	}
+	col = c.reverseColumn(col)
 	// If the prefix was materialized, we can directly access it
-	col := c.getColumn(fmt.Sprintf("%sNetPrefix", direction))
 	if col.ClickHouseMaterialized {
 		return []any{
-			fmt.Sprintf("%sNetPrefix", direction), "=",
+			col.Name, "=",
 			fmt.Sprintf("'%s'", net.String()),
 		}, nil
+	}
+	direction := "Dst"
+	if strings.HasPrefix(col.Name, "Src") {
+		direction = "Src"
 	}
 	// If the prefix is not materialized, we use the "between" operator
 	c.globalStore["meta"].(*Meta).MainTableRequired = true
@@ -158,7 +165,7 @@ func (c *current) parsePrefix(direction, prefix string) ([]any, error) {
 		fmt.Sprintf("%sAddr", direction),
 		fmt.Sprintf("BETWEEN toIPv6('%s') AND toIPv6('%s') AND",
 			net.Masked().Addr().String(), lastIP(net).String()),
-		c.getColumn(fmt.Sprintf("%sNetMask", direction)), "=", net.Bits(),
+		fmt.Sprintf("%sNetMask", direction), "=", net.Bits(),
 	}, nil
 }
 

--- a/console/filter/parser.peg
+++ b/console/filter/parser.peg
@@ -6,34 +6,34 @@
 
   import (
     "errors"
-    "fmt"
     "net/netip"
     "strings"
 
-    "akvorado/common/helpers"
     "akvorado/common/schema"
+    sb "akvorado/common/sqlbuilder"
   )
 }
 
 Input ← _ expr:Expr _ EOF {
-  meta := c.globalStore["meta"].(*Meta)
-  return c.compileExpr(toSlice(expr), meta), nil
-}
-
-Expr "expression" ← head:(SubExpr / NotExpr / ConditionExpr) rest:( _ ( KW_AND / KW_OR ) _ Expr )* {
-  expr := []any{head}
-  for _, e := range toSlice(rest) {
-    rest := toSlice(e)
-    expr = append(expr, strings.ToUpper(toString(rest[1])))
-    expr = append(expr, rest[3])
-  }
   return expr, nil
 }
-SubExpr "sub-expression" ← '(' _ expr:Expr _ ')' {
-  return []any{"(", expr, ")"}, nil
+
+// AND binds more tightly than OR, like in SQL. The two levels below build the
+// expression tree with that precedence.
+Expr "expression" ← OrExpr
+OrExpr ← head:AndExpr rest:( _ KW_OR _ AndExpr )* {
+  return combine(sb.Or, head, rest), nil
 }
-NotExpr "NOT expression" ← KW_NOT _ expr:Expr {
-  return []any{"NOT", expr}, nil
+AndExpr ← head:UnitExpr rest:( _ KW_AND _ UnitExpr )* {
+  return combine(sb.And, head, rest), nil
+}
+UnitExpr ← SubExpr / NotExpr / ConditionExpr
+
+SubExpr "sub-expression" ← '(' _ expr:Expr _ ')' {
+  return sb.Parens(asExpr(expr)), nil
+}
+NotExpr "NOT expression" ← KW_NOT _ expr:UnitExpr {
+  return sb.Not(asExpr(expr)), nil
 }
 
 ConditionExpr "conditional" ←
@@ -64,20 +64,21 @@ ColumnIP ←
     { return c.acceptColumn() }
 ConditionIPExpr "condition on IP" ←
    column:ColumnIP _
-   operator:("<<" / "=") _ subnet:Subnet {
-     return []any{column, subnet}, nil
+   ("<<" / "=") _ subnet:Subnet {
+     return betweenPrefix(c.column(column.(schema.Column)), subnet.(netip.Prefix), false), nil
    }
  / column:ColumnIP _
-   operator:("!<<" / "!=") _ subnet:Subnet {
-     return []any{column, "NOT", subnet}, nil
+   ("!<<" / "!=") _ subnet:Subnet {
+     return betweenPrefix(c.column(column.(schema.Column)), subnet.(netip.Prefix), true), nil
    }
  / column:ColumnIP _
    operator:("=" / "!=") _ ip:IP {
-     return []any{column, operator, "toIPv6(", quote(ip), ")"}, nil
+     return sb.Op(c.column(column.(schema.Column)), toString(operator),
+       sb.Function("toIPv6", sb.String(ip.(netip.Addr).String()))), nil
    }
  / column:ColumnIP _
    operator:InOperator _ '(' _ value:ListIPOrSubnet _ ')' {
-     return buildIPOrSubnetCondition(column, toString(operator), toSlice(value)), nil
+     return c.ipOrSubnetCondition(column.(schema.Column), toString(operator), toSlice(value))
    }
 
 
@@ -87,15 +88,11 @@ ConditionPrefixExpr "condition on prefix" ←
             { return c.acceptColumn() }) _
    operator:("=" / "!=") _
    prefix:Prefix {
-     prefix, err := c.parsePrefix(column.(schema.Column), toString(prefix))
-     if err != nil {
-       return nil, err
+     expr := c.prefixCondition(column.(schema.Column), prefix.(netip.Prefix))
+     if toString(operator) == "!=" {
+       return sb.Not(expr), nil
      }
-     switch toString(operator) {
-       case "=": return []any{prefix}, nil
-       case "!=": return []any{"NOT (", prefix, ")"}, nil
-     }
-     return "", nil
+     return expr, nil
    }
 
 ConditionMACExpr "condition on MAC" ←
@@ -103,14 +100,14 @@ ConditionMACExpr "condition on MAC" ←
            &{ return c.columnIsOfType(value, "mac") }
             { return c.acceptColumn() }) _
  rcond:RConditionMACExpr {
-  return []any{column, rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column))), nil
 }
 RConditionMACExpr "condition on MAC" ←
    operator:("=" / "!=") _ mac:MAC {
-       return []any{operator, "MACStringToNum(", quote(mac), ")"}, nil
+       return condition{toString(operator), macToNum(mac)}, nil
    }
  / operator:InOperator _ '(' _ value:ListMAC _ ')' {
-  return []any{operator, "(", value, ")"}, nil
+  return condition{toString(operator), sb.Tuple(macList(toSlice(value))...)}, nil
 }
 
 ColumnString ←
@@ -120,17 +117,17 @@ ColumnString ←
 ConditionStringExpr "condition on string" ←
  column:ColumnString _
  rcond:RConditionStringExpr {
-  return []any{column, rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column))), nil
 }
 RConditionStringExpr "condition on string" ←
    operator:("=" / "!=" / LikeOperator ) _ str:StringLiteral {
-     return []any{operator, quote(str)}, nil
+     return condition{toString(operator), sb.String(toString(str))}, nil
    }
  / operator:("=" / "!=") _ value:ColumnString {
-     return []any{operator, value}, nil
+     return condition{toString(operator), c.column(value.(schema.Column))}, nil
    }
  / operator:InOperator _ '(' _ value:ListString _ ')' {
-  return []any{operator, "(", value, ")"}, nil
+  return condition{toString(operator), sb.Tuple(stringList(toSlice(value))...)}, nil
    }
 
 ConditionBoundaryExpr "condition on boundary" ←
@@ -139,7 +136,8 @@ ConditionBoundaryExpr "condition on boundary" ←
             { return c.acceptColumn() }) _
  operator:("=" / "!=") _
  boundary:("external"i / "internal"i / "undefined"i) {
-  return []any{column, operator, quote(strings.ToLower(toString(boundary)))}, nil
+  return sb.Op(c.column(column.(schema.Column)), toString(operator),
+    sb.String(strings.ToLower(toString(boundary)))), nil
 }
 
 ColumnUint ←
@@ -149,14 +147,14 @@ ColumnUint ←
 ConditionUintExpr "condition on integer" ←
  column:ColumnUint _
  rcond:RConditionUintExpr {
-  return []any{column, rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column))), nil
 }
 RConditionUintExpr "condition on integer" ←
    operator:("=" / ">=" / "<=" / "<" / ">" / "!=") _ value:(Unsigned64 / ColumnUint) {
-     return []any{operator, value}, nil
+     return condition{toString(operator), c.value(value)}, nil
    }
  / operator:InOperator _ '(' _ value:ListUnsigned64 _ ')' {
-     return []any{operator, "(", value, ")"}, nil
+     return condition{toString(operator), sb.Tuple(c.values(toSlice(value))...)}, nil
    }
 
 ConditionArrayUintExpr "condition on array of integers" ←
@@ -164,13 +162,14 @@ ConditionArrayUintExpr "condition on array of integers" ←
            &{ return c.columnIsOfType(value, "array(uint)") }
             { return c.acceptColumn() }) _
    "=" _ value:Unsigned64 {
-     return []any{"has(", column, ",", value, ")"}, nil
+     return sb.Function("has", c.column(column.(schema.Column)), c.value(value)), nil
    }
  / column:(value:ColumnName
            &{ return c.columnIsOfType(value, "array(uint)") }
             { return c.acceptColumn() }) _
    "!=" _ value:Unsigned64 {
-     return []any{"NOT has(", column, ",", value, ")"}, nil
+     return sb.Not(sb.Function("has",
+       c.column(column.(schema.Column)), c.value(value))), nil
    }
 
 ColumnASN ←
@@ -180,40 +179,52 @@ ColumnASN ←
 ConditionASExpr "condition on AS number" ←
  column:ColumnASN _
  rcond:RConditionASExpr {
-  return []any{column, rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column))), nil
 }
 RConditionASExpr "condition on AS number" ←
-   operator:("=" / "!=") _ value:(ASN / ColumnASN) { return []any{operator, value}, nil }
+   operator:("=" / "!=") _ value:(ASN / ColumnASN) {
+     return condition{toString(operator), c.value(value)}, nil
+   }
  / operator:InOperator _ '(' _ value:ListASN _ ')' {
-  return []any{operator, "(", value, ")"}, nil
+  return condition{toString(operator), sb.Tuple(c.values(toSlice(value))...)}, nil
 }
 
 ConditionASPathExpr "condition on AS path" ←
    column:(value:ColumnName
            &{ return c.columnIsOfType(value, "aspath") }
-            { return c.acceptColumn() }) _ "=" _ value:ASN { return []any{"has(", column, ",", value, ")"}, nil }
+            { return c.acceptColumn() }) _ "=" _ value:ASN {
+     return sb.Function("has", c.column(column.(schema.Column)), c.value(value)), nil
+   }
  / column:(value:ColumnName
            &{ return c.columnIsOfType(value, "aspath") }
-            { return c.acceptColumn() }) _ "!=" _ value:ASN { return []any{"NOT has(", column, ",", value, ")"}, nil }
+            { return c.acceptColumn() }) _ "!=" _ value:ASN {
+     return sb.Not(sb.Function("has",
+       c.column(column.(schema.Column)), c.value(value))), nil
+   }
 
 ConditionCommunitiesExpr "condition on communities" ←
    column:(value:ColumnName
            &{ return c.columnIsOfType(value, "community") }
-            { return c.acceptColumn() }) _ "=" _ value:Community { return []any{"has(", column, ",", value, ")"}, nil }
+            { return c.acceptColumn() }) _ "=" _ value:Community {
+     return sb.Function("has", c.column(column.(schema.Column)), c.value(value)), nil
+   }
  / column:(value:ColumnName
            &{ return c.columnIsOfType(value, "community") }
-            { return c.acceptColumn() }) _ "!=" _ value:Community { return []any{"NOT has(", column, ",", value, ")"}, nil }
+            { return c.acceptColumn() }) _ "!=" _ value:Community {
+     return sb.Not(sb.Function("has",
+       c.column(column.(schema.Column)), c.value(value))), nil
+   }
  / column:(value:ColumnName
            &{ return c.columnIsOfType(value, "community") }
             { return c.acceptColumn() }) _ "=" _ value:LargeCommunity {
-     largeName := strings.Replace(column.(schema.Column).Name, "Communities", "LargeCommunities", 1)
-     return []any{"has(", c.getColumn(largeName), ",", value, ")"}, nil
+     return sb.Function("has",
+       c.column(c.largeCommunitiesColumn(column.(schema.Column))), c.value(value)), nil
    }
  / column:(value:ColumnName
            &{ return c.columnIsOfType(value, "community") }
             { return c.acceptColumn() }) _ "!=" _ value:LargeCommunity {
-     largeName := strings.Replace(column.(schema.Column).Name, "Communities", "LargeCommunities", 1)
-     return []any{"NOT has(", c.getColumn(largeName), ",", value, ")"}, nil
+     return sb.Not(sb.Function("has",
+       c.column(c.largeCommunitiesColumn(column.(schema.Column))), c.value(value))), nil
    }
 
 ConditionETypeExpr "condition on Ethernet type" ←
@@ -226,7 +237,8 @@ ConditionETypeExpr "condition on Ethernet type" ←
     "ipv6": constants.ETypeIPv6,
    }
    etype := etypes[strings.ToLower(toString(value))]
-   return []any{column, operator, etype}, nil
+   return sb.Op(c.column(column.(schema.Column)), toString(operator),
+     sb.Uint(uint64(etype))), nil
 }
 ConditionProtoExpr "condition on protocol" ← ConditionProtoIntExpr / ConditionProtoStrExpr
 ConditionProtoIntExpr "condition on protocol as integer" ←
@@ -234,28 +246,29 @@ ConditionProtoIntExpr "condition on protocol as integer" ←
            &{ return c.columnIsOfType(value, "proto") }
             { return c.acceptColumn() }) _
  rcond:RConditionProtoIntExpr {
-  return []any{column, rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column))), nil
 }
 RConditionProtoIntExpr "condition on protocol as integer" ←
    operator:("=" / ">=" / "<=" / "<" / ">" / "!=") _ value:Unsigned8 {
-     return []any{operator, value}, nil
+     return condition{toString(operator), c.value(value)}, nil
    }
  / operator:InOperator _ '(' _ value:ListUnsigned8 _ ')' {
-     return []any{operator, "(", value, ")"}, nil
+     return condition{toString(operator), sb.Tuple(c.values(toSlice(value))...)}, nil
    }
 ConditionProtoStrExpr "condition on protocol as string" ←
  column:(value:ColumnName
            &{ return c.columnIsOfType(value, "proto") }
             { return c.acceptColumn() }) _
  rcond:RConditionProtoStrExpr {
-  return []any{"dictGetOrDefault('protocols', 'name', ", column, ", '???')", rcond}, nil
+  return rcond.(condition).apply(c.column(column.(schema.Column)).
+    Apply(protocolName)), nil
 }
 RConditionProtoStrExpr "condition on protocol as string" ←
    operator:("=" / "!=") _ value:StringLiteral {
-     return []any{operator, quote(value)}, nil
+     return condition{toString(operator), sb.String(toString(value))}, nil
    }
  / operator:InOperator _ '(' _ value:ListString _ ')' {
-     return []any{operator, "(", value, ")"}, nil
+     return condition{toString(operator), sb.Tuple(stringList(toSlice(value))...)}, nil
    }
 
 ConditionDirectionExpr "condition on direction" ←
@@ -264,22 +277,23 @@ ConditionDirectionExpr "condition on direction" ←
             { return c.acceptColumn() }) _
  operator:("=" / "!=") _
  direction:("undefined"i / "ingress"i / "egress"i) {
-  return []any{column, operator, quote(strings.ToLower(toString(direction)))}, nil
+  return sb.Op(c.column(column.(schema.Column)), toString(operator),
+    sb.String(strings.ToLower(toString(direction)))), nil
 }
 
 IP "IP address" ← [0-9A-Fa-f:.]+ !IdentStart {
   ip, err := netip.ParseAddr(string(c.text))
   if err != nil {
-    return "", errors.New("expecting an IP address")
+    return netip.Addr{}, errors.New("expecting an IP address")
   }
-  return ip.String(), nil
+  return ip, nil
 }
 Subnet "IP subnet" ← [0-9A-Fa-f:.]+ "/" [0-9]+ !IdentStart {
   net, err := netip.ParsePrefix(string(c.text))
   if err != nil {
-    return "", errors.New("expecting a subnet")
+    return netip.Prefix{}, errors.New("expecting a subnet")
   }
-  return fmt.Sprintf("BETWEEN toIPv6('%s') AND toIPv6('%s')", net.Masked().Addr().String(), lastIP(net).String()), nil
+  return net, nil
 }
 
 ListIPOrSubnet "list of IP addresses or subnets" ←
@@ -289,11 +303,11 @@ ListIPOrSubnet "list of IP addresses or subnets" ←
  / value:(Subnet / IP) { return []any{value}, nil }
 
 Prefix "IP prefix" ← [0-9A-Fa-f:.]+ "/" [0-9]+ !IdentStart {
-  _, err := netip.ParsePrefix(string(c.text))
+  net, err := netip.ParsePrefix(string(c.text))
   if err != nil {
-    return nil, errors.New("expecting a prefix")
+    return netip.Prefix{}, errors.New("expecting a prefix")
   }
-  return string(c.text), nil
+  return net, nil
 }
 
 MAC "MAC address" ← [0-9A-Fa-f:.]+ !IdentStart {
@@ -307,21 +321,21 @@ MAC "MAC address" ← [0-9A-Fa-f:.]+ !IdentStart {
   return hw.String(), nil
 }
 ListMAC "list of MAC addresses" ←
-   head:MAC _ ',' _ tail:ListMAC { return fmt.Sprintf("MACStringToNum(%s), %s", quote(head), tail), nil }
- / value:MAC { return fmt.Sprintf("MACStringToNum(%s)", quote(value)), nil }
+   head:MAC _ ',' _ tail:ListMAC { return append([]any{head}, toSlice(tail)...), nil }
+ / value:MAC { return []any{value}, nil }
 
 ASN "AS number" ← "AS"i? value:Unsigned32 !IdentStart {
   return value, nil
 }
 ListASN "list of AS numbers" ←
-   head:ASN _ ',' _ tail:ListASN { return fmt.Sprintf("%s, %s", toString(head), tail), nil }
- / value:ASN { return toString(value), nil }
+   head:ASN _ ',' _ tail:ListASN { return append([]any{head}, toSlice(tail)...), nil }
+ / value:ASN { return []any{value}, nil }
 
 Community "community" ← value1:Unsigned16 ":" value2:Unsigned16 !IdentStart !":" {
   return (uint32(value1.(uint16)) << 16) + uint32(value2.(uint16)), nil
 }
 LargeCommunity "large community" ← value1:Unsigned32 ":" value2:Unsigned32 ":" value3:Unsigned32 !IdentStart !":" {
-  return fmt.Sprintf("bitShiftLeft(%d::UInt128, 64) + bitShiftLeft(%d::UInt128, 32) + %d::UInt128", value1, value2, value3), nil
+  return largeCommunity(value1.(uint32), value2.(uint32), value3.(uint32)), nil
 }
 
 StringLiteral "quoted string" ← ( '"' chars:DoubleStringChar* '"' {
@@ -335,24 +349,24 @@ SourceChar ← .
 DoubleStringChar ← ( '\\' ( '\\' / '"' ) / !( '"' / EOL ) SourceChar ) { return string(c.text), nil }
 SingleStringChar ← ( '\\' ( '\\' / "'" ) / !( "'" / EOL ) SourceChar ) { return string(c.text), nil }
 ListString "list of strings" ←
-   head:StringLiteral _ ',' _ tail:ListString { return fmt.Sprintf("%s, %s", quote(head), tail), nil }
- / value:StringLiteral { return quote(value), nil }
+   head:StringLiteral _ ',' _ tail:ListString { return append([]any{head}, toSlice(tail)...), nil }
+ / value:StringLiteral { return []any{value}, nil }
 
 Unsigned8 "unsigned 8-bit integer" ← [0-9]+ !IdentStart {
   v, err := strconv.ParseUint(string(c.text), 10, 8)
   if err != nil {
-    return "", errors.New("expecting an unsigned 8-bit integer")
+    return uint8(0), errors.New("expecting an unsigned 8-bit integer")
   }
   return uint8(v), nil
 }
 ListUnsigned8 "list of unsigned 8-bit integers" ←
-   head:Unsigned8 _ ',' _ tail:ListUnsigned8 { return fmt.Sprintf("%s, %s", toString(head), tail), nil }
- / value:Unsigned8 { return toString(value), nil }
+   head:Unsigned8 _ ',' _ tail:ListUnsigned8 { return append([]any{head}, toSlice(tail)...), nil }
+ / value:Unsigned8 { return []any{value}, nil }
 
 Unsigned16 "unsigned 16-bit integer" ← [0-9]+ !IdentStart {
   v, err := strconv.ParseUint(string(c.text), 10, 16)
   if err != nil {
-    return "", errors.New("expecting an unsigned 16-bit integer")
+    return uint16(0), errors.New("expecting an unsigned 16-bit integer")
   }
   return uint16(v), nil
 }
@@ -360,7 +374,7 @@ Unsigned16 "unsigned 16-bit integer" ← [0-9]+ !IdentStart {
 Unsigned32 "unsigned 32-bit integer" ← [0-9]+ !IdentStart {
   v, err := strconv.ParseUint(string(c.text), 10, 32)
   if err != nil {
-    return "", errors.New("expecting an unsigned 32-bit integer")
+    return uint32(0), errors.New("expecting an unsigned 32-bit integer")
   }
   return uint32(v), nil
 }
@@ -368,13 +382,13 @@ Unsigned32 "unsigned 32-bit integer" ← [0-9]+ !IdentStart {
 Unsigned64 "unsigned 64-bit integer" ← [0-9]+ !IdentStart {
   v, err := strconv.ParseUint(string(c.text), 10, 64)
   if err != nil {
-    return "", errors.New("expecting an unsigned integer")
+    return uint64(0), errors.New("expecting an unsigned integer")
   }
   return uint64(v), nil
 }
 ListUnsigned64 "list of unsigned integers" ←
-   head:Unsigned64 _ ',' _ tail:ListUnsigned64 { return fmt.Sprintf("%s, %s", toString(head), tail), nil }
- / value:Unsigned64 { return toString(value), nil }
+   head:Unsigned64 _ ',' _ tail:ListUnsigned64 { return append([]any{head}, toSlice(tail)...), nil }
+ / value:Unsigned64 { return []any{value}, nil }
 
 LikeOperator "LIKE operators" ←
    KW_LIKE

--- a/console/filter/parser.peg
+++ b/console/filter/parser.peg
@@ -87,12 +87,7 @@ ConditionPrefixExpr "condition on prefix" ←
             { return c.acceptColumn() }) _
    operator:("=" / "!=") _
    prefix:Prefix {
-     col := column.(schema.Column)
-     direction := "Dst"
-     if strings.HasPrefix(col.Name, "Src") {
-       direction = "Src"
-     }
-     prefix, err := c.parsePrefix(direction, toString(prefix))
+     prefix, err := c.parsePrefix(column.(schema.Column), toString(prefix))
      if err != nil {
        return nil, err
      }

--- a/console/filter/parser_test.go
+++ b/console/filter/parser_test.go
@@ -484,6 +484,7 @@ output provider */ = 'telia'`,
 		if diff := helpers.Diff(got.(string), tc.Output); diff != "" {
 			t.Errorf("Parse(%q) (-got, +want):\n%s", tc.Input, diff)
 		}
+		checkWhereParses(t, got.(string))
 		if diff := helpers.Diff(tc.MetaIn, tc.MetaOut); diff != "" {
 			t.Errorf("Parse(%q) meta (-got, +want):\n%s", tc.Input, diff)
 		}
@@ -529,6 +530,7 @@ func TestValidMaterializedFilter(t *testing.T) {
 		if diff := helpers.Diff(got.(string), tc.Output); diff != "" {
 			t.Errorf("Parse(%q) (-got, +want):\n%s", tc.Input, diff)
 		}
+		checkWhereParses(t, got.(string))
 		if diff := helpers.Diff(tc.MetaIn, tc.MetaOut); diff != "" {
 			t.Errorf("Parse(%q) meta (-got, +want):\n%s", tc.Input, diff)
 		}

--- a/console/filter/parser_test.go
+++ b/console/filter/parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 )
 
 func TestValidFilter(t *testing.T) {
@@ -112,11 +113,34 @@ func TestValidFilter(t *testing.T) {
 			MetaOut: Meta{MainTableRequired: true},
 		},
 		{
+			// The address and the mask must both follow the reversed column.
+			Input:   `SrcNetPrefix = 192.168.0.128/27`,
+			Output:  `DstAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND DstNetMask = 27`,
+			MetaIn:  Meta{ReverseDirection: true},
+			MetaOut: Meta{ReverseDirection: true, MainTableRequired: true},
+		},
+		{
+			Input:   `SrcNetPrefix != 192.168.0.128/27`,
+			Output:  `NOT (DstAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND DstNetMask = 27)`,
+			MetaIn:  Meta{ReverseDirection: true},
+			MetaOut: Meta{ReverseDirection: true, MainTableRequired: true},
+		},
+		{
 			// The address and the mask must both follow the reverted column.
 			Input:   `SrcNetPrefix = 192.168.0.128/27`,
 			Output:  `DstAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND DstNetMask = 27`,
 			MetaIn:  Meta{ReverseDirection: true},
 			MetaOut: Meta{ReverseDirection: true, MainTableRequired: true},
+		},
+		{
+			Input:   `NOT SrcNetPrefix = 192.168.0.128/27`,
+			Output:  `NOT (SrcAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND SrcNetMask = 27)`,
+			MetaOut: Meta{MainTableRequired: true},
+		},
+		{
+			Input:   `NOT SrcNetPrefix = 192.168.0.128/27 AND SrcAS = 12322`,
+			Output:  `NOT (SrcAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND SrcNetMask = 27) AND SrcAS = 12322`,
+			MetaOut: Meta{MainTableRequired: true},
 		},
 		{
 			Input:   `DstNetPrefix != 192.168.0.128/27`,
@@ -351,11 +375,11 @@ func TestValidFilter(t *testing.T) {
 			MetaOut: Meta{MainTableRequired: true},
 		},
 		{
-			Input: `NOT DstPort > 1024 AND SrcPort < 1024`, Output: `NOT DstPort > 1024 AND SrcPort < 1024`,
+			Input: `NOT DstPort > 1024 AND SrcPort < 1024`, Output: `NOT (DstPort > 1024) AND SrcPort < 1024`,
 			MetaOut: Meta{MainTableRequired: true},
 		},
 		{
-			Input: `not DstPort > 1024 and SrcPort < 1024`, Output: `NOT DstPort > 1024 AND SrcPort < 1024`,
+			Input: `not DstPort > 1024 and SrcPort < 1024`, Output: `NOT (DstPort > 1024) AND SrcPort < 1024`,
 			MetaOut: Meta{MainTableRequired: true},
 		},
 		{
@@ -494,10 +518,11 @@ output provider */ = 'telia'`,
 			t.Errorf("Parse(%q) error:\n%+v", tc.Input, err)
 			continue
 		}
-		if diff := helpers.Diff(got.(string), tc.Output); diff != "" {
+		sql := got.(sb.Expr).String()
+		if diff := helpers.Diff(sql, tc.Output); diff != "" {
 			t.Errorf("Parse(%q) (-got, +want):\n%s", tc.Input, diff)
 		}
-		checkWhereParses(t, got.(string))
+		checkWhereParses(t, sql)
 		if diff := helpers.Diff(tc.MetaIn, tc.MetaOut); diff != "" {
 			t.Errorf("Parse(%q) meta (-got, +want):\n%s", tc.Input, diff)
 		}
@@ -550,10 +575,11 @@ func TestValidMaterializedFilter(t *testing.T) {
 			t.Errorf("Parse(%q) error:\n%+v", tc.Input, err)
 			continue
 		}
-		if diff := helpers.Diff(got.(string), tc.Output); diff != "" {
+		sql := got.(sb.Expr).String()
+		if diff := helpers.Diff(sql, tc.Output); diff != "" {
 			t.Errorf("Parse(%q) (-got, +want):\n%s", tc.Input, diff)
 		}
-		checkWhereParses(t, got.(string))
+		checkWhereParses(t, sql)
 		if diff := helpers.Diff(tc.MetaIn, tc.MetaOut); diff != "" {
 			t.Errorf("Parse(%q) meta (-got, +want):\n%s", tc.Input, diff)
 		}

--- a/console/filter/parser_test.go
+++ b/console/filter/parser_test.go
@@ -111,6 +111,19 @@ func TestValidFilter(t *testing.T) {
 			Output:  `SrcAddr BETWEEN toIPv6('2001:db8::') AND toIPv6('2001:db8:0:ffff:ffff:ffff:ffff:ffff') AND SrcNetMask = 48`,
 			MetaOut: Meta{MainTableRequired: true},
 		},
+		{
+			// The address and the mask must both follow the reverted column.
+			Input:   `SrcNetPrefix = 192.168.0.128/27`,
+			Output:  `DstAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND DstNetMask = 27`,
+			MetaIn:  Meta{ReverseDirection: true},
+			MetaOut: Meta{ReverseDirection: true, MainTableRequired: true},
+		},
+		{
+			Input:   `DstNetPrefix != 192.168.0.128/27`,
+			Output:  `NOT (SrcAddr BETWEEN toIPv6('192.168.0.128') AND toIPv6('192.168.0.159') AND SrcNetMask = 27)`,
+			MetaIn:  Meta{ReverseDirection: true},
+			MetaOut: Meta{ReverseDirection: true, MainTableRequired: true},
+		},
 		{Input: `ExporterGroup= "group"`, Output: `ExporterGroup = 'group'`},
 		{
 			Input: `SrcAddr=203.0.113.1`, Output: `SrcAddr = toIPv6('203.0.113.1')`,
@@ -512,6 +525,12 @@ func TestValidMaterializedFilter(t *testing.T) {
 			Input:   `SrcNetPrefix = 2001:db8::/48`,
 			Output:  `SrcNetPrefix = '2001:db8::/48'`,
 			MetaOut: Meta{MainTableRequired: false},
+		},
+		{
+			Input:   `SrcNetPrefix = 192.168.0.128/27`,
+			Output:  `DstNetPrefix = '192.168.0.128/27'`,
+			MetaIn:  Meta{ReverseDirection: true},
+			MetaOut: Meta{ReverseDirection: true},
 		},
 	}
 	for _, tc := range cases {

--- a/console/filter/parser_test.go
+++ b/console/filter/parser_test.go
@@ -534,11 +534,15 @@ func TestValidMaterializedFilter(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		// A materialized prefix column is only worth querying directly once it
+		// is also present outside the main table.
 		s := schema.NewMock(t).EnableAllColumns()
 		cd, _ := s.Schema.LookupColumnByKey(schema.ColumnDstNetPrefix)
 		cd.ClickHouseMaterialized = true
+		cd.ClickHouseMainOnly = false
 		cs, _ := s.Schema.LookupColumnByKey(schema.ColumnSrcNetPrefix)
 		cs.ClickHouseMaterialized = true
+		cs.ClickHouseMainOnly = false
 
 		tc.MetaIn.Schema = s
 		got, err := Parse("", []byte(tc.Input), GlobalStore("meta", &tc.MetaIn))
@@ -553,6 +557,63 @@ func TestValidMaterializedFilter(t *testing.T) {
 		if diff := helpers.Diff(tc.MetaIn, tc.MetaOut); diff != "" {
 			t.Errorf("Parse(%q) meta (-got, +want):\n%s", tc.Input, diff)
 		}
+	}
+}
+
+// TestPrefixFilterMainTableRequired checks a filter on a prefix only asks for
+// the main table when one of the columns it uses lives there.
+func TestPrefixFilterMainTableRequired(t *testing.T) {
+	cases := []struct {
+		Description  string
+		Materialized bool
+		MainOnly     bool
+		Expected     bool
+	}{
+		{
+			// The default schema: the address and the mask are on the main
+			// table only.
+			Description: "address and mask on the main table",
+			MainOnly:    true,
+			Expected:    true,
+		}, {
+			Description: "address and mask on every table",
+			MainOnly:    false,
+			Expected:    false,
+		}, {
+			Description:  "materialized prefix on the main table",
+			Materialized: true,
+			MainOnly:     true,
+			Expected:     true,
+		}, {
+			Description:  "materialized prefix on every table",
+			Materialized: true,
+			MainOnly:     false,
+			Expected:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			s := schema.NewMock(t).EnableAllColumns()
+			for _, key := range []schema.ColumnKey{
+				schema.ColumnSrcAddr, schema.ColumnSrcNetMask, schema.ColumnSrcNetPrefix,
+			} {
+				column, _ := s.Schema.LookupColumnByKey(key)
+				column.ClickHouseMainOnly = tc.MainOnly
+			}
+			if tc.Materialized {
+				column, _ := s.Schema.LookupColumnByKey(schema.ColumnSrcNetPrefix)
+				column.ClickHouseMaterialized = true
+			}
+
+			meta := Meta{Schema: s}
+			if _, err := Parse("", []byte(`SrcNetPrefix = 192.168.0.128/27`),
+				GlobalStore("meta", &meta)); err != nil {
+				t.Fatalf("Parse() error:\n%+v", err)
+			}
+			if diff := helpers.Diff(meta.MainTableRequired, tc.Expected); diff != "" {
+				t.Errorf("Parse() MainTableRequired (-got, +want):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/console/filter/sql_test.go
+++ b/console/filter/sql_test.go
@@ -7,17 +7,16 @@ import (
 	"fmt"
 	"testing"
 
-	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
+	sb "akvorado/common/sqlbuilder"
 )
 
-// checkWhereParses checks an expression is a valid boolean expression.
+// checkWhereParses checks an expression is a valid boolean expression. The
+// grammar builds a syntax tree, so this checks the tree turns back into SQL a
+// database would accept.
 func checkWhereParses(t *testing.T, where string) {
 	t.Helper()
 	if where == "" {
 		return
 	}
-	sql := fmt.Sprintf("SELECT 1 FROM flows WHERE %s", where)
-	if _, err := chparser.NewParser(sql).ParseStmts(); err != nil {
-		t.Errorf("ParseStmts(%q) error:\n%+v", where, err)
-	}
+	sb.CheckStatement(t, fmt.Sprintf("SELECT 1 FROM flows WHERE %s", where))
 }

--- a/console/filter/sql_test.go
+++ b/console/filter/sql_test.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// checkWhereParses checks an expression is a valid boolean expression.
+func checkWhereParses(t *testing.T, where string) {
+	t.Helper()
+	if where == "" {
+		return
+	}
+	sql := fmt.Sprintf("SELECT 1 FROM flows WHERE %s", where)
+	if _, err := chparser.NewParser(sql).ParseStmts(); err != nil {
+		t.Errorf("ParseStmts(%q) error:\n%+v", where, err)
+	}
+}

--- a/console/graph.go
+++ b/console/graph.go
@@ -4,11 +4,10 @@
 package console
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -39,37 +38,52 @@ func reverseUnits(units string) string {
 	return units
 }
 
+// truncateIP cuts an address down to the network of the requested prefix
+// length.
+func truncateIP(bits sb.Expr) func(sb.Expr) sb.Expr {
+	return func(addr sb.Expr) sb.Expr {
+		return sb.Function("tupleElement",
+			sb.Function("IPv6CIDRToRange", addr, bits),
+			sb.Uint(1))
+	}
+}
+
 // sourceSelect builds a SELECT query to use as a source for data. Notably, it
 // will do IP truncation.
-func (input graphCommonHandlerInput) sourceSelect(table string) string {
+func (input graphCommonHandlerInput) sourceSelect(table string) *sb.Query {
 	if input.TruncateAddrV4 == 0 {
 		input.TruncateAddrV4 = 32
 	}
 	if input.TruncateAddrV6 == 0 {
 		input.TruncateAddrV6 = 128
 	}
-	truncated := []string{}
+	truncated := []sb.Expr{}
 	for _, qc := range input.Dimensions {
 		if column, _ := input.schema.LookupColumnByKey(qc.Key()); column.ConsoleTruncateIP {
 			if input.TruncateAddrV4 == 32 && input.TruncateAddrV6 == 128 {
 				continue
 			}
-			if input.TruncateAddrV6 == input.TruncateAddrV4+96 {
-				truncated = append(truncated,
-					fmt.Sprintf("tupleElement(IPv6CIDRToRange(%s, %d), 1) AS %s",
-						qc.String(), input.TruncateAddrV6, qc.String()))
-			} else {
-				truncated = append(truncated,
-					fmt.Sprintf("tupleElement(IPv6CIDRToRange(%s, if(tupleElement(IPv6CIDRToRange(%s, 96), 1) = toIPv6('0.0.0.0'), %d, %d)), 1) AS %s",
-						qc.String(), qc.String(),
-						input.TruncateAddrV4+96, input.TruncateAddrV6,
-						qc.String()))
+			addr := sb.Column(qc.String())
+			bits := sb.Uint(uint64(input.TruncateAddrV6))
+			if input.TruncateAddrV6 != input.TruncateAddrV4+96 {
+				// Addresses are all stored as IPv6 ones, so the prefix length
+				// to use depends on the family of each address.
+				bits = sb.Function("if",
+					sb.Op(addr.Apply(truncateIP(sb.Uint(96))), "=",
+						sb.Function("toIPv6", sb.String("0.0.0.0"))),
+					sb.Uint(uint64(input.TruncateAddrV4+96)),
+					sb.Uint(uint64(input.TruncateAddrV6)))
 			}
+			truncated = append(truncated,
+				sb.Alias(addr.Apply(truncateIP(bits)), qc.String()))
 		}
 	}
+	source := sb.Select()
 	if len(truncated) == 0 {
-		return fmt.Sprintf("SELECT * FROM %s SETTINGS asterisk_include_alias_columns = 1", table)
+		source.Item(sb.Star())
+	} else {
+		source.Item(sb.Star(), sb.Replace(truncated...))
 	}
-	return fmt.Sprintf("SELECT * REPLACE (%s) FROM %s SETTINGS asterisk_include_alias_columns = 1",
-		strings.Join(truncated, ", "), table)
+	return source.From(table).
+		Setting("asterisk_include_alias_columns", sb.Uint(1))
 }

--- a/console/graph.go
+++ b/console/graph.go
@@ -84,6 +84,6 @@ func (input graphCommonHandlerInput) sourceSelect(table string) *sb.Query {
 	} else {
 		source.Item(sb.Star(), sb.Replace(truncated...))
 	}
-	return source.From(table).
+	return source.From(sb.Table(table)).
 		Setting("asterisk_include_alias_columns", sb.Uint(1))
 }

--- a/console/graph.go
+++ b/console/graph.go
@@ -41,7 +41,7 @@ func reverseUnits(units string) string {
 
 // sourceSelect builds a SELECT query to use as a source for data. Notably, it
 // will do IP truncation.
-func (input graphCommonHandlerInput) sourceSelect() string {
+func (input graphCommonHandlerInput) sourceSelect(table string) string {
 	if input.TruncateAddrV4 == 0 {
 		input.TruncateAddrV4 = 32
 	}
@@ -68,7 +68,8 @@ func (input graphCommonHandlerInput) sourceSelect() string {
 		}
 	}
 	if len(truncated) == 0 {
-		return "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1"
+		return fmt.Sprintf("SELECT * FROM %s SETTINGS asterisk_include_alias_columns = 1", table)
 	}
-	return fmt.Sprintf("SELECT * REPLACE (%s) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1", strings.Join(truncated, ", "))
+	return fmt.Sprintf("SELECT * REPLACE (%s) FROM %s SETTINGS asterisk_include_alias_columns = 1",
+		strings.Join(truncated, ", "), table)
 }

--- a/console/graph_test.go
+++ b/console/graph_test.go
@@ -8,6 +8,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -61,8 +62,8 @@ func TestSourceSelect(t *testing.T) {
 		if err := query.Columns(tc.Input.Dimensions).Validate(tc.Input.schema); err != nil {
 			t.Fatalf("Validate() error:\n%+v", err)
 		}
-		got := tc.Input.sourceSelect("flows_1m0s")
-		if diff := helpers.Diff(got, tc.Expected); diff != "" {
+		got := sb.Normalize(t, tc.Input.sourceSelect("flows_1m0s").String())
+		if diff := helpers.Diff(got, sb.Normalize(t, tc.Expected)); diff != "" {
 			t.Errorf("sourceSelect(%q) (-got, +want): \n%s", tc.Description, diff)
 		}
 	}

--- a/console/graph_test.go
+++ b/console/graph_test.go
@@ -23,7 +23,7 @@ func TestSourceSelect(t *testing.T) {
 			Input: graphCommonHandlerInput{
 				Dimensions: []query.Column{},
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM flows_1m0s SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "no truncatable dimensions",
 			Input: graphCommonHandlerInput{
@@ -31,13 +31,13 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 16,
 				TruncateAddrV6: 40,
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM flows_1m0s SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "no truncatation",
 			Input: graphCommonHandlerInput{
 				Dimensions: []query.Column{query.NewColumn("SrcAddr")},
 			},
-			Expected: "SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * FROM flows_1m0s SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "IPv4/IPv6 same prefix length",
 			Input: graphCommonHandlerInput{
@@ -45,7 +45,7 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 16,
 				TruncateAddrV6: 112,
 			},
-			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, 112), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, 112), 1) AS SrcAddr) FROM flows_1m0s SETTINGS asterisk_include_alias_columns = 1",
 		}, {
 			Description: "IPv4/IPv6 different prefix length",
 			Input: graphCommonHandlerInput{
@@ -53,7 +53,7 @@ func TestSourceSelect(t *testing.T) {
 				TruncateAddrV4: 24,
 				TruncateAddrV6: 40,
 			},
-			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 40)), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1",
+			Expected: "SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 40)), 1) AS SrcAddr) FROM flows_1m0s SETTINGS asterisk_include_alias_columns = 1",
 		},
 	}
 	for _, tc := range cases {
@@ -61,7 +61,7 @@ func TestSourceSelect(t *testing.T) {
 		if err := query.Columns(tc.Input.Dimensions).Validate(tc.Input.schema); err != nil {
 			t.Fatalf("Validate() error:\n%+v", err)
 		}
-		got := tc.Input.sourceSelect()
+		got := tc.Input.sourceSelect("flows_1m0s")
 		if diff := helpers.Diff(got, tc.Expected); diff != "" {
 			t.Errorf("sourceSelect(%q) (-got, +want): \n%s", tc.Description, diff)
 		}

--- a/console/line.go
+++ b/console/line.go
@@ -154,7 +154,7 @@ func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQ
 		sb.Alias(sb.Op(unitsSQL, "/", sb.Uint(r.Interval)), "xps"),
 		sb.Alias(dimensionsField, "dimensions"),
 	).
-		From("source").
+		From(sb.Table("source")).
 		Where(where).
 		GroupBy(sb.Column("time"), sb.Column("dimensions")).
 		OrderBy(sb.Order(sb.Column("time")).Fill(

--- a/console/line.go
+++ b/console/line.go
@@ -95,26 +95,33 @@ func (input graphLineHandlerInput) previousPeriod() graphLineHandlerInput {
 }
 
 type toSQL1Options struct {
-	skipWithClause    bool
-	reverseDirection  bool
-	offsetedStart     time.Time
-	mainTableRequired bool
+	skipWithClause   bool
+	reverseDirection bool
+	offsetedStart    time.Time
 }
 
-func (input graphLineHandlerInput) toSQL1(axis int, options toSQL1Options) templateQuery {
-	var startForInterval *time.Time
+func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQL1Options) string {
 	var offsetShift string
 	if !options.offsetedStart.IsZero() {
-		startForInterval = &options.offsetedStart
 		offsetShift = fmt.Sprintf(" + INTERVAL %d second",
 			int64(options.offsetedStart.Sub(input.Start).Seconds()))
 	}
-	where := templateWhere(input.Filter)
+	// The previous period covers an earlier range, so each axis gets its own
+	// time filter out of the shared resolution.
+	r := res.forRange(input.Start, input.End)
+	where := r.where(input.Filter)
+
+	// Units
+	units := input.Units
+	if options.reverseDirection {
+		units = reverseUnits(units)
+	}
+	unitsSQL := unitsExpr(units)
 
 	// Select
 	fields := []string{
-		fmt.Sprintf(`{{ .ToStartOfInterval }}%s AS time`, offsetShift),
-		`{{ .Units }}/{{ .Interval }} AS xps`,
+		fmt.Sprintf(`%s%s AS time`, r.ToStartOfInterval, offsetShift),
+		fmt.Sprintf(`%s/%d AS xps`, unitsSQL, r.Interval),
 	}
 	selectFields := []string{}
 	dimensions := []string{}
@@ -140,22 +147,16 @@ func (input graphLineHandlerInput) toSQL1(axis int, options toSQL1Options) templ
 	// With
 	withStr := ""
 	if !options.skipWithClause {
-		with := []string{fmt.Sprintf("source AS (%s)", input.sourceSelect())}
+		with := []string{fmt.Sprintf("source AS (%s)", input.sourceSelect(r.Table))}
 		if len(dimensions) > 0 {
-			with = append(with, selectLineRowsByLimitType(input, dimensions, where))
+			with = append(with, selectLineRowsByLimitType(input, dimensions, where, unitsSQL))
 		}
 		if len(with) > 0 {
 			withStr = fmt.Sprintf("\nWITH\n %s", strings.Join(with, ",\n "))
 		}
 	}
 
-	// Units
-	units := input.Units
-	if options.reverseDirection {
-		units = reverseUnits(units)
-	}
-
-	template := fmt.Sprintf(`%s
+	return strings.TrimSpace(fmt.Sprintf(`%s
 SELECT %d AS axis, * FROM (
 SELECT
  %s
@@ -163,58 +164,48 @@ FROM source
 WHERE %s
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}%s
- TO {{ .TimefilterEnd }} + INTERVAL 1 second%s
- STEP {{ .Interval }}
+ FROM %s%s
+ TO %s + INTERVAL 1 second%s
+ STEP %d
  INTERPOLATE (dimensions AS %s))`,
-		withStr, axis, strings.Join(fields, ",\n "), where, offsetShift, offsetShift,
+		withStr, axis, strings.Join(fields, ",\n "), where,
+		r.TimefilterStart, offsetShift,
+		r.TimefilterEnd, offsetShift,
+		r.Interval,
 		dimensionsInterpolate,
-	)
+	))
+}
 
-	context := inputContext{
-		Start:                  input.Start,
-		End:                    input.End,
-		StartForTableSelection: startForInterval,
-		MainTableRequired:      options.mainTableRequired,
-		Points:                 input.Points,
-		Units:                  units,
-	}
-
-	return templateQuery{
-		Template: strings.TrimSpace(template),
-		Context:  context,
+// resolveContext returns what is needed to select the table for this query.
+func (input graphLineHandlerInput) resolveContext() inputContext {
+	return inputContext{
+		Start:             input.Start,
+		End:               input.End,
+		MainTableRequired: requireMainTable(input.schema, input.Dimensions, input.Filter),
+		Points:            input.Points,
 	}
 }
 
-// toSQL converts a graph input to an SQL request
-func (input graphLineHandlerInput) toSQL() []templateQuery {
-	// Calculate mainTableRequired once and use it for all axes to ensure
-	// consistency. This is useful as previous period will remove the
-	// dimensions.
-	mainTableRequired := requireMainTable(input.schema, input.Dimensions, input.Filter)
-	queries := []templateQuery{input.toSQL1(1, toSQL1Options{
-		mainTableRequired: mainTableRequired,
-	})}
+// toSQL converts a graph input to a list of SQL requests, one per axis.
+func (input graphLineHandlerInput) toSQL(res resolution) []string {
+	queries := []string{input.toSQL1(1, res, toSQL1Options{})}
 	if input.Bidirectional {
-		queries = append(queries, input.reverseDirection().toSQL1(2, toSQL1Options{
-			skipWithClause:    true,
-			reverseDirection:  true,
-			mainTableRequired: mainTableRequired,
+		queries = append(queries, input.reverseDirection().toSQL1(2, res, toSQL1Options{
+			skipWithClause:   true,
+			reverseDirection: true,
 		}))
 	}
 	if input.PreviousPeriod {
-		queries = append(queries, input.previousPeriod().toSQL1(3, toSQL1Options{
-			skipWithClause:    true,
-			offsetedStart:     input.Start,
-			mainTableRequired: mainTableRequired,
+		queries = append(queries, input.previousPeriod().toSQL1(3, res, toSQL1Options{
+			skipWithClause: true,
+			offsetedStart:  input.Start,
 		}))
 	}
 	if input.Bidirectional && input.PreviousPeriod {
-		queries = append(queries, input.reverseDirection().previousPeriod().toSQL1(4, toSQL1Options{
-			skipWithClause:    true,
-			reverseDirection:  true,
-			offsetedStart:     input.Start,
-			mainTableRequired: mainTableRequired,
+		queries = append(queries, input.reverseDirection().previousPeriod().toSQL1(4, res, toSQL1Options{
+			skipWithClause:   true,
+			reverseDirection: true,
+			offsetedStart:    input.Start,
 		}))
 	}
 	return queries
@@ -242,8 +233,8 @@ func (c *Component) graphLineHandlerFunc(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	queries := input.toSQL()
-	sqlQuery := c.finalizeTemplateQueries(queries)
+	r := c.resolve(input.resolveContext())
+	sqlQuery := strings.Join(input.toSQL(r), "\nUNION ALL\n")
 	w.Header().Set("X-SQL-Query", strings.ReplaceAll(sqlQuery, "\n", "  "))
 
 	results := []struct {
@@ -252,6 +243,7 @@ func (c *Component) graphLineHandlerFunc(w http.ResponseWriter, req *http.Reques
 		Xps        float64   `ch:"xps"`
 		Dimensions []string  `ch:"dimensions"`
 	}{}
+	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
 	if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, sqlQuery); err != nil {
 		c.r.Err(err).Str("query", sqlQuery).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})

--- a/console/line.go
+++ b/console/line.go
@@ -234,7 +234,7 @@ func (c *Component) graphLineHandlerFunc(w http.ResponseWriter, req *http.Reques
 	}
 
 	r := c.resolve(input.resolveContext())
-	sqlQuery := strings.Join(input.toSQL(r), "\nUNION ALL\n")
+	sqlQuery := unionAll(input.toSQL(r))
 	w.Header().Set("X-SQL-Query", strings.ReplaceAll(sqlQuery, "\n", "  "))
 
 	results := []struct {

--- a/console/line.go
+++ b/console/line.go
@@ -72,49 +72,48 @@ func nearestPeriod(period time.Duration) (time.Duration, string) {
 	}
 }
 
-// previousPeriod shifts the provided input to the previous period.
-// The chosen period depend on the current period. For less than
-// 2-hour period, the previous period is the hour. For less than 2-day
-// period, this is the day. For less than 2-weeks, this is the week,
-// for less than 2-months, this is the month, otherwise, this is the
-// year. Also, dimensions are stripped.
-func (input graphLineHandlerInput) previousPeriod() graphLineHandlerInput {
+// previousPeriod shifts the provided input to the previous period and returns
+// by how much it moved. The chosen period depend on the current period. For
+// less than 2-hour period, the previous period is the hour. For less than 2-day
+// period, this is the day. For less than 2-weeks, this is the week, for less
+// than 2-months, this is the month, otherwise, this is the year. Also,
+// dimensions are stripped.
+func (input graphLineHandlerInput) previousPeriod() (graphLineHandlerInput, time.Duration) {
 	input.Dimensions = []query.Column{}
 	diff := input.End.Sub(input.Start)
 	period, _ := nearestPeriod(diff)
 	if period == 0 {
-		// We use a full year this time (think for example we
-		// want to see how was New Year Eve compared to last
-		// year)
-		input.Start = input.Start.AddDate(-1, 0, 0)
-		input.End = input.End.AddDate(-1, 0, 0)
-		return input
+		// We use a full year this time (think for example we want to see how
+		// was New Year Eve compared to last year). A year has no fixed length,
+		// so it is measured from the start of the period. Both ends have to
+		// move by the same amount, otherwise a leap day would give the previous
+		// period one point more or less than the main one.
+		period = input.Start.Sub(input.Start.AddDate(-1, 0, 0))
 	}
 	input.Start = input.Start.Add(-period)
 	input.End = input.End.Add(-period)
-	return input
+	return input, period
 }
 
 type toSQL1Options struct {
 	skipWithClause   bool
 	reverseDirection bool
-	offsetedStart    time.Time
+	// shiftedBy is how far back the range of this axis was moved. Its
+	// timestamps move forward by the same amount, so the axis is drawn on the
+	// time axis of the main period.
+	shiftedBy time.Duration
 }
 
-func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQL1Options) *sb.Query {
-	// The previous period covers an earlier range, so each axis gets its own
-	// time filter out of the shared resolution.
-	r := res.forRange(input.Start, input.End)
+func (input graphLineHandlerInput) toSQL1(axis int, r resolved, options toSQL1Options) *sb.Query {
 	where := r.where(input.Filter)
 
 	// The previous period is drawn on the time axis of the main one, so its
 	// timestamps are shifted forward.
 	shift := func(expr sb.Expr) sb.Expr {
-		if options.offsetedStart.IsZero() {
+		if options.shiftedBy == 0 {
 			return expr
 		}
-		return sb.Op(expr, "+",
-			seconds(uint64(options.offsetedStart.Sub(input.Start).Seconds())))
+		return sb.Op(expr, "+", seconds(uint64(options.shiftedBy.Seconds())))
 	}
 
 	// Units
@@ -188,24 +187,29 @@ func (input graphLineHandlerInput) resolveContext() inputContext {
 
 // toSQL converts a graph input to a list of SQL requests, one per axis.
 func (input graphLineHandlerInput) toSQL(res resolution) []*sb.Query {
-	queries := []*sb.Query{input.toSQL1(1, res, toSQL1Options{})}
+	// The resolution is applied once: the previous period reuses the resulting
+	// range, moved back in time, so both cover the same number of points.
+	main := res.forRange(input.Start, input.End)
+	queries := []*sb.Query{input.toSQL1(1, main, toSQL1Options{})}
 	if input.Bidirectional {
-		queries = append(queries, input.reverseDirection().toSQL1(2, res, toSQL1Options{
+		queries = append(queries, input.reverseDirection().toSQL1(2, main, toSQL1Options{
 			skipWithClause:   true,
 			reverseDirection: true,
 		}))
 	}
 	if input.PreviousPeriod {
-		queries = append(queries, input.previousPeriod().toSQL1(3, res, toSQL1Options{
+		previous, period := input.previousPeriod()
+		queries = append(queries, previous.toSQL1(3, main.shiftBack(period), toSQL1Options{
 			skipWithClause: true,
-			offsetedStart:  input.Start,
+			shiftedBy:      period,
 		}))
 	}
 	if input.Bidirectional && input.PreviousPeriod {
-		queries = append(queries, input.reverseDirection().previousPeriod().toSQL1(4, res, toSQL1Options{
+		previous, period := input.reverseDirection().previousPeriod()
+		queries = append(queries, previous.toSQL1(4, main.shiftBack(period), toSQL1Options{
 			skipWithClause:   true,
 			reverseDirection: true,
-			offsetedStart:    input.Start,
+			shiftedBy:        period,
 		}))
 	}
 	return queries

--- a/console/line.go
+++ b/console/line.go
@@ -14,6 +14,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/httpserver"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -100,16 +101,21 @@ type toSQL1Options struct {
 	offsetedStart    time.Time
 }
 
-func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQL1Options) string {
-	var offsetShift string
-	if !options.offsetedStart.IsZero() {
-		offsetShift = fmt.Sprintf(" + INTERVAL %d second",
-			int64(options.offsetedStart.Sub(input.Start).Seconds()))
-	}
+func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQL1Options) *sb.Query {
 	// The previous period covers an earlier range, so each axis gets its own
 	// time filter out of the shared resolution.
 	r := res.forRange(input.Start, input.End)
 	where := r.where(input.Filter)
+
+	// The previous period is drawn on the time axis of the main one, so its
+	// timestamps are shifted forward.
+	shift := func(expr sb.Expr) sb.Expr {
+		if options.offsetedStart.IsZero() {
+			return expr
+		}
+		return sb.Op(expr, "+",
+			seconds(uint64(options.offsetedStart.Sub(input.Start).Seconds())))
+	}
 
 	// Units
 	units := input.Units
@@ -119,61 +125,55 @@ func (input graphLineHandlerInput) toSQL1(axis int, res resolution, options toSQ
 	unitsSQL := unitsExpr(units)
 
 	// Select
-	fields := []string{
-		fmt.Sprintf(`%s%s AS time`, r.ToStartOfInterval, offsetShift),
-		fmt.Sprintf(`%s/%d AS xps`, unitsSQL, r.Interval),
-	}
-	selectFields := []string{}
-	dimensions := []string{}
-	dimensionsInterpolate := ""
-	others := []string{}
+	selectFields := []sb.Expr{}
+	dimensions := []sb.Expr{}
+	others := []sb.Expr{}
 	for _, column := range input.Dimensions {
-		field := column.ToSQLSelect(input.schema)
-		selectFields = append(selectFields, field)
-		dimensions = append(dimensions, column.String())
-		others = append(others, "'Other'")
+		selectFields = append(selectFields, column.ToSQLSelect(input.schema))
+		dimensions = append(dimensions, sb.Column(column.String()))
+		others = append(others, sb.String("Other"))
 	}
+	// Rows outside the selected ones are folded into a single "Other" row. The
+	// same value fills the gaps left by WITH FILL.
+	othersArray := func() sb.Expr {
+		if len(dimensions) == 0 {
+			return sb.Function("emptyArrayString")
+		}
+		return sb.Array(others...)
+	}
+	dimensionsField := othersArray()
 	if len(dimensions) > 0 {
-		fields = append(fields, fmt.Sprintf(`if((%s) IN rows, [%s], [%s]) AS dimensions`,
-			strings.Join(dimensions, ", "),
-			strings.Join(selectFields, ", "),
-			strings.Join(others, ", ")))
-		dimensionsInterpolate = fmt.Sprintf("[%s]", strings.Join(others, ", "))
-	} else {
-		fields = append(fields, "emptyArrayString() AS dimensions")
-		dimensionsInterpolate = "emptyArrayString()"
+		dimensionsField = sb.Function("if",
+			sb.Op(sb.Tuple(dimensions...), "IN", sb.Column("rows")),
+			sb.Array(selectFields...),
+			othersArray())
 	}
 
-	// With
-	withStr := ""
+	inner := sb.Select(
+		sb.Alias(shift(r.toStartOfInterval()), "time"),
+		sb.Alias(sb.Op(unitsSQL, "/", sb.Uint(r.Interval)), "xps"),
+		sb.Alias(dimensionsField, "dimensions"),
+	).
+		From("source").
+		Where(where).
+		GroupBy(sb.Column("time"), sb.Column("dimensions")).
+		OrderBy(sb.Order(sb.Column("time")).Fill(
+			shift(r.timefilterStart()),
+			shift(sb.Op(r.timefilterEnd(), "+", seconds(1))),
+			sb.Uint(r.Interval))).
+		Interpolate("dimensions", othersArray())
+
+	query := sb.Select(
+		sb.Alias(sb.Int(int64(axis)), "axis"),
+		sb.Star()).
+		FromSelect(inner)
 	if !options.skipWithClause {
-		with := []string{fmt.Sprintf("source AS (%s)", input.sourceSelect(r.Table))}
+		query.With("source", input.sourceSelect(r.Table))
 		if len(dimensions) > 0 {
-			with = append(with, selectLineRowsByLimitType(input, dimensions, where, unitsSQL))
-		}
-		if len(with) > 0 {
-			withStr = fmt.Sprintf("\nWITH\n %s", strings.Join(with, ",\n "))
+			query.With("rows", selectLineRowsByLimitType(input, dimensions, where, unitsSQL))
 		}
 	}
-
-	return strings.TrimSpace(fmt.Sprintf(`%s
-SELECT %d AS axis, * FROM (
-SELECT
- %s
-FROM source
-WHERE %s
-GROUP BY time, dimensions
-ORDER BY time WITH FILL
- FROM %s%s
- TO %s + INTERVAL 1 second%s
- STEP %d
- INTERPOLATE (dimensions AS %s))`,
-		withStr, axis, strings.Join(fields, ",\n "), where,
-		r.TimefilterStart, offsetShift,
-		r.TimefilterEnd, offsetShift,
-		r.Interval,
-		dimensionsInterpolate,
-	))
+	return query
 }
 
 // resolveContext returns what is needed to select the table for this query.
@@ -187,8 +187,8 @@ func (input graphLineHandlerInput) resolveContext() inputContext {
 }
 
 // toSQL converts a graph input to a list of SQL requests, one per axis.
-func (input graphLineHandlerInput) toSQL(res resolution) []string {
-	queries := []string{input.toSQL1(1, res, toSQL1Options{})}
+func (input graphLineHandlerInput) toSQL(res resolution) []*sb.Query {
+	queries := []*sb.Query{input.toSQL1(1, res, toSQL1Options{})}
 	if input.Bidirectional {
 		queries = append(queries, input.reverseDirection().toSQL1(2, res, toSQL1Options{
 			skipWithClause:   true,

--- a/console/line_test.go
+++ b/console/line_test.go
@@ -5,6 +5,8 @@ package console
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -158,12 +160,109 @@ func TestGraphPreviousPeriod(t *testing.T) {
 	}
 }
 
+func TestGraphLineResolveContext(t *testing.T) {
+	sch := schema.NewMock(t)
+	start := time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
+	end := time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC)
+	cases := []struct {
+		Description string
+		Dimensions  []query.Column
+		Filter      query.Filter
+		Expected    inputContext
+	}{
+		{
+			Description: "no dimension",
+			Dimensions:  []query.Column{},
+			Expected:    inputContext{Start: start, End: end, Points: 100},
+		}, {
+			Description: "dimension on the main table only",
+			Dimensions:  []query.Column{query.NewColumn("SrcPort")},
+			Expected: inputContext{
+				Start: start, End: end, Points: 100, MainTableRequired: true,
+			},
+		}, {
+			Description: "filter on the main table only",
+			Dimensions:  []query.Column{},
+			Filter:      query.NewFilter("SrcPort = 80"),
+			Expected: inputContext{
+				Start: start, End: end, Points: 100, MainTableRequired: true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			input := graphLineHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
+					schema:     sch,
+					Start:      start,
+					End:        end,
+					Dimensions: tc.Dimensions,
+					Filter:     tc.Filter,
+				},
+				Points: 100,
+			}
+			if err := query.Columns(input.Dimensions).Validate(sch); err != nil {
+				t.Fatalf("Validate() error:\n%+v", err)
+			}
+			if err := input.Filter.Validate(sch); err != nil {
+				t.Fatalf("Validate() error:\n%+v", err)
+			}
+			if diff := helpers.Diff(input.resolveContext(), tc.Expected); diff != "" {
+				t.Errorf("resolveContext() (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestGraphQueryAxesRanges checks the two properties the axes must have: they
+// all step on the same time grid, but the previous period covers its own range.
+func TestGraphQueryAxesRanges(t *testing.T) {
+	input := graphLineHandlerInput{
+		graphCommonHandlerInput: graphCommonHandlerInput{
+			schema:     schema.NewMock(t),
+			Start:      time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+			End:        time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+			Dimensions: []query.Column{},
+			Units:      "l3bps",
+		},
+		Points:         100,
+		PreviousPeriod: true,
+	}
+	if err := input.Filter.Validate(input.schema); err != nil {
+		t.Fatalf("Validate() error:\n%+v", err)
+	}
+	got := input.toSQL(testResolution)
+	if len(got) != 2 {
+		t.Fatalf("toSQL() got %d axes, expected 2", len(got))
+	}
+
+	// Same step for both axes: the previous period is drawn on the time axis
+	// of the main one.
+	steps := regexp.MustCompile(`STEP (\d+)`)
+	main := steps.FindStringSubmatch(got[0])
+	previous := steps.FindStringSubmatch(got[1])
+	if main == nil || previous == nil {
+		t.Fatalf("toSQL() missing STEP:\n%s\n%s", got[0], got[1])
+	}
+	if diff := helpers.Diff(previous[1], main[1]); diff != "" {
+		t.Errorf("toSQL() previous period STEP (-got, +want):\n%s", diff)
+	}
+
+	// But the previous period queries the day before.
+	if !strings.Contains(got[0], "BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')") {
+		t.Errorf("toSQL() main axis does not cover the requested period:\n%s", got[0])
+	}
+	if !strings.Contains(got[1], "BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC')") {
+		t.Errorf("toSQL() previous period does not cover the day before:\n%s", got[1])
+	}
+}
+
 func TestGraphQuerySQL(t *testing.T) {
 	cases := []struct {
 		Description string
 		Pos         helpers.Pos
 		Input       graphLineHandlerInput
-		Expected    []templateQuery
+		Expected    []string
 	}{
 		{
 			Description: "no dimensions, no filters, bps",
@@ -178,30 +277,22 @@ func TestGraphQuerySQL(t *testing.T) {
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no dimensions, no filters, l2 bps",
@@ -216,30 +307,22 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l2bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM((Bytes+38*Packets)*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no dimensions, no filters, pps",
@@ -254,30 +337,22 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "pps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Packets*SamplingRate)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no dimensions, no filters, fps",
@@ -292,30 +367,22 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "fps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ COUNT(*)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "truncated source address",
@@ -332,32 +399,23 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:             time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:               time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points:            100,
-						Units:             "l3bps",
-						MainTableRequired: true,
-					},
-					Template: `WITH
- source AS (SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 48)), 1) AS SrcAddr) FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr FROM source WHERE {{ .Timefilter }} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')) GROUP BY SrcAddr ORDER BY {{ .Units }} DESC LIMIT 0)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 48)), 1) AS SrcAddr) FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT SrcAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')) GROUP BY SrcAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((SrcAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', '')], ['Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255'))
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255'))
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other']))`,
-				},
 			},
 		}, {
 			Description: "no dimensions",
@@ -372,33 +430,25 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
-			Description: "no dimensions, escaped filter",
+			Description: "no dimensions, filter with braces",
 			Pos:         helpers.Mark(),
 			Input: graphLineHandlerInput{
 				graphCommonHandlerInput: graphCommonHandlerInput{
@@ -410,30 +460,22 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfDescription = '{{"{{"}} hello }}' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfDescription = '{{ hello }}' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no dimensions, reverse direction",
@@ -449,50 +491,35 @@ ORDER BY time WITH FILL
 				Points:        100,
 				Bidirectional: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				}, {
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `SELECT 2 AS axis, * FROM (
+				`SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR' AND DstCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no dimensions, reverse direction, inl2%",
@@ -508,50 +535,35 @@ ORDER BY time WITH FILL
 				Points:        100,
 				Bidirectional: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "inl2%",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				}, {
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "outl2%",
-					},
-					Template: `SELECT 2 AS axis, * FROM (
+				`SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR' AND DstCountry = 'US')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "no filters",
@@ -570,31 +582,23 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY ExporterName, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				},
 			},
 		}, {
 			Description: "no filters, limitType by max",
@@ -614,31 +618,23 @@ ORDER BY time WITH FILL
 				},
 				Points: 100,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM ( SELECT ExporterName, InIfProvider, {{ .Units }} AS sum_at_time FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ) GROUP BY ExporterName, InIfProvider ORDER BY MAX(sum_at_time) DESC LIMIT 20)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM ( SELECT ExporterName, InIfProvider, SUM(Bytes*SamplingRate*8) AS sum_at_time FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY ExporterName, InIfProvider ) GROUP BY ExporterName, InIfProvider ORDER BY MAX(sum_at_time) DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				},
 			},
 		}, {
 			Description: "no filters, reverse",
@@ -658,51 +654,36 @@ ORDER BY time WITH FILL
 				Points:        100,
 				Bidirectional: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY ExporterName, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				}, {
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `SELECT 2 AS axis, * FROM (
+				`SELECT 2 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((ExporterName, OutIfProvider) IN rows, [ExporterName, OutIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				},
 			},
 		}, {
 			Description: "no filters, previous period",
@@ -722,55 +703,36 @@ ORDER BY time WITH FILL
 				Points:         100,
 				PreviousPeriod: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT ExporterName, InIfProvider FROM source WHERE {{ .Timefilter }} GROUP BY ExporterName, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 20)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT ExporterName, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY ExporterName, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 20)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((ExporterName, InIfProvider) IN rows, [ExporterName, InIfProvider], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				}, {
-					Context: inputContext{
-						Start: time.Date(2022, 4, 9, 15, 45, 10, 0, time.UTC),
-						End:   time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						StartForTableSelection: func() *time.Time {
-							t := time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
-							return &t
-						}(),
-						Points: 100,
-						Units:  "l3bps",
-					},
-					Template: `SELECT 3 AS axis, * FROM (
+				`SELECT 3 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} + INTERVAL 86400 second AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second + INTERVAL 86400 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }} + INTERVAL 86400 second
- TO {{ .TimefilterEnd }} + INTERVAL 1 second + INTERVAL 86400 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-09 15:45:00', 'UTC') + INTERVAL 86400 second
+ TO toDateTime('2022-04-10 15:45:00', 'UTC') + INTERVAL 1 second + INTERVAL 86400 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		}, {
 			Description: "previous period while main table is required",
@@ -789,57 +751,36 @@ ORDER BY time WITH FILL
 				Points:         100,
 				PreviousPeriod: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:             time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:               time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						MainTableRequired: true,
-						Points:            100,
-						Units:             "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr, DstAddr FROM source WHERE {{ .Timefilter }} AND (InIfBoundary = 'external') GROUP BY SrcAddr, DstAddr ORDER BY {{ .Units }} DESC LIMIT 0)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ rows AS (SELECT SrcAddr, DstAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfBoundary = 'external') GROUP BY SrcAddr, DstAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((SrcAddr, DstAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', ''), replaceRegexpOne(IPv6NumToString(DstAddr), '^::ffff:', '')], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfBoundary = 'external')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfBoundary = 'external')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-10 15:45:00', 'UTC')
+ TO toDateTime('2022-04-11 15:45:00', 'UTC') + INTERVAL 1 second
+ STEP 60
  INTERPOLATE (dimensions AS ['Other', 'Other']))`,
-				}, {
-					Context: inputContext{
-						Start: time.Date(2022, 4, 9, 15, 45, 10, 0, time.UTC),
-						End:   time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						StartForTableSelection: func() *time.Time {
-							t := time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
-							return &t
-						}(),
-						MainTableRequired: true,
-						Points:            100,
-						Units:             "l3bps",
-					},
-					Template: `SELECT 3 AS axis, * FROM (
+				`SELECT 3 AS axis, * FROM (
 SELECT
- {{ .ToStartOfInterval }} + INTERVAL 86400 second AS time,
- {{ .Units }}/{{ .Interval }} AS xps,
+ toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second + INTERVAL 86400 second AS time,
+ SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (InIfBoundary = 'external')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC') AND (InIfBoundary = 'external')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
- FROM {{ .TimefilterStart }} + INTERVAL 86400 second
- TO {{ .TimefilterEnd }} + INTERVAL 1 second + INTERVAL 86400 second
- STEP {{ .Interval }}
+ FROM toDateTime('2022-04-09 15:45:00', 'UTC') + INTERVAL 86400 second
+ TO toDateTime('2022-04-10 15:45:00', 'UTC') + INTERVAL 1 second + INTERVAL 86400 second
+ STEP 60
  INTERPOLATE (dimensions AS emptyArrayString()))`,
-				},
 			},
 		},
 	}
@@ -852,7 +793,7 @@ ORDER BY time WITH FILL
 			t.Fatalf("%sValidate() error:\n%+v", tc.Pos, err)
 		}
 		t.Run(tc.Description, func(t *testing.T) {
-			got := tc.Input.toSQL()
+			got := tc.Input.toSQL(testResolution)
 			if diff := helpers.Diff(got, tc.Expected); diff != "" {
 				t.Errorf("%stoSQL (-got, +want):\n%s", tc.Pos, diff)
 			}

--- a/console/line_test.go
+++ b/console/line_test.go
@@ -109,13 +109,15 @@ func TestGraphPreviousPeriod(t *testing.T) {
 			"Feb 10, 2020 at 15:04", "Mar 25, 2020 at 17:34",
 			"Jan 13, 2020 at 15:04", "Feb 26, 2020 at 17:34",
 		}, {
+			// 2020 is a leap year: the end moves by the same 365 days as the
+			// start, otherwise the previous period would be one day shorter.
 			helpers.Mark(),
 			"Feb 10, 2020 at 15:04", "Jul 25, 2020 at 17:34",
-			"Feb 10, 2019 at 15:04", "Jul 25, 2019 at 17:34",
+			"Feb 10, 2019 at 15:04", "Jul 26, 2019 at 17:34",
 		}, {
 			helpers.Mark(),
 			"Feb 10, 2019 at 15:04", "Jul 25, 2020 at 17:34",
-			"Feb 10, 2018 at 15:04", "Jul 25, 2019 at 17:34",
+			"Feb 10, 2018 at 15:04", "Jul 26, 2019 at 17:34",
 		},
 	}
 	for _, tc := range cases {
@@ -148,7 +150,7 @@ func TestGraphPreviousPeriod(t *testing.T) {
 				},
 			}
 			query.Columns(input.Dimensions).Validate(input.schema)
-			got := input.previousPeriod()
+			got, period := input.previousPeriod()
 			expected := graphLineHandlerInput{
 				graphCommonHandlerInput: graphCommonHandlerInput{
 					Start:      expectedStart,
@@ -158,6 +160,14 @@ func TestGraphPreviousPeriod(t *testing.T) {
 			}
 			if diff := helpers.Diff(got, expected); diff != "" {
 				t.Fatalf("%spreviousPeriod() (-got, +want):\n%s", tc.Pos, diff)
+			}
+			// Both ends move by the returned period, so the previous period
+			// covers exactly as much time as the main one.
+			if diff := helpers.Diff(start.Sub(got.Start), period); diff != "" {
+				t.Errorf("%spreviousPeriod() start shift (-got, +want):\n%s", tc.Pos, diff)
+			}
+			if diff := helpers.Diff(end.Sub(got.End), period); diff != "" {
+				t.Errorf("%spreviousPeriod() end shift (-got, +want):\n%s", tc.Pos, diff)
 			}
 		})
 	}
@@ -258,6 +268,84 @@ func TestGraphQueryAxesRanges(t *testing.T) {
 	if !strings.Contains(got[1], "BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC')") {
 		t.Errorf("toSQL() previous period does not cover the day before:\n%s", got[1])
 	}
+}
+
+// TestGraphQueryAxesLeapYear checks the previous period covers as much time as
+// the main one when a leap day sits between them. Both share a time axis and
+// step on the same grid, so a longer range would give the previous period one
+// point more than the main one.
+func TestGraphQueryAxesLeapYear(t *testing.T) {
+	cases := []struct {
+		Description string
+		Pos         helpers.Pos
+		Start       time.Time
+		End         time.Time
+	}{
+		{
+			// A year back from here is 365 days, but the requested period
+			// covers February 29th and the previous one does not.
+			Description: "leap day in the main period",
+			Pos:         helpers.Mark(),
+			Start:       time.Date(2020, 1, 1, 15, 45, 10, 0, time.UTC),
+			End:         time.Date(2020, 3, 5, 15, 45, 10, 0, time.UTC),
+		}, {
+			// The other way around: a year back is 366 days and only the
+			// previous period covers February 29th.
+			Description: "leap day in the previous period",
+			Pos:         helpers.Mark(),
+			Start:       time.Date(2021, 1, 1, 15, 45, 10, 0, time.UTC),
+			End:         time.Date(2021, 3, 5, 15, 45, 10, 0, time.UTC),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			input := graphLineHandlerInput{
+				graphCommonHandlerInput: graphCommonHandlerInput{
+					schema:     schema.NewMock(t),
+					Start:      tc.Start,
+					End:        tc.End,
+					Dimensions: []query.Column{},
+					Units:      "l3bps",
+				},
+				Points:         100,
+				PreviousPeriod: true,
+			}
+			if err := input.Filter.Validate(input.schema); err != nil {
+				t.Fatalf("Validate() error:\n%+v", err)
+			}
+			got := toSQLStrings(t, input.toSQL(testResolution))
+			if len(got) != 2 {
+				t.Fatalf("toSQL() got %d axes, expected 2", len(got))
+			}
+			main := timefilterSpan(t, got[0])
+			previous := timefilterSpan(t, got[1])
+			if diff := helpers.Diff(previous, main); diff != "" {
+				t.Errorf("%stoSQL() previous period span (-got, +want):\n%s\nmain axis:\n%s\nprevious period:\n%s",
+					tc.Pos, diff, got[0], got[1])
+			}
+		})
+	}
+}
+
+var timefilterRegexp = regexp.MustCompile(
+	`TimeReceived BETWEEN toDateTime\('([^']+)', 'UTC'\) AND toDateTime\('([^']+)', 'UTC'\)`)
+
+// timefilterSpan returns how much time the WHERE clause of a query covers. With
+// a shared interval, this is what decides how many points an axis has.
+func timefilterSpan(t *testing.T, sql string) time.Duration {
+	t.Helper()
+	matches := timefilterRegexp.FindStringSubmatch(sql)
+	if matches == nil {
+		t.Fatalf("no time filter found in:\n%s", sql)
+	}
+	parse := func(value string) time.Time {
+		when, err := time.ParseInLocation("2006-01-02 15:04:05", value, time.UTC)
+		if err != nil {
+			t.Fatalf("time.ParseInLocation(%q) error:\n%+v", value, err)
+		}
+		return when
+	}
+	return parse(matches[2]).Sub(parse(matches[1]))
 }
 
 func TestGraphQuerySQL(t *testing.T) {

--- a/console/line_test.go
+++ b/console/line_test.go
@@ -14,6 +14,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -32,7 +33,6 @@ func TestGraphLineInputReverseDirection(t *testing.T) {
 		},
 		Points: 100,
 	}
-	original1 := fmt.Sprintf("%+v", input)
 	expected := graphLineHandlerInput{
 		graphCommonHandlerInput: graphCommonHandlerInput{
 			Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
@@ -50,13 +50,16 @@ func TestGraphLineInputReverseDirection(t *testing.T) {
 	expected.Filter.Validate(input.schema)
 	query.Columns(input.Dimensions).Validate(input.schema)
 	query.Columns(expected.Dimensions).Validate(input.schema)
+	snapshot := func() string {
+		return fmt.Sprintf("%+v %s %s", input, input.Filter.Direct(), input.Filter.Reverse())
+	}
+	original := snapshot()
 	got := input.reverseDirection()
-	original2 := fmt.Sprintf("%+v", input)
 	if diff := helpers.Diff(got, expected); diff != "" {
 		t.Fatalf("reverseDirection() (-got, +want):\n%s", diff)
 	}
-	if original1 != original2 {
-		t.Fatalf("reverseDirection() modified original to:\n-%s\n+%s", original1, original2)
+	if now := snapshot(); original != now {
+		t.Fatalf("reverseDirection() modified original to:\n-%s\n+%s", original, now)
 	}
 }
 
@@ -231,7 +234,7 @@ func TestGraphQueryAxesRanges(t *testing.T) {
 	if err := input.Filter.Validate(input.schema); err != nil {
 		t.Fatalf("Validate() error:\n%+v", err)
 	}
-	got := input.toSQL(testResolution)
+	got := toSQLStrings(t, input.toSQL(testResolution))
 	if len(got) != 2 {
 		t.Fatalf("toSQL() got %d axes, expected 2", len(got))
 	}
@@ -402,14 +405,14 @@ ORDER BY time WITH FILL
 			Expected: []string{
 				`WITH
  source AS (SELECT * REPLACE (tupleElement(IPv6CIDRToRange(SrcAddr, if(tupleElement(IPv6CIDRToRange(SrcAddr, 96), 1) = toIPv6('0.0.0.0'), 120, 48)), 1) AS SrcAddr) FROM flows SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')) GROUP BY SrcAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
+ rows AS (SELECT SrcAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255') GROUP BY SrcAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
  toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((SrcAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', '')], ['Other']) AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255'))
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND SrcAddr BETWEEN toIPv6('1.0.0.0') AND toIPv6('1.255.255.255')
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -439,7 +442,7 @@ SELECT
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR' AND SrcCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -469,7 +472,7 @@ SELECT
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfDescription = '{{ hello }}' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND InIfDescription = '{{ hello }}' AND SrcCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -500,7 +503,7 @@ SELECT
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR' AND SrcCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -513,7 +516,7 @@ SELECT
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND SrcCountry = 'FR' AND DstCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -544,7 +547,7 @@ SELECT
  ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(InIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, InIfName),0)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR' AND SrcCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR' AND SrcCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -557,7 +560,7 @@ SELECT
  ifNotFinite(SUM((Bytes+38*Packets)*SamplingRate*8*100/(OutIfSpeed*1000000))/COUNT(DISTINCT ExporterAddress, OutIfName),0)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR' AND DstCountry = 'US')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND SrcCountry = 'FR' AND DstCountry = 'US'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -754,14 +757,14 @@ ORDER BY time WITH FILL
 			Expected: []string{
 				`WITH
  source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
- rows AS (SELECT SrcAddr, DstAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfBoundary = 'external') GROUP BY SrcAddr, DstAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
+ rows AS (SELECT SrcAddr, DstAddr FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND InIfBoundary = 'external' GROUP BY SrcAddr, DstAddr ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 0)
 SELECT 1 AS axis, * FROM (
 SELECT
  toStartOfInterval(TimeReceived + INTERVAL 60 second, INTERVAL 60 second) - INTERVAL 60 second AS time,
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  if((SrcAddr, DstAddr) IN rows, [replaceRegexpOne(IPv6NumToString(SrcAddr), '^::ffff:', ''), replaceRegexpOne(IPv6NumToString(DstAddr), '^::ffff:', '')], ['Other', 'Other']) AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (InIfBoundary = 'external')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND InIfBoundary = 'external'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-10 15:45:00', 'UTC')
@@ -774,7 +777,7 @@ SELECT
  SUM(Bytes*SamplingRate*8)/60 AS xps,
  emptyArrayString() AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC') AND (InIfBoundary = 'external')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-09 15:45:00', 'UTC') AND toDateTime('2022-04-10 15:45:00', 'UTC') AND InIfBoundary = 'external'
 GROUP BY time, dimensions
 ORDER BY time WITH FILL
  FROM toDateTime('2022-04-09 15:45:00', 'UTC') + INTERVAL 86400 second
@@ -793,8 +796,8 @@ ORDER BY time WITH FILL
 			t.Fatalf("%sValidate() error:\n%+v", tc.Pos, err)
 		}
 		t.Run(tc.Description, func(t *testing.T) {
-			got := tc.Input.toSQL(testResolution)
-			if diff := helpers.Diff(got, tc.Expected); diff != "" {
+			got := toSQLStrings(t, tc.Input.toSQL(testResolution))
+			if diff := helpers.Diff(got, sb.NormalizeAll(t, tc.Expected)); diff != "" {
 				t.Errorf("%stoSQL (-got, +want):\n%s", tc.Pos, diff)
 			}
 		})

--- a/console/query.go
+++ b/console/query.go
@@ -53,12 +53,12 @@ func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []sb.Expr, 
 		rows.FromSelect(
 			sb.Select(slices.Concat(dimensions,
 				[]sb.Expr{sb.Alias(units, "sum_at_time")})...).
-				From("source").
+				From(sb.Table("source")).
 				Where(where).
 				GroupBy(dimensions...)).
 			OrderBy(sb.Order(
 				sb.Function("MAX", sb.Column("sum_at_time"))).Desc())
 		return rows
 	}
-	return rows.From("source").Where(where).OrderBy(sb.Order(units).Desc())
+	return rows.From(sb.Table("source")).Where(where).OrderBy(sb.Order(units).Desc())
 }

--- a/console/query.go
+++ b/console/query.go
@@ -4,11 +4,11 @@
 package console
 
 import (
-	"fmt"
 	"slices"
 	"strings"
 
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -35,35 +35,30 @@ func (c *Component) fixQueryColumnName(name string) string {
 	return ""
 }
 
-func selectSankeyRowsByLimitType(input graphSankeyHandlerInput, dimensions []string, where, units string) string {
+func selectSankeyRowsByLimitType(input graphSankeyHandlerInput, dimensions []sb.Expr, where, units sb.Expr) *sb.Query {
 	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where, units)
 }
 
-func selectLineRowsByLimitType(input graphLineHandlerInput, dimensions []string, where, units string) string {
+func selectLineRowsByLimitType(input graphLineHandlerInput, dimensions []sb.Expr, where, units sb.Expr) *sb.Query {
 	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where, units)
 }
 
-func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []string, where, units string) string {
-	var rowsType string
-	var source string
-	var orderBy string
+// selectRowsByLimitType builds the query picking the dimension values to
+// display. The other values are grouped as "Other".
+func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []sb.Expr, where, units sb.Expr) *sb.Query {
+	rows := sb.Select(dimensions...).GroupBy(dimensions...).Limit(input.Limit)
 	if input.LimitType == "max" {
-		source = fmt.Sprintf("( SELECT %s AS sum_at_time FROM source WHERE %s GROUP BY %s )",
-			strings.Join(slices.Concat(dimensions, []string{units}), ", "),
-			where,
-			strings.Join(dimensions, ", "),
-		)
-		orderBy = "MAX(sum_at_time)"
-	} else {
-		source = fmt.Sprintf("source WHERE %s", where)
-		orderBy = units
+		// Rank on the highest value reached instead of the total, so a short
+		// burst is not hidden by a steady flow.
+		rows.FromSelect(
+			sb.Select(slices.Concat(dimensions,
+				[]sb.Expr{sb.Alias(units, "sum_at_time")})...).
+				From("source").
+				Where(where).
+				GroupBy(dimensions...)).
+			OrderBy(sb.Order(
+				sb.Function("MAX", sb.Column("sum_at_time"))).Desc())
+		return rows
 	}
-	rowsType = fmt.Sprintf(
-		"rows AS (SELECT %s FROM %s GROUP BY %s ORDER BY %s DESC LIMIT %d)",
-		strings.Join(dimensions, ", "),
-		source,
-		strings.Join(dimensions, ", "),
-		orderBy,
-		input.Limit)
-	return rowsType
+	return rows.From("source").Where(where).OrderBy(sb.Order(units).Desc())
 }

--- a/console/query.go
+++ b/console/query.go
@@ -5,6 +5,7 @@ package console
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"akvorado/common/schema"
@@ -34,28 +35,28 @@ func (c *Component) fixQueryColumnName(name string) string {
 	return ""
 }
 
-func selectSankeyRowsByLimitType(input graphSankeyHandlerInput, dimensions []string, where string) string {
-	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where)
+func selectSankeyRowsByLimitType(input graphSankeyHandlerInput, dimensions []string, where, units string) string {
+	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where, units)
 }
 
-func selectLineRowsByLimitType(input graphLineHandlerInput, dimensions []string, where string) string {
-	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where)
+func selectLineRowsByLimitType(input graphLineHandlerInput, dimensions []string, where, units string) string {
+	return selectRowsByLimitType(input.graphCommonHandlerInput, dimensions, where, units)
 }
 
-func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []string, where string) string {
+func selectRowsByLimitType(input graphCommonHandlerInput, dimensions []string, where, units string) string {
 	var rowsType string
 	var source string
 	var orderBy string
 	if input.LimitType == "max" {
 		source = fmt.Sprintf("( SELECT %s AS sum_at_time FROM source WHERE %s GROUP BY %s )",
-			strings.Join(append(dimensions, "{{ .Units }}"), ", "),
+			strings.Join(slices.Concat(dimensions, []string{units}), ", "),
 			where,
 			strings.Join(dimensions, ", "),
 		)
 		orderBy = "MAX(sum_at_time)"
 	} else {
 		source = fmt.Sprintf("source WHERE %s", where)
-		orderBy = "{{ .Units }}"
+		orderBy = units
 	}
 	rowsType = fmt.Sprintf(
 		"rows AS (SELECT %s FROM %s GROUP BY %s ORDER BY %s DESC LIMIT %d)",

--- a/console/query/column.go
+++ b/console/query/column.go
@@ -11,6 +11,7 @@ import (
 
 	"akvorado/common/constants"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 )
 
 // Column represents a query column. It should be instantiated with NewColumn() or
@@ -101,34 +102,40 @@ func (qcs Columns) Validate(schema *schema.Component) error {
 }
 
 // ToSQLSelect transforms a column into an expression to use in SELECT
-func (qc Column) ToSQLSelect(sch *schema.Component) string {
-	var strValue string
+func (qc Column) ToSQLSelect(sch *schema.Component) sb.Expr {
 	key := qc.Key()
+	self := sb.Column(qc.String())
 	switch key {
 	// Special cases
 	case schema.ColumnSrcAS, schema.ColumnDstAS, schema.ColumnDst1stAS, schema.ColumnDst2ndAS, schema.ColumnDst3rdAS:
-		strValue = fmt.Sprintf(`concat(toString(%s), ': ', dictGetOrDefault('%s', 'name', %s, '???'))`,
-			qc, schema.DictionaryASNs, qc)
+		return sb.Function("concat",
+			sb.Function("toString", self),
+			sb.String(": "),
+			self.Apply(DictionaryName(schema.DictionaryASNs, "???")))
 	case schema.ColumnInIfBoundary, schema.ColumnOutIfBoundary:
-		strValue = fmt.Sprintf(`toString(%s)`, qc.String())
+		return sb.Function("toString", self)
 	case schema.ColumnEType:
-		strValue = fmt.Sprintf(`if(EType = %d, 'IPv4', if(EType = %d, 'IPv6', '???'))`,
-			constants.ETypeIPv4, constants.ETypeIPv6)
+		etype := sb.Column(schema.ColumnEType.String())
+		return sb.Function("if",
+			sb.Op(etype, "=", sb.Uint(constants.ETypeIPv4)),
+			sb.String("IPv4"),
+			sb.Function("if",
+				sb.Op(etype, "=", sb.Uint(constants.ETypeIPv6)),
+				sb.String("IPv6"),
+				sb.String("???")))
 	case schema.ColumnProto:
-		strValue = fmt.Sprintf(`dictGetOrDefault('%s', 'name', Proto, '???')`, schema.DictionaryProtocols)
-	case schema.ColumnMPLSLabels:
-		strValue = `arrayStringConcat(MPLSLabels, ' ')`
-	case schema.ColumnDstASPath:
-		strValue = `arrayStringConcat(DstASPath, ' ')`
+		return self.Apply(DictionaryName(schema.DictionaryProtocols, "???"))
+	case schema.ColumnMPLSLabels, schema.ColumnDstASPath:
+		return sb.Function("arrayStringConcat", self, sb.String(" "))
 	case schema.ColumnSrcCommunities, schema.ColumnDstCommunities:
-		strValue = fmt.Sprintf(`arrayStringConcat(arrayConcat(
-			arrayMap(c -> concat(toString(bitShiftRight(c, 16)), ':', toString(bitAnd(c, 0xffff))), %sCommunities),
-			arrayMap(c -> concat(toString(bitAnd(bitShiftRight(c, 64), 0xffffffff)), ':',
-								toString(bitAnd(bitShiftRight(c, 32), 0xffffffff)), ':',
-								toString(bitAnd(c, 0xffffffff))), %sLargeCommunities)
-			), ' ')`, qc.String()[:3], qc.String()[:3])
+		direction := qc.String()[:3]
+		return sb.Function("arrayStringConcat",
+			sb.Function("arrayConcat",
+				CommunitiesToStrings(fmt.Sprintf("%sCommunities", direction)),
+				LargeCommunitiesToStrings(fmt.Sprintf("%sLargeCommunities", direction))),
+			sb.String(" "))
 	case schema.ColumnSrcMAC, schema.ColumnDstMAC:
-		strValue = fmt.Sprintf("MACNumToString(%s)", qc)
+		return sb.Function("MACNumToString", self)
 	case schema.ColumnTCPFlags:
 		bits := []string{
 			"FIN",
@@ -141,25 +148,96 @@ func (qc Column) ToSQLSelect(sch *schema.Component) string {
 			"CWR",
 			"NS",
 		}
-		array := make([]string, len(bits))
-		for bit, v := range bits {
-			array[bit] = fmt.Sprintf("if(bitTest(%s, %d) = 1, '%s', '')", qc, bit, v[:1])
+		flags := make([]sb.Expr, len(bits))
+		for bit, name := range bits {
+			flags[bit] = sb.Function("if",
+				sb.Op(
+					sb.Function("bitTest", self, sb.Uint(uint64(bit))),
+					"=", sb.Uint(1)),
+				sb.String(name[:1]),
+				sb.String(""))
 		}
-		strValue = fmt.Sprintf("arrayStringConcat([%s], '')", strings.Join(array, ", "))
+		return sb.Function("arrayStringConcat",
+			sb.Array(flags...), sb.String(""))
 	case schema.ColumnDstPort, schema.ColumnSrcPort:
-		strValue = fmt.Sprintf(`replaceRegexpOne(multiIf(%s==6, concat(toString(%s), '/', dictGetOrDefault('%s', 'name', %s,'')), %s==17, concat(toString(%s), '/', dictGetOrDefault('%s', 'name', %s,'')), toString(%s)), '/$', '')`,
-			schema.ColumnProto, qc, schema.DictionaryTCP, qc, schema.ColumnProto, qc, schema.DictionaryUDP, qc, qc)
+		proto := sb.Column(schema.ColumnProto.String())
+		named := func(dictionary string) sb.Expr {
+			return sb.Function("concat",
+				sb.Function("toString", self),
+				sb.String("/"),
+				self.Apply(DictionaryName(dictionary, "")))
+		}
+		// The port may have no name in the dictionary, in which case the
+		// trailing slash is dropped.
+		return sb.Function("replaceRegexpOne",
+			sb.Function("multiIf",
+				sb.Op(proto, "=", sb.Uint(constants.ProtoTCP)),
+				named(schema.DictionaryTCP),
+				sb.Op(proto, "=", sb.Uint(constants.ProtoUDP)),
+				named(schema.DictionaryUDP),
+				sb.Function("toString", self)),
+			sb.String("/$"), sb.String(""))
 
 	// Generic cases
 	default:
-		strValue = qc.String()
 		if col, ok := sch.LookupColumnByKey(key); ok {
 			if strings.HasPrefix(col.ClickHouseType, "UInt") {
-				strValue = fmt.Sprintf(`toString(%s)`, qc)
-			} else if col.ClickHouseType == "IPv6" || col.ClickHouseType == "LowCardinality(IPv6)" {
-				strValue = fmt.Sprintf("replaceRegexpOne(IPv6NumToString(%s), '^::ffff:', '')", qc)
+				return sb.Function("toString", self)
+			}
+			if col.ClickHouseType == "IPv6" || col.ClickHouseType == "LowCardinality(IPv6)" {
+				return self.Apply(AddressToString)
 			}
 		}
+		return self
 	}
-	return strValue
+}
+
+// DictionaryName looks up the name matching a key in a ClickHouse dictionary.
+// When the key is unknown, the fallback is used instead.
+func DictionaryName(dictionary, fallback string) func(sb.Expr) sb.Expr {
+	return func(key sb.Expr) sb.Expr {
+		return sb.Function("dictGetOrDefault",
+			sb.String(dictionary), sb.String("name"),
+			key, sb.String(fallback))
+	}
+}
+
+// AddressToString turns an address into a string. All addresses are stored as
+// IPv6 ones, so the prefix of an IPv4-mapped address is removed.
+func AddressToString(addr sb.Expr) sb.Expr {
+	return sb.Function("replaceRegexpOne",
+		sb.Function("IPv6NumToString", addr),
+		sb.String("^::ffff:"), sb.String(""))
+}
+
+// CommunitiesToStrings turns an array of BGP communities into an array of
+// strings using the "AS:value" notation.
+func CommunitiesToStrings(column string) sb.Expr {
+	return sb.Function("arrayMap",
+		sb.Lambda("c", sb.Function("concat",
+			sb.Function("toString",
+				sb.Function("bitShiftRight", sb.Column("c"), sb.Uint(16))),
+			sb.String(":"),
+			sb.Function("toString",
+				sb.Function("bitAnd", sb.Column("c"), sb.Number("0xffff"))))),
+		sb.Column(column))
+}
+
+// LargeCommunitiesToStrings turns an array of large BGP communities into an
+// array of strings using the "AS:value:value" notation.
+func LargeCommunitiesToStrings(column string) sb.Expr {
+	part := func(shift uint64) sb.Expr {
+		value := sb.Column("c")
+		if shift > 0 {
+			value = sb.Function("bitShiftRight", value, sb.Uint(shift))
+		}
+		return sb.Function("toString",
+			sb.Function("bitAnd", value, sb.Number("0xffffffff")))
+	}
+	return sb.Function("arrayMap",
+		sb.Lambda("c", sb.Function("concat",
+			part(64), sb.String(":"),
+			part(32), sb.String(":"),
+			part(0))),
+		sb.Column(column))
 }

--- a/console/query/column_test.go
+++ b/console/query/column_test.go
@@ -86,12 +86,11 @@ func TestQueryColumnSQLSelect(t *testing.T) {
 			Expected: `arrayStringConcat(DstASPath, ' ')`,
 		}, {
 			Input: schema.ColumnDstCommunities,
-			Expected: `arrayStringConcat(arrayConcat(
-			arrayMap(c -> concat(toString(bitShiftRight(c, 16)), ':', toString(bitAnd(c, 0xffff))), DstCommunities),
-			arrayMap(c -> concat(toString(bitAnd(bitShiftRight(c, 64), 0xffffffff)), ':',
-								toString(bitAnd(bitShiftRight(c, 32), 0xffffffff)), ':',
-								toString(bitAnd(c, 0xffffffff))), DstLargeCommunities)
-			), ' ')`,
+			Expected: "arrayStringConcat(arrayConcat(" +
+				"arrayMap(c -> concat(toString(bitShiftRight(c, 16)), ':', toString(bitAnd(c, 0xffff))), DstCommunities), " +
+				"arrayMap(c -> concat(toString(bitAnd(bitShiftRight(c, 64), 0xffffffff)), ':', " +
+				"toString(bitAnd(bitShiftRight(c, 32), 0xffffffff)), ':', " +
+				"toString(bitAnd(c, 0xffffffff))), DstLargeCommunities)), ' ')",
 		}, {
 			Input:    schema.ColumnDstMAC,
 			Expected: `MACNumToString(DstMAC)`,
@@ -110,10 +109,10 @@ func TestQueryColumnSQLSelect(t *testing.T) {
 			Expected: `arrayStringConcat([if(bitTest(TCPFlags, 0) = 1, 'F', ''), if(bitTest(TCPFlags, 1) = 1, 'S', ''), if(bitTest(TCPFlags, 2) = 1, 'R', ''), if(bitTest(TCPFlags, 3) = 1, 'P', ''), if(bitTest(TCPFlags, 4) = 1, '.', ''), if(bitTest(TCPFlags, 5) = 1, 'U', ''), if(bitTest(TCPFlags, 6) = 1, 'E', ''), if(bitTest(TCPFlags, 7) = 1, 'C', ''), if(bitTest(TCPFlags, 8) = 1, 'N', '')], '')`,
 		}, {
 			Input:    schema.ColumnDstPort,
-			Expected: "replaceRegexpOne(multiIf(Proto==6, concat(toString(DstPort), '/', dictGetOrDefault('tcp', 'name', DstPort,'')), Proto==17, concat(toString(DstPort), '/', dictGetOrDefault('udp', 'name', DstPort,'')), toString(DstPort)), '/$', '')",
+			Expected: "replaceRegexpOne(multiIf(Proto = 6, concat(toString(DstPort), '/', dictGetOrDefault('tcp', 'name', DstPort, '')), Proto = 17, concat(toString(DstPort), '/', dictGetOrDefault('udp', 'name', DstPort, '')), toString(DstPort)), '/$', '')",
 		}, {
 			Input:    schema.ColumnSrcPort,
-			Expected: "replaceRegexpOne(multiIf(Proto==6, concat(toString(SrcPort), '/', dictGetOrDefault('tcp', 'name', SrcPort,'')), Proto==17, concat(toString(SrcPort), '/', dictGetOrDefault('udp', 'name', SrcPort,'')), toString(SrcPort)), '/$', '')",
+			Expected: "replaceRegexpOne(multiIf(Proto = 6, concat(toString(SrcPort), '/', dictGetOrDefault('tcp', 'name', SrcPort, '')), Proto = 17, concat(toString(SrcPort), '/', dictGetOrDefault('udp', 'name', SrcPort, '')), toString(SrcPort)), '/$', '')",
 		},
 	}
 	for _, tc := range cases {
@@ -122,9 +121,9 @@ func TestQueryColumnSQLSelect(t *testing.T) {
 			if err := column.Validate(schema.NewMock(t).EnableAllColumns()); err != nil {
 				t.Fatalf("Validate() error:\n%+v", err)
 			}
-			got := column.ToSQLSelect(sch)
+			got := column.ToSQLSelect(sch).String()
 			if diff := helpers.Diff(got, tc.Expected); diff != "" {
-				t.Errorf("toSQLWhere (-got, +want):\n%s", diff)
+				t.Errorf("ToSQLSelect() (-got, +want):\n%s", diff)
 			}
 		})
 	}

--- a/console/query/filter.go
+++ b/console/query/filter.go
@@ -57,19 +57,19 @@ func (qf *Filter) Validate(sch *schema.Component) error {
 		return nil
 	}
 	input := []byte(qf.filter)
-	meta := &filter.Meta{Schema: sch}
-	direct, err := filter.Parse("", input, filter.GlobalStore("meta", meta))
+	directMeta := &filter.Meta{Schema: sch}
+	direct, err := filter.Parse("", input, filter.GlobalStore("meta", directMeta))
 	if err != nil {
 		return fmt.Errorf("cannot parse filter: %s", filter.HumanError(err))
 	}
-	meta = &filter.Meta{Schema: sch, ReverseDirection: true}
-	reverse, err := filter.Parse("", input, filter.GlobalStore("meta", meta))
+	reverseMeta := &filter.Meta{Schema: sch, ReverseDirection: true}
+	reverse, err := filter.Parse("", input, filter.GlobalStore("meta", reverseMeta))
 	if err != nil {
 		return fmt.Errorf("cannot parse reverse filter: %s", filter.HumanError(err))
 	}
 	qf.filter = direct.(string)
 	qf.reverseFilter = reverse.(string)
-	qf.mainTableRequired = meta.MainTableRequired
+	qf.mainTableRequired = directMeta.MainTableRequired || reverseMeta.MainTableRequired
 	qf.validated = true
 	return nil
 }

--- a/console/query/filter.go
+++ b/console/query/filter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/filter"
 )
 
@@ -15,7 +16,8 @@ import (
 type Filter struct {
 	validated         bool
 	filter            string
-	reverseFilter     string
+	direct            sb.Expr
+	reverse           sb.Expr
 	mainTableRequired bool
 }
 
@@ -34,9 +36,17 @@ func (qf Filter) String() string {
 	return qf.filter
 }
 
-// Equal tells if two filters are equal.
+// Equal tells if two filters are equal. Once validated, two filters written
+// differently but compiling to the same conditions are equal.
 func (qf Filter) Equal(oqf Filter) bool {
-	return qf.filter == oqf.filter
+	if qf.validated != oqf.validated {
+		return false
+	}
+	if !qf.validated {
+		return qf.filter == oqf.filter
+	}
+	return qf.direct.String() == oqf.direct.String() &&
+		qf.reverse.String() == oqf.reverse.String()
 }
 
 // MarshalText turns a filter into a string.
@@ -67,8 +77,8 @@ func (qf *Filter) Validate(sch *schema.Component) error {
 	if err != nil {
 		return fmt.Errorf("cannot parse reverse filter: %s", filter.HumanError(err))
 	}
-	qf.filter = direct.(string)
-	qf.reverseFilter = reverse.(string)
+	qf.direct = direct.(sb.Expr)
+	qf.reverse = reverse.(sb.Expr)
 	qf.mainTableRequired = directMeta.MainTableRequired || reverseMeta.MainTableRequired
 	qf.validated = true
 	return nil
@@ -81,18 +91,18 @@ func (qf Filter) MainTableRequired() bool {
 }
 
 // Reverse provides the reverse filter.
-func (qf Filter) Reverse() string {
+func (qf Filter) Reverse() sb.Expr {
 	qf.check()
-	return qf.reverseFilter
+	return qf.reverse
 }
 
 // Direct provides the filter.
-func (qf Filter) Direct() string {
+func (qf Filter) Direct() sb.Expr {
 	qf.check()
-	return qf.filter
+	return qf.direct
 }
 
 // Swap swap direct and reverse filter.
 func (qf *Filter) Swap() {
-	qf.filter, qf.reverseFilter = qf.reverseFilter, qf.filter
+	qf.direct, qf.reverse = qf.reverse, qf.direct
 }

--- a/console/query/filter_test.go
+++ b/console/query/filter_test.go
@@ -39,7 +39,7 @@ func TestUnmarshalFilter(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if diff := helpers.Diff(qf.Direct(), tc.Expected); diff != "" {
+			if diff := helpers.Diff(qf.Direct().String(), tc.Expected); diff != "" {
 				t.Fatalf("UnmarshalText(%q) (-got, +want):\n%s", tc.Input, diff)
 			}
 		})
@@ -83,10 +83,10 @@ func TestFilterSwap(t *testing.T) {
 		t.Fatalf("Validate() error:\n%+v", err)
 	}
 	filter.Swap()
-	if diff := helpers.Diff(filter.Direct(), "DstAS = 12322"); diff != "" {
+	if diff := helpers.Diff(filter.Direct().String(), "DstAS = 12322"); diff != "" {
 		t.Fatalf("Swap() (-got, +want):\n%s", diff)
 	}
-	if diff := helpers.Diff(filter.Reverse(), "SrcAS = 12322"); diff != "" {
+	if diff := helpers.Diff(filter.Reverse().String(), "SrcAS = 12322"); diff != "" {
 		t.Fatalf("Swap() (-got, +want):\n%s", diff)
 	}
 }

--- a/console/query/filter_test.go
+++ b/console/query/filter_test.go
@@ -46,6 +46,37 @@ func TestUnmarshalFilter(t *testing.T) {
 	}
 }
 
+func TestFilterMainTableRequired(t *testing.T) {
+	// DstPort is moved out of the main table, while SrcPort stays in it. A
+	// filter on either one needs the main table, because a filter can be
+	// swapped to get the reverse direction.
+	sch, err := schema.New(schema.Configuration{
+		NotMainTableOnly: []schema.ColumnKey{schema.ColumnDstPort},
+	})
+	if err != nil {
+		t.Fatalf("schema.New() error:\n%+v", err)
+	}
+	cases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{"SrcPort = 80", true},
+		{"DstPort = 80", true},
+		{"SrcAS = 12322", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			qf := query.NewFilter(tc.Input)
+			if err := qf.Validate(sch); err != nil {
+				t.Fatalf("Validate() error:\n%+v", err)
+			}
+			if diff := helpers.Diff(qf.MainTableRequired(), tc.Expected); diff != "" {
+				t.Errorf("MainTableRequired(%q) (-got, +want):\n%s", tc.Input, diff)
+			}
+		})
+	}
+}
+
 func TestFilterSwap(t *testing.T) {
 	filter := query.NewFilter("SrcAS = 12322")
 	if err := filter.Validate(schema.NewMock(t)); err != nil {

--- a/console/root.go
+++ b/console/root.go
@@ -5,6 +5,7 @@
 package console
 
 import (
+	"fmt"
 	"io/fs"
 	"net/http"
 	"os"
@@ -23,6 +24,7 @@ import (
 	"akvorado/common/httpserver"
 	"akvorado/common/reporter"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/authentication"
 	"akvorado/console/database"
 	"akvorado/console/query"
@@ -35,8 +37,9 @@ type Component struct {
 	t      tomb.Tomb
 	config Configuration
 
-	flowsTables     []flowsTable
-	flowsTablesLock sync.RWMutex
+	homepageGraphFilter sb.Expr
+	flowsTables         []flowsTable
+	flowsTablesLock     sync.RWMutex
 
 	metrics struct {
 		clickhouseQueries *reporter.CounterVec
@@ -62,11 +65,20 @@ func New(r *reporter.Reporter, config Configuration, dependencies Dependencies) 
 	if err := query.Columns(config.DefaultVisualizeOptions.Dimensions).Validate(dependencies.Schema); err != nil {
 		return nil, err
 	}
+	var homepageGraphFilter sb.Expr
+	if config.HomepageGraphFilter != "" {
+		var err error
+		homepageGraphFilter, err = sb.ParseExpr(config.HomepageGraphFilter)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse homepage graph filter: %w", err)
+		}
+	}
 	c := Component{
-		r:           r,
-		d:           &dependencies,
-		config:      config,
-		flowsTables: []flowsTable{{"flows", 0, time.Time{}}},
+		r:                   r,
+		d:                   &dependencies,
+		config:              config,
+		homepageGraphFilter: homepageGraphFilter,
+		flowsTables:         []flowsTable{{"flows", 0, time.Time{}}},
 	}
 
 	c.d.Daemon.Track(&c.t, "console")

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -12,6 +12,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/httpserver"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -63,7 +64,7 @@ type sankeyToSQL1Options struct {
 	rowsColumns []query.Column
 }
 
-func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sankeyToSQL1Options) string {
+func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sankeyToSQL1Options) *sb.Query {
 	r := res.forRange(input.Start, input.End)
 	where := r.where(input.Filter)
 	rowsColumns := options.rowsColumns
@@ -79,39 +80,45 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sa
 	unitsSQL := unitsExpr(units)
 
 	// Select
-	arrayFields := []string{}
-	dimensions := []string{}
+	arrayFields := []sb.Expr{}
+	dimensions := []sb.Expr{}
 	for i, column := range input.Dimensions {
-		arrayFields = append(arrayFields, fmt.Sprintf(`if(%s IN (SELECT %s FROM rows), %s, 'Other')`,
-			column.String(),
-			rowsColumns[i].String(),
-			column.ToSQLSelect(input.schema)))
-		dimensions = append(dimensions, column.String())
-	}
-	fields := []string{
-		fmt.Sprintf(`%s/range AS xps`, unitsSQL),
-		fmt.Sprintf("[%s] AS dimensions", strings.Join(arrayFields, ",\n  ")),
+		arrayFields = append(arrayFields, sb.Function("if",
+			sb.Op(sb.Column(column.String()), "IN",
+				sb.Select(sb.Column(rowsColumns[i].String())).
+					From("rows").Subquery()),
+			column.ToSQLSelect(input.schema),
+			sb.String("Other")))
+		dimensions = append(dimensions, sb.Column(column.String()))
 	}
 
-	// With
-	withStr := ""
+	inner := sb.Select(
+		sb.Alias(sb.Op(unitsSQL, "/", sb.Column("range")), "xps"),
+		sb.Alias(sb.Array(arrayFields...), "dimensions"),
+	).
+		From("source").
+		Where(where).
+		GroupBy(sb.Column("dimensions")).
+		OrderBy(sb.Order(sb.Column("xps")).Desc())
+
+	query := sb.Select(
+		sb.Alias(sb.Int(int64(axis)), "axis"),
+		sb.Star()).
+		FromSelect(inner)
 	if !options.skipWithClause {
-		with := []string{
-			fmt.Sprintf("source AS (%s)", input.sourceSelect(r.Table)),
-			fmt.Sprintf(`(SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE %s) AS range`, where),
-		}
-		with = append(with, selectSankeyRowsByLimitType(input, dimensions, where, unitsSQL))
-		withStr = fmt.Sprintf("WITH\n %s\n", strings.Join(with, ",\n "))
+		query.With("source", input.sourceSelect(r.Table))
+		// There is no time axis here, so the traffic is averaged over the whole
+		// period covered by the data.
+		query.WithScalar(
+			sb.Select(sb.Op(
+				sb.Function("MAX", sb.Column("TimeReceived")), "-",
+				sb.Function("MIN", sb.Column("TimeReceived")))).
+				From("source").
+				Where(where),
+			"range")
+		query.With("rows", selectSankeyRowsByLimitType(input, dimensions, where, unitsSQL))
 	}
-
-	return strings.TrimSpace(fmt.Sprintf(`%sSELECT %d AS axis, * FROM (
-SELECT
- %s
-FROM source
-WHERE %s
-GROUP BY dimensions
-ORDER BY xps DESC)`,
-		withStr, axis, strings.Join(fields, ",\n "), where))
+	return query
 }
 
 // resolveContext returns what is needed to select the table for this query.
@@ -127,8 +134,8 @@ func (input graphSankeyHandlerInput) resolveContext() inputContext {
 }
 
 // toSQL converts a sankey query to a list of SQL requests, one per axis.
-func (input graphSankeyHandlerInput) toSQL(res resolution) []string {
-	queries := []string{input.toSQL1(1, res, sankeyToSQL1Options{})}
+func (input graphSankeyHandlerInput) toSQL(res resolution) []*sb.Query {
+	queries := []*sb.Query{input.toSQL1(1, res, sankeyToSQL1Options{})}
 	if input.Bidirectional {
 		queries = append(queries, input.reverseDirection().toSQL1(2, res, sankeyToSQL1Options{
 			skipWithClause:   true,

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -53,8 +53,9 @@ func (input graphSankeyHandlerInput) reverseDirection() graphSankeyHandlerInput 
 }
 
 type sankeyToSQL1Options struct {
-	skipWithClause   bool
-	reverseDirection bool
+	skipWithClause    bool
+	reverseDirection  bool
+	mainTableRequired bool
 	// rowsColumns names, for each dimension in input.Dimensions, the column
 	// from the forward `rows` CTE that corresponds positionally to it. For the
 	// forward query it is left nil and falls back to input.Dimensions. For the
@@ -114,7 +115,7 @@ ORDER BY xps DESC)`,
 	context := inputContext{
 		Start:             input.Start,
 		End:               input.End,
-		MainTableRequired: requireMainTable(input.schema, input.Dimensions, input.Filter),
+		MainTableRequired: options.mainTableRequired,
 		Points:            20,
 		Units:             units,
 	}
@@ -127,12 +128,16 @@ ORDER BY xps DESC)`,
 
 // toSQL converts a sankey query to an SQL request
 func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
-	queries := []templateQuery{input.toSQL1(1, sankeyToSQL1Options{})}
+	mainTableRequired := requireMainTable(input.schema, input.Dimensions, input.Filter)
+	queries := []templateQuery{input.toSQL1(1, sankeyToSQL1Options{
+		mainTableRequired: mainTableRequired,
+	})}
 	if input.Bidirectional {
 		queries = append(queries, input.reverseDirection().toSQL1(2, sankeyToSQL1Options{
-			skipWithClause:   true,
-			reverseDirection: true,
-			rowsColumns:      input.Dimensions,
+			skipWithClause:    true,
+			reverseDirection:  true,
+			mainTableRequired: mainTableRequired,
+			rowsColumns:       input.Dimensions,
 		}))
 	}
 	return queries, nil

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -53,9 +53,8 @@ func (input graphSankeyHandlerInput) reverseDirection() graphSankeyHandlerInput 
 }
 
 type sankeyToSQL1Options struct {
-	skipWithClause    bool
-	reverseDirection  bool
-	mainTableRequired bool
+	skipWithClause   bool
+	reverseDirection bool
 	// rowsColumns names, for each dimension in input.Dimensions, the column
 	// from the forward `rows` CTE that corresponds positionally to it. For the
 	// forward query it is left nil and falls back to input.Dimensions. For the
@@ -64,12 +63,20 @@ type sankeyToSQL1Options struct {
 	rowsColumns []query.Column
 }
 
-func (input graphSankeyHandlerInput) toSQL1(axis int, options sankeyToSQL1Options) templateQuery {
-	where := templateWhere(input.Filter)
+func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sankeyToSQL1Options) string {
+	r := res.forRange(input.Start, input.End)
+	where := r.where(input.Filter)
 	rowsColumns := options.rowsColumns
 	if rowsColumns == nil {
 		rowsColumns = input.Dimensions
 	}
+
+	// Units
+	units := input.Units
+	if options.reverseDirection {
+		units = reverseUnits(units)
+	}
+	unitsSQL := unitsExpr(units)
 
 	// Select
 	arrayFields := []string{}
@@ -82,7 +89,7 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, options sankeyToSQL1Option
 		dimensions = append(dimensions, column.String())
 	}
 	fields := []string{
-		`{{ .Units }}/range AS xps`,
+		fmt.Sprintf(`%s/range AS xps`, unitsSQL),
 		fmt.Sprintf("[%s] AS dimensions", strings.Join(arrayFields, ",\n  ")),
 	}
 
@@ -90,57 +97,46 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, options sankeyToSQL1Option
 	withStr := ""
 	if !options.skipWithClause {
 		with := []string{
-			fmt.Sprintf("source AS (%s)", input.sourceSelect()),
+			fmt.Sprintf("source AS (%s)", input.sourceSelect(r.Table)),
 			fmt.Sprintf(`(SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE %s) AS range`, where),
 		}
-		with = append(with, selectSankeyRowsByLimitType(input, dimensions, where))
+		with = append(with, selectSankeyRowsByLimitType(input, dimensions, where, unitsSQL))
 		withStr = fmt.Sprintf("WITH\n %s\n", strings.Join(with, ",\n "))
 	}
 
-	// Units
-	units := input.Units
-	if options.reverseDirection {
-		units = reverseUnits(units)
-	}
-
-	template := fmt.Sprintf(`%sSELECT %d AS axis, * FROM (
+	return strings.TrimSpace(fmt.Sprintf(`%sSELECT %d AS axis, * FROM (
 SELECT
  %s
 FROM source
 WHERE %s
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-		withStr, axis, strings.Join(fields, ",\n "), where)
+		withStr, axis, strings.Join(fields, ",\n "), where))
+}
 
-	context := inputContext{
+// resolveContext returns what is needed to select the table for this query.
+// There is no time axis here, so the number of points only steers the table
+// selection towards a reasonably consolidated one.
+func (input graphSankeyHandlerInput) resolveContext() inputContext {
+	return inputContext{
 		Start:             input.Start,
 		End:               input.End,
-		MainTableRequired: options.mainTableRequired,
+		MainTableRequired: requireMainTable(input.schema, input.Dimensions, input.Filter),
 		Points:            20,
-		Units:             units,
-	}
-
-	return templateQuery{
-		Template: strings.TrimSpace(template),
-		Context:  context,
 	}
 }
 
-// toSQL converts a sankey query to an SQL request
-func (input graphSankeyHandlerInput) toSQL() ([]templateQuery, error) {
-	mainTableRequired := requireMainTable(input.schema, input.Dimensions, input.Filter)
-	queries := []templateQuery{input.toSQL1(1, sankeyToSQL1Options{
-		mainTableRequired: mainTableRequired,
-	})}
+// toSQL converts a sankey query to a list of SQL requests, one per axis.
+func (input graphSankeyHandlerInput) toSQL(res resolution) []string {
+	queries := []string{input.toSQL1(1, res, sankeyToSQL1Options{})}
 	if input.Bidirectional {
-		queries = append(queries, input.reverseDirection().toSQL1(2, sankeyToSQL1Options{
-			skipWithClause:    true,
-			reverseDirection:  true,
-			mainTableRequired: mainTableRequired,
-			rowsColumns:       input.Dimensions,
+		queries = append(queries, input.reverseDirection().toSQL1(2, res, sankeyToSQL1Options{
+			skipWithClause:   true,
+			reverseDirection: true,
+			rowsColumns:      input.Dimensions,
 		}))
 	}
-	return queries, nil
+	return queries
 }
 
 func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Request) {
@@ -165,20 +161,16 @@ func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	queries, err := input.toSQL()
-	if err != nil {
-		httpserver.WriteJSON(w, http.StatusBadRequest, helpers.M{"message": helpers.Capitalize(err.Error())})
-		return
-	}
-
 	// Prepare and execute query
-	sqlQuery := c.finalizeTemplateQueries(queries)
+	r := c.resolve(input.resolveContext())
+	sqlQuery := strings.Join(input.toSQL(r), "\nUNION ALL\n")
 	w.Header().Set("X-SQL-Query", strings.ReplaceAll(sqlQuery, "\n", "  "))
 	results := []struct {
 		Axis       uint8    `ch:"axis"`
 		Xps        float64  `ch:"xps"`
 		Dimensions []string `ch:"dimensions"`
 	}{}
+	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
 	if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, sqlQuery); err != nil {
 		c.r.Err(err).Str("query", sqlQuery).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -160,10 +160,17 @@ func (c *Component) graphSankeyHandlerFunc(w http.ResponseWriter, req *http.Requ
 				c.config.DimensionsLimit)})
 		return
 	}
+	if len(input.Dimensions) == 0 {
+		// A sankey diagram links dimension values together, there is nothing to
+		// draw without a dimension.
+		httpserver.WriteJSON(w, http.StatusBadRequest,
+			helpers.M{"message": "At least one dimension is required."})
+		return
+	}
 
 	// Prepare and execute query
 	r := c.resolve(input.resolveContext())
-	sqlQuery := strings.Join(input.toSQL(r), "\nUNION ALL\n")
+	sqlQuery := unionAll(input.toSQL(r))
 	w.Header().Set("X-SQL-Query", strings.ReplaceAll(sqlQuery, "\n", "  "))
 	results := []struct {
 		Axis       uint8    `ch:"axis"`

--- a/console/sankey.go
+++ b/console/sankey.go
@@ -86,7 +86,7 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sa
 		arrayFields = append(arrayFields, sb.Function("if",
 			sb.Op(sb.Column(column.String()), "IN",
 				sb.Select(sb.Column(rowsColumns[i].String())).
-					From("rows").Subquery()),
+					From(sb.Table("rows")).Subquery()),
 			column.ToSQLSelect(input.schema),
 			sb.String("Other")))
 		dimensions = append(dimensions, sb.Column(column.String()))
@@ -96,7 +96,7 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sa
 		sb.Alias(sb.Op(unitsSQL, "/", sb.Column("range")), "xps"),
 		sb.Alias(sb.Array(arrayFields...), "dimensions"),
 	).
-		From("source").
+		From(sb.Table("source")).
 		Where(where).
 		GroupBy(sb.Column("dimensions")).
 		OrderBy(sb.Order(sb.Column("xps")).Desc())
@@ -113,7 +113,7 @@ func (input graphSankeyHandlerInput) toSQL1(axis int, res resolution, options sa
 			sb.Select(sb.Op(
 				sb.Function("MAX", sb.Column("TimeReceived")), "-",
 				sb.Function("MIN", sb.Column("TimeReceived")))).
-				From("source").
+				From(sb.Table("source")).
 				Where(where),
 			"range")
 		query.With("rows", selectSankeyRowsByLimitType(input, dimensions, where, unitsSQL))

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -12,6 +12,7 @@ import (
 
 	"akvorado/common/helpers"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
 )
 
@@ -30,7 +31,6 @@ func TestGraphSankeyInputReverseDirection(t *testing.T) {
 		},
 		Bidirectional: true,
 	}
-	original1 := fmt.Sprintf("%+v", input)
 	expected := graphSankeyHandlerInput{
 		graphCommonHandlerInput: graphCommonHandlerInput{
 			Start: time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
@@ -48,13 +48,16 @@ func TestGraphSankeyInputReverseDirection(t *testing.T) {
 	expected.Filter.Validate(input.schema)
 	query.Columns(input.Dimensions).Validate(input.schema)
 	query.Columns(expected.Dimensions).Validate(input.schema)
+	snapshot := func() string {
+		return fmt.Sprintf("%+v %s %s", input, input.Filter.Direct(), input.Filter.Reverse())
+	}
+	original := snapshot()
 	got := input.reverseDirection()
-	original2 := fmt.Sprintf("%+v", input)
 	if diff := helpers.Diff(got, expected); diff != "" {
 		t.Fatalf("reverseDirection() (-got, +want):\n%s", diff)
 	}
-	if original1 != original2 {
-		t.Fatalf("reverseDirection() modified original to:\n-%s\n+%s", original1, original2)
+	if now := snapshot(); original != now {
+		t.Fatalf("reverseDirection() modified original to:\n-%s\n+%s", original, now)
 	}
 }
 
@@ -209,15 +212,15 @@ ORDER BY xps DESC)`,
 			Expected: []string{
 				`WITH
  source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 10)
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR') AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR' GROUP BY SrcAS, ExporterName ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 10)
 SELECT 1 AS axis, * FROM (
 SELECT
  SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR'
 GROUP BY dimensions
 ORDER BY xps DESC)`,
 			},
@@ -241,15 +244,15 @@ ORDER BY xps DESC)`,
 			Expected: []string{
 				`WITH
  source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')) AS range,
- rows AS (SELECT SrcAS, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR') GROUP BY SrcAS, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 5)
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR') AS range,
+ rows AS (SELECT SrcAS, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR' GROUP BY SrcAS, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
  SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(InIfProvider IN (SELECT InIfProvider FROM rows), InIfProvider, 'Other')] AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND DstCountry = 'FR'
 GROUP BY dimensions
 ORDER BY xps DESC)`,
 				`SELECT 2 AS axis, * FROM (
@@ -258,7 +261,7 @@ SELECT
  [if(DstAS IN (SELECT SrcAS FROM rows), concat(toString(DstAS), ': ', dictGetOrDefault('asns', 'name', DstAS, '???')), 'Other'),
   if(OutIfProvider IN (SELECT InIfProvider FROM rows), OutIfProvider, 'Other')] AS dimensions
 FROM source
-WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND SrcCountry = 'FR'
 GROUP BY dimensions
 ORDER BY xps DESC)`,
 			},
@@ -273,8 +276,8 @@ ORDER BY xps DESC)`,
 			t.Fatalf("%sValidate() error:\n%+v", tc.Pos, err)
 		}
 		t.Run(tc.Description, func(t *testing.T) {
-			got := tc.Input.toSQL(testResolution)
-			if diff := helpers.Diff(got, tc.Expected); diff != "" {
+			got := toSQLStrings(t, tc.Input.toSQL(testResolution))
+			if diff := helpers.Diff(got, sb.NormalizeAll(t, tc.Expected)); diff != "" {
 				t.Errorf("%stoSQL (-got, +want):\n%s", tc.Pos, diff)
 			}
 		})

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -281,6 +281,27 @@ ORDER BY xps DESC)`,
 	}
 }
 
+func TestSankeyHandlerNoDimension(t *testing.T) {
+	_, h, _, _ := NewMock(t, DefaultConfiguration())
+	helpers.TestHTTPEndpoints(t, h.LocalAddr(), helpers.HTTPEndpointCases{
+		{
+			Description: "no dimension",
+			URL:         "/api/v0/console/graph/sankey",
+			JSONInput: helpers.M{
+				"start":      time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
+				"end":        time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
+				"dimensions": []string{},
+				"limit":      10,
+				"units":      "l3bps",
+			},
+			StatusCode: 400,
+			JSONOutput: helpers.M{
+				"message": "At least one dimension is required.",
+			},
+		},
+	})
+}
+
 func TestSankeyHandler(t *testing.T) {
 	_, h, mockConn, _ := NewMock(t, DefaultConfiguration())
 

--- a/console/sankey_test.go
+++ b/console/sankey_test.go
@@ -63,7 +63,7 @@ func TestSankeyQuerySQL(t *testing.T) {
 		Description string
 		Pos         helpers.Pos
 		Input       graphSankeyHandlerInput
-		Expected    []templateQuery
+		Expected    []string
 	}{
 		{
 			Description: "two dimensions, no filters, l3 bps",
@@ -81,28 +81,20 @@ func TestSankeyQuerySQL(t *testing.T) {
 					Units:  "l3bps",
 				},
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY SrcAS, ExporterName ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		}, {
 			Description: "two dimensions, no filters, l3 bps, limitType by max",
@@ -121,28 +113,20 @@ ORDER BY xps DESC)`,
 					Units:     "l3bps",
 				},
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM ( SELECT SrcAS, ExporterName, {{ .Units }} AS sum_at_time FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ) GROUP BY SrcAS, ExporterName ORDER BY MAX(sum_at_time) DESC LIMIT 5)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM ( SELECT SrcAS, ExporterName, SUM(Bytes*SamplingRate*8) AS sum_at_time FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY SrcAS, ExporterName ) GROUP BY SrcAS, ExporterName ORDER BY MAX(sum_at_time) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		}, {
 			Description: "two dimensions, no filters, l2 bps",
@@ -160,28 +144,20 @@ ORDER BY xps DESC)`,
 					Units:  "l2bps",
 				},
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l2bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY SrcAS, ExporterName ORDER BY SUM((Bytes+38*Packets)*SamplingRate*8) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM((Bytes+38*Packets)*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		}, {
 			Description: "two dimensions, no filters, pps",
@@ -199,28 +175,20 @@ ORDER BY xps DESC)`,
 					Units:  "pps",
 				},
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "pps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }}) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 5)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') GROUP BY SrcAS, ExporterName ORDER BY SUM(Packets*SamplingRate) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Packets*SamplingRate)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }}
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		}, {
 			Description: "two dimensions, with filter",
@@ -238,28 +206,20 @@ ORDER BY xps DESC)`,
 					Units:  "l3bps",
 				},
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR')) AS range,
- rows AS (SELECT SrcAS, ExporterName FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY {{ .Units }} DESC LIMIT 10)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')) AS range,
+ rows AS (SELECT SrcAS, ExporterName FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR') GROUP BY SrcAS, ExporterName ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 10)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(ExporterName IN (SELECT ExporterName FROM rows), ExporterName, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		}, {
 			Description: "two dimensions, bidirectional",
@@ -278,44 +238,29 @@ ORDER BY xps DESC)`,
 				},
 				Bidirectional: true,
 			},
-			Expected: []templateQuery{
-				{
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l3bps",
-					},
-					Template: `WITH
- source AS (SELECT * FROM {{ .Table }} SETTINGS asterisk_include_alias_columns = 1),
- (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR')) AS range,
- rows AS (SELECT SrcAS, InIfProvider FROM source WHERE {{ .Timefilter }} AND (DstCountry = 'FR') GROUP BY SrcAS, InIfProvider ORDER BY {{ .Units }} DESC LIMIT 5)
+			Expected: []string{
+				`WITH
+ source AS (SELECT * FROM flows SETTINGS asterisk_include_alias_columns = 1),
+ (SELECT MAX(TimeReceived) - MIN(TimeReceived) FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')) AS range,
+ rows AS (SELECT SrcAS, InIfProvider FROM source WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR') GROUP BY SrcAS, InIfProvider ORDER BY SUM(Bytes*SamplingRate*8) DESC LIMIT 5)
 SELECT 1 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(SrcAS IN (SELECT SrcAS FROM rows), concat(toString(SrcAS), ': ', dictGetOrDefault('asns', 'name', SrcAS, '???')), 'Other'),
   if(InIfProvider IN (SELECT InIfProvider FROM rows), InIfProvider, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (DstCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (DstCountry = 'FR')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				}, {
-					Context: inputContext{
-						Start:  time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC),
-						End:    time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC),
-						Points: 20,
-						Units:  "l3bps",
-					},
-					Template: `SELECT 2 AS axis, * FROM (
+				`SELECT 2 AS axis, * FROM (
 SELECT
- {{ .Units }}/range AS xps,
+ SUM(Bytes*SamplingRate*8)/range AS xps,
  [if(DstAS IN (SELECT SrcAS FROM rows), concat(toString(DstAS), ': ', dictGetOrDefault('asns', 'name', DstAS, '???')), 'Other'),
   if(OutIfProvider IN (SELECT InIfProvider FROM rows), OutIfProvider, 'Other')] AS dimensions
 FROM source
-WHERE {{ .Timefilter }} AND (SrcCountry = 'FR')
+WHERE TimeReceived BETWEEN toDateTime('2022-04-10 15:45:00', 'UTC') AND toDateTime('2022-04-11 15:45:00', 'UTC') AND (SrcCountry = 'FR')
 GROUP BY dimensions
 ORDER BY xps DESC)`,
-				},
 			},
 		},
 	}
@@ -328,7 +273,7 @@ ORDER BY xps DESC)`,
 			t.Fatalf("%sValidate() error:\n%+v", tc.Pos, err)
 		}
 		t.Run(tc.Description, func(t *testing.T) {
-			got, _ := tc.Input.toSQL()
+			got := tc.Input.toSQL(testResolution)
 			if diff := helpers.Diff(got, tc.Expected); diff != "" {
 				t.Errorf("%stoSQL (-got, +want):\n%s", tc.Pos, diff)
 			}

--- a/console/sql_test.go
+++ b/console/sql_test.go
@@ -9,25 +9,9 @@ import (
 	"time"
 
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 	"akvorado/console/query"
-
-	"github.com/AfterShip/clickhouse-sql-parser/parser"
 )
-
-// checkParses parses a complete SQL statement.
-func checkParses(t *testing.T, sql string) {
-	t.Helper()
-	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
-		t.Errorf("cannot parse generated SQL:\n%s\n\nerror:\n%+v", sql, err)
-	}
-}
-
-// checkExprParses parses a single expression. The parser only exposes statement
-// parsing, so the expression is wrapped in a SELECT.
-func checkExprParses(t *testing.T, expr string) {
-	t.Helper()
-	checkParses(t, fmt.Sprintf("SELECT %s", expr))
-}
 
 var (
 	testStart = time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
@@ -45,7 +29,7 @@ func TestColumnSQLSelectParses(t *testing.T) {
 		}
 		tested++
 		t.Run(column.Name, func(t *testing.T) {
-			checkExprParses(t, qc.ToSQLSelect(sch))
+			sb.CheckStatement(t, fmt.Sprintf("SELECT %s", qc.ToSQLSelect(sch)))
 		})
 	}
 	if tested < 20 {
@@ -154,7 +138,7 @@ func TestGeneratedQueriesParse(t *testing.T) {
 						Bidirectional:           bidirectional,
 						PreviousPeriod:          previousPeriod,
 					}
-					checkParses(t, unionAll(line.toSQL(testResolution)))
+					sb.CheckStatement(t, unionAll(line.toSQL(testResolution)))
 
 					if len(variant.Dimensions) == 0 {
 						// The sankey handler rejects those
@@ -164,9 +148,21 @@ func TestGeneratedQueriesParse(t *testing.T) {
 						graphCommonHandlerInput: common,
 						Bidirectional:           bidirectional,
 					}
-					checkParses(t, unionAll(sankey.toSQL(testResolution)))
+					sb.CheckStatement(t, unionAll(sankey.toSQL(testResolution)))
 				})
 			}
 		}
 	}
+}
+
+// toSQLStrings renders the per-axis queries, so the tests can pin the SQL each
+// axis produces. The result is normalized, like the expected SQL it is compared
+// with.
+func toSQLStrings(t *testing.T, queries []*sb.Query) []string {
+	t.Helper()
+	sql := make([]string, len(queries))
+	for i, query := range queries {
+		sql[i] = sb.Normalize(t, query.String())
+	}
+	return sql
 }

--- a/console/sql_test.go
+++ b/console/sql_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Free Mobile
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package console
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"akvorado/common/schema"
+	"akvorado/console/query"
+
+	"github.com/AfterShip/clickhouse-sql-parser/parser"
+)
+
+// checkParses parses a complete SQL statement.
+func checkParses(t *testing.T, sql string) {
+	t.Helper()
+	if _, err := parser.NewParser(sql).ParseStmts(); err != nil {
+		t.Errorf("cannot parse generated SQL:\n%s\n\nerror:\n%+v", sql, err)
+	}
+}
+
+// checkExprParses parses a single expression. The parser only exposes statement
+// parsing, so the expression is wrapped in a SELECT.
+func checkExprParses(t *testing.T, expr string) {
+	t.Helper()
+	checkParses(t, fmt.Sprintf("SELECT %s", expr))
+}
+
+var (
+	testStart = time.Date(2022, 4, 10, 15, 45, 10, 0, time.UTC)
+	testEnd   = time.Date(2022, 4, 11, 15, 45, 10, 0, time.UTC)
+)
+
+func TestColumnSQLSelectParses(t *testing.T) {
+	sch := schema.NewMock(t).EnableAllColumns()
+	tested := 0
+	for _, column := range sch.Columns() {
+		qc := query.NewColumn(column.Name)
+		if err := qc.Validate(sch); err != nil {
+			// Not usable as a dimension
+			continue
+		}
+		tested++
+		t.Run(column.Name, func(t *testing.T) {
+			checkExprParses(t, qc.ToSQLSelect(sch))
+		})
+	}
+	if tested < 20 {
+		t.Errorf("only %d columns tested, expected the whole schema", tested)
+	}
+}
+
+func TestGeneratedQueriesParse(t *testing.T) {
+	sch := schema.NewMock(t).EnableAllColumns()
+
+	// Each variant exercises a different part of the query shape. They are
+	// combined with the flags below rather than crossed with each other, to
+	// keep the number of queries reasonable.
+	variants := []struct {
+		Description string
+		Dimensions  []query.Column
+		Filter      string
+		LimitType   string
+		Units       string
+		Truncate    bool
+	}{
+		{Description: "no dimension", Units: "l3bps"},
+		{
+			Description: "one dimension",
+			Dimensions:  []query.Column{query.NewColumn("ExporterName")},
+			Units:       "fps",
+		}, {
+			Description: "two dimensions, truncated addresses",
+			Dimensions:  []query.Column{query.NewColumn("SrcAddr"), query.NewColumn("DstAS")},
+			Units:       "pps",
+			Truncate:    true,
+		}, {
+			// Lambdas, hexadecimal literals and newlines inside one expression
+			Description: "communities",
+			Dimensions:  []query.Column{query.NewColumn("SrcCommunities")},
+			Units:       "l2bps",
+		}, {
+			// Dictionary lookups and a regular expression
+			Description: "ports and protocol",
+			Dimensions:  []query.Column{query.NewColumn("SrcPort"), query.NewColumn("Proto")},
+			Units:       "inl2%",
+		}, {
+			Description: "TCP flags",
+			Dimensions:  []query.Column{query.NewColumn("TCPFlags")},
+			Units:       "outl2%",
+		}, {
+			Description: "filter on strings",
+			Dimensions:  []query.Column{query.NewColumn("ExporterName")},
+			Filter:      "SrcCountry = 'FR' AND DstCountry != 'US'",
+			LimitType:   "max",
+			Units:       "l3bps",
+		}, {
+			// Turns into an IN plus a BETWEEN disjunction
+			Description: "filter on addresses and subnets",
+			Dimensions:  []query.Column{query.NewColumn("SrcAddr")},
+			Filter:      "SrcAddr IN (192.0.2.0/24, 203.0.113.1)",
+			LimitType:   "last",
+			Units:       "l3bps",
+		}, {
+			Description: "filter needing the main table",
+			Dimensions:  []query.Column{query.NewColumn("ExporterName")},
+			Filter:      "SrcPort = 80",
+			Units:       "l3bps",
+		}, {
+			Description: "filter with quotes and backslashes",
+			Dimensions:  []query.Column{query.NewColumn("ExporterName")},
+			Filter:      `InIfDescription = 'a backslash \\ and a quote \''`,
+			Units:       "l3bps",
+		}, {
+			Description: "filter with braces",
+			Dimensions:  []query.Column{query.NewColumn("ExporterName")},
+			Filter:      "InIfDescription != '{{ hello }}'",
+			Units:       "l3bps",
+		},
+	}
+
+	for _, variant := range variants {
+		for _, bidirectional := range []bool{false, true} {
+			for _, previousPeriod := range []bool{false, true} {
+				name := fmt.Sprintf("%s-b%v-p%v", variant.Description, bidirectional, previousPeriod)
+				t.Run(name, func(t *testing.T) {
+					common := graphCommonHandlerInput{
+						schema:     sch,
+						Start:      testStart,
+						End:        testEnd,
+						Dimensions: variant.Dimensions,
+						Limit:      10,
+						LimitType:  variant.LimitType,
+						Filter:     query.NewFilter(variant.Filter),
+						Units:      variant.Units,
+					}
+					if variant.Truncate {
+						common.TruncateAddrV4 = 24
+						common.TruncateAddrV6 = 48
+					}
+					if err := query.Columns(common.Dimensions).Validate(sch); err != nil {
+						t.Fatalf("Validate() error:\n%+v", err)
+					}
+					if err := common.Filter.Validate(sch); err != nil {
+						t.Fatalf("Validate() error:\n%+v", err)
+					}
+
+					line := graphLineHandlerInput{
+						graphCommonHandlerInput: common,
+						Points:                  100,
+						Bidirectional:           bidirectional,
+						PreviousPeriod:          previousPeriod,
+					}
+					checkParses(t, unionAll(line.toSQL(testResolution)))
+
+					if len(variant.Dimensions) == 0 {
+						// The sankey handler rejects those
+						return
+					}
+					sankey := graphSankeyHandlerInput{
+						graphCommonHandlerInput: common,
+						Bidirectional:           bidirectional,
+					}
+					checkParses(t, unionAll(sankey.toSQL(testResolution)))
+				})
+			}
+		}
+	}
+}

--- a/console/widgets.go
+++ b/console/widgets.go
@@ -50,10 +50,10 @@ func (c *Component) widgetFlowLastHandlerFunc(w http.ResponseWriter, req *http.R
 		last.Item(expr)
 	}
 	sqlQuery := last.
-		From("flows").
+		From(sb.Table("flows")).
 		Where(sb.Op(sb.Column("TimeReceived"), "=",
 			sb.Select(sb.Function("MAX", sb.Column("TimeReceived"))).
-				From("flows").Subquery())).
+				From(sb.Table("flows")).Subquery())).
 		Limit(1).
 		String()
 	w.Header().Set("X-SQL-Query", sqlQuery)
@@ -227,8 +227,8 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 		sb.Alias(sb.Op(
 			sb.Op(bytes, "/", sb.Column("Total")), "*", sb.Uint(100)),
 			"Percent")).
-		WithScalar(sb.Select(bytes).From(r.Table).Where(where), "Total").
-		From(r.Table).
+		WithScalar(sb.Select(bytes).From(sb.Table(r.Table)).Where(where), "Total").
+		From(sb.Table(r.Table)).
 		Where(where).
 		GroupBy(groupby...).
 		OrderBy(sb.Order(sb.Column("Percent")).Desc()).
@@ -265,7 +265,7 @@ func (c *Component) widgetGraphHandlerFunc(w http.ResponseWriter, req *http.Requ
 	sqlQuery := sb.Select(
 		sb.Alias(r.toStartOfInterval(), "Time"),
 		sb.Alias(gbps, "Gbps")).
-		From(r.Table).
+		From(sb.Table(r.Table)).
 		Where(sb.And(r.timefilter(), c.homepageGraphFilter)).
 		GroupBy(sb.Column("Time")).
 		OrderBy(sb.Order(sb.Column("Time")).Fill(

--- a/console/widgets.go
+++ b/console/widgets.go
@@ -189,32 +189,30 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 	}
 
 	now := c.d.Clock.Now()
-	template := fmt.Sprintf(`
+	start, end := now.Add(-5*time.Minute), now
+	r := c.resolve(inputContext{
+		Start:             start,
+		End:               end,
+		MainTableRequired: mainTableRequired,
+		Points:            5,
+	}).forRange(start, end)
+	query := fmt.Sprintf(`
 WITH
- (SELECT SUM(Bytes*SamplingRate) FROM {{ .Table }} WHERE {{ .Timefilter }} %s) AS Total
+ (SELECT SUM(Bytes*SamplingRate) FROM %s WHERE %s %s) AS Total
 SELECT
  if(empty(%s),'Unknown',%s) AS Name,
  SUM(Bytes*SamplingRate) / Total * 100 AS Percent
-FROM {{ .Table }}
-WHERE {{ .Timefilter }}
+FROM %s
+WHERE %s
 %s
 GROUP BY %s
 ORDER BY Percent DESC
 LIMIT 5`,
-		filter, selector, selector, filter, groupby)
-
-	query := c.finalizeTemplateQuery(templateQuery{
-		Template: template,
-		Context: inputContext{
-			Start:             now.Add(-5 * time.Minute),
-			End:               now,
-			MainTableRequired: mainTableRequired,
-			Points:            5,
-		},
-	})
+		r.Table, r.Timefilter, filter, selector, selector, r.Table, r.Timefilter, filter, groupby)
 	w.Header().Set("X-SQL-Query", query)
 
 	results := []topResult{}
+	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
 	if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, strings.TrimSpace(query)); err != nil {
 		c.r.Err(err).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})
@@ -230,35 +228,34 @@ func (c *Component) widgetGraphHandlerFunc(w http.ResponseWriter, req *http.Requ
 	}
 	ctx := c.t.Context(req.Context())
 	now := c.d.Clock.Now()
-	template := fmt.Sprintf(`
+	start, end := now.Add(-c.config.HomepageGraphTimeRange), now
+	r := c.resolve(inputContext{
+		Start:             start,
+		End:               end,
+		MainTableRequired: false,
+		Points:            200,
+	}).forRange(start, end)
+	query := fmt.Sprintf(`
 SELECT
- {{ .ToStartOfInterval }} AS Time,
- SUM(Bytes*SamplingRate*8/{{ .Interval }})/1000/1000/1000 AS Gbps
-FROM {{ .Table }}
-WHERE {{ .Timefilter }}
+ %s AS Time,
+ SUM(Bytes*SamplingRate*8/%d)/1000/1000/1000 AS Gbps
+FROM %s
+WHERE %s
 %s
 GROUP BY Time
 ORDER BY Time WITH FILL
- FROM {{ .TimefilterStart }}
- TO {{ .TimefilterEnd }} + INTERVAL 1 second
- STEP {{ .Interval }}`,
-		filter)
-
-	query := c.finalizeTemplateQuery(templateQuery{
-		Template: template,
-		Context: inputContext{
-			Start:             now.Add(-c.config.HomepageGraphTimeRange),
-			End:               now,
-			MainTableRequired: false,
-			Points:            200,
-		},
-	})
+ FROM %s
+ TO %s + INTERVAL 1 second
+ STEP %d`,
+		r.ToStartOfInterval, r.Interval, r.Table, r.Timefilter, filter,
+		r.TimefilterStart, r.TimefilterEnd, r.Interval)
 	w.Header().Set("X-SQL-Query", query)
 
 	results := []struct {
 		Time time.Time `json:"t"`
 		Gbps float64   `json:"gbps"`
 	}{}
+	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
 	err := c.d.ClickHouseDB.Conn.Select(ctx, &results, strings.TrimSpace(query))
 	if err != nil {
 		c.r.Err(err).Msg("unable to query database")

--- a/console/widgets.go
+++ b/console/widgets.go
@@ -4,49 +4,61 @@
 package console
 
 import (
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 	"time"
 
+	"akvorado/common/constants"
 	"akvorado/common/helpers"
 	"akvorado/common/httpserver"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
+	"akvorado/console/query"
 )
 
 func (c *Component) widgetFlowLastHandlerFunc(w http.ResponseWriter, req *http.Request) {
 	ctx := c.t.Context(req.Context())
 	replace := []struct {
 		key         schema.ColumnKey
-		replaceWith string
+		replaceWith sb.Expr
 	}{
-		{schema.ColumnSrcCommunities, communitiesFormat("SrcCommunities")},
-		{schema.ColumnSrcLargeCommunities, largeCommunitiesFormat("SrcLargeCommunities")},
-		{schema.ColumnDstCommunities, communitiesFormat("DstCommunities")},
-		{schema.ColumnDstLargeCommunities, largeCommunitiesFormat("DstLargeCommunities")},
-		{schema.ColumnSrcMAC, `MACNumToString(SrcMAC)`},
-		{schema.ColumnDstMAC, `MACNumToString(DstMAC)`},
+		{schema.ColumnSrcCommunities, query.CommunitiesToStrings("SrcCommunities")},
+		{schema.ColumnSrcLargeCommunities, query.LargeCommunitiesToStrings("SrcLargeCommunities")},
+		{schema.ColumnDstCommunities, query.CommunitiesToStrings("DstCommunities")},
+		{schema.ColumnDstLargeCommunities, query.LargeCommunitiesToStrings("DstLargeCommunities")},
+		{schema.ColumnSrcMAC, sb.Function("MACNumToString", sb.Column("SrcMAC"))},
+		{schema.ColumnDstMAC, sb.Function("MACNumToString", sb.Column("DstMAC"))},
 	}
-	selectClause := []string{"SELECT *"}
+	// The columns below are not readable as they are stored, so they are
+	// dropped from the "*" and added back in a friendlier form.
+	replaced := []sb.Expr{}
 	except := []string{}
 	for _, r := range replace {
 		if column, ok := c.d.Schema.LookupColumnByKey(r.key); ok && !column.Disabled {
 			except = append(except, r.key.String())
-			selectClause = append(selectClause, fmt.Sprintf("%s AS %s", r.replaceWith, r.key))
+			replaced = append(replaced, sb.Alias(r.replaceWith, r.key.String()))
 		}
 	}
+	last := sb.Select()
 	if len(except) > 0 {
-		selectClause[0] = fmt.Sprintf("SELECT * EXCEPT (%s)", strings.Join(except, ", "))
+		last.Item(sb.Star(), sb.Except(except...))
+	} else {
+		last.Item(sb.Star())
 	}
-	query := fmt.Sprintf(`
-%s
-FROM flows
-WHERE TimeReceived=(SELECT MAX(TimeReceived) FROM flows)
-LIMIT 1`, strings.Join(selectClause, ",\n "))
-	w.Header().Set("X-SQL-Query", query)
+	for _, expr := range replaced {
+		last.Item(expr)
+	}
+	sqlQuery := last.
+		From("flows").
+		Where(sb.Op(sb.Column("TimeReceived"), "=",
+			sb.Select(sb.Function("MAX", sb.Column("TimeReceived"))).
+				From("flows").Subquery())).
+		Limit(1).
+		String()
+	w.Header().Set("X-SQL-Query", sqlQuery)
 	// Do not increase counter for this one.
-	rows, err := c.d.ClickHouseDB.Conn.Query(ctx, query)
+	rows, err := c.d.ClickHouseDB.Conn.Query(ctx, sqlQuery)
 	if err != nil {
 		c.r.Err(err).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})
@@ -76,14 +88,6 @@ LIMIT 1`, strings.Join(selectClause, ",\n "))
 		response[column] = vars[index]
 	}
 	httpserver.WriteIndentedJSON(w, http.StatusOK, response)
-}
-
-func communitiesFormat(prefix string) string {
-	return fmt.Sprintf(`arrayMap(c -> concat(toString(bitShiftRight(c, 16)), ':', toString(bitAnd(c, 0xffff))), %s)`, prefix)
-}
-
-func largeCommunitiesFormat(prefix string) string {
-	return fmt.Sprintf(`arrayMap(c -> concat(toString(bitAnd(bitShiftRight(c, 64), 0xffffffff)), ':', toString(bitAnd(bitShiftRight(c, 32), 0xffffffff)), ':', toString(bitAnd(c, 0xffffffff))), %s)`, prefix)
 }
 
 func (c *Component) widgetFlowRateHandlerFunc(w http.ResponseWriter, req *http.Request) {
@@ -135,11 +139,14 @@ type topResult struct {
 func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Request) {
 	ctx := c.t.Context(req.Context())
 	var (
-		selector          string
-		groupby           string
-		filter            string
+		selector          sb.Expr
+		groupby           []sb.Expr
+		filter            sb.Expr
 		mainTableRequired bool
 	)
+	dictName := func(dictionary string, column string) sb.Expr {
+		return sb.Column(column).Apply(query.DictionaryName(dictionary, "???"))
+	}
 
 	rawName := req.PathValue("name")
 	widgetName, err := HomepageTopWidgetString(rawName)
@@ -149,43 +156,57 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 	}
 
 	switch widgetName {
-	case HomepageTopWidgetSrcAS:
-		selector = fmt.Sprintf(`concat(toString(SrcAS), ': ', dictGetOrDefault('%s', 'name', SrcAS, '???'))`, schema.DictionaryASNs)
-		groupby = `SrcAS`
-	case HomepageTopWidgetDstAS:
-		selector = fmt.Sprintf(`concat(toString(DstAS), ': ', dictGetOrDefault('%s', 'name', DstAS, '???'))`, schema.DictionaryASNs)
-		groupby = `DstAS`
+	case HomepageTopWidgetSrcAS, HomepageTopWidgetDstAS:
+		column := "SrcAS"
+		if widgetName == HomepageTopWidgetDstAS {
+			column = "DstAS"
+		}
+		selector = sb.Function("concat",
+			sb.Function("toString", sb.Column(column)),
+			sb.String(": "),
+			dictName(schema.DictionaryASNs, column))
+		groupby = sb.Columns(column)
 	case HomepageTopWidgetSrcCountry:
-		selector = `SrcCountry`
+		selector = sb.Column("SrcCountry")
 	case HomepageTopWidgetDstCountry:
-		selector = `DstCountry`
+		selector = sb.Column("DstCountry")
 	case HomepageTopWidgetExporter:
-		selector = "ExporterName"
+		selector = sb.Column("ExporterName")
 	case HomepageTopWidgetProtocol:
-		selector = fmt.Sprintf(`dictGetOrDefault('%s', 'name', Proto, '???')`, schema.DictionaryProtocols)
-		groupby = `Proto`
+		selector = dictName(schema.DictionaryProtocols, "Proto")
+		groupby = sb.Columns("Proto")
 	case HomepageTopWidgetEtype:
-		selector = `if(equals(EType, 34525), 'IPv6', if(equals(EType, 2048), 'IPv4', '???'))`
-		groupby = `EType`
-	case HomepageTopWidgetSrcPort:
-		selector = fmt.Sprintf(`concat(dictGetOrDefault('%s', 'name', Proto, '???'), '/', toString(SrcPort))`, schema.DictionaryProtocols)
-		groupby = `Proto, SrcPort`
-		mainTableRequired = true
-	case HomepageTopWidgetDstPort:
-		selector = fmt.Sprintf(`concat(dictGetOrDefault('%s', 'name', Proto, '???'), '/', toString(DstPort))`, schema.DictionaryProtocols)
-		groupby = `Proto, DstPort`
+		etype := sb.Column("EType")
+		selector = sb.Function("if",
+			sb.Function("equals", etype, sb.Uint(constants.ETypeIPv6)),
+			sb.String("IPv6"),
+			sb.Function("if",
+				sb.Function("equals", etype, sb.Uint(constants.ETypeIPv4)),
+				sb.String("IPv4"),
+				sb.String("???")))
+		groupby = sb.Columns("EType")
+	case HomepageTopWidgetSrcPort, HomepageTopWidgetDstPort:
+		column := "SrcPort"
+		if widgetName == HomepageTopWidgetDstPort {
+			column = "DstPort"
+		}
+		selector = sb.Function("concat",
+			dictName(schema.DictionaryProtocols, "Proto"),
+			sb.String("/"),
+			sb.Function("toString", sb.Column(column)))
+		groupby = sb.Columns("Proto", column)
 		mainTableRequired = true
 	default:
 		httpserver.WriteJSON(w, http.StatusNotFound, helpers.M{"message": "Unknown top request."})
 		return
 	}
 	if strings.HasPrefix(rawName, "src-") {
-		filter = "AND InIfBoundary = 'external'"
+		filter = sb.Op(sb.Column("InIfBoundary"), "=", sb.String("external"))
 	} else if strings.HasPrefix(rawName, "dst-") {
-		filter = "AND OutIfBoundary = 'external'"
+		filter = sb.Op(sb.Column("OutIfBoundary"), "=", sb.String("external"))
 	}
-	if groupby == "" {
-		groupby = selector
+	if len(groupby) == 0 {
+		groupby = []sb.Expr{selector}
 	}
 
 	now := c.d.Clock.Now()
@@ -196,24 +217,28 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 		MainTableRequired: mainTableRequired,
 		Points:            5,
 	}).forRange(start, end)
-	query := fmt.Sprintf(`
-WITH
- (SELECT SUM(Bytes*SamplingRate) FROM %s WHERE %s %s) AS Total
-SELECT
- if(empty(%s),'Unknown',%s) AS Name,
- SUM(Bytes*SamplingRate) / Total * 100 AS Percent
-FROM %s
-WHERE %s
-%s
-GROUP BY %s
-ORDER BY Percent DESC
-LIMIT 5`,
-		r.Table, r.Timefilter, filter, selector, selector, r.Table, r.Timefilter, filter, groupby)
-	w.Header().Set("X-SQL-Query", query)
+	where := sb.And(r.timefilter(), filter)
+	bytes := sb.MustParseExpr("SUM(Bytes*SamplingRate)")
+	sqlQuery := sb.Select(
+		sb.Alias(sb.Function("if",
+			sb.Function("empty", selector),
+			sb.String("Unknown"),
+			selector), "Name"),
+		sb.Alias(sb.Op(
+			sb.Op(bytes, "/", sb.Column("Total")), "*", sb.Uint(100)),
+			"Percent")).
+		WithScalar(sb.Select(bytes).From(r.Table).Where(where), "Total").
+		From(r.Table).
+		Where(where).
+		GroupBy(groupby...).
+		OrderBy(sb.Order(sb.Column("Percent")).Desc()).
+		Limit(5).
+		String()
+	w.Header().Set("X-SQL-Query", sqlQuery)
 
 	results := []topResult{}
 	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
-	if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, strings.TrimSpace(query)); err != nil {
+	if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, sqlQuery); err != nil {
 		c.r.Err(err).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})
 		return
@@ -222,10 +247,6 @@ LIMIT 5`,
 }
 
 func (c *Component) widgetGraphHandlerFunc(w http.ResponseWriter, req *http.Request) {
-	filter := c.config.HomepageGraphFilter
-	if filter != "" {
-		filter = fmt.Sprintf("AND %s", filter)
-	}
 	ctx := c.t.Context(req.Context())
 	now := c.d.Clock.Now()
 	start, end := now.Add(-c.config.HomepageGraphTimeRange), now
@@ -235,28 +256,31 @@ func (c *Component) widgetGraphHandlerFunc(w http.ResponseWriter, req *http.Requ
 		MainTableRequired: false,
 		Points:            200,
 	}).forRange(start, end)
-	query := fmt.Sprintf(`
-SELECT
- %s AS Time,
- SUM(Bytes*SamplingRate*8/%d)/1000/1000/1000 AS Gbps
-FROM %s
-WHERE %s
-%s
-GROUP BY Time
-ORDER BY Time WITH FILL
- FROM %s
- TO %s + INTERVAL 1 second
- STEP %d`,
-		r.ToStartOfInterval, r.Interval, r.Table, r.Timefilter, filter,
-		r.TimefilterStart, r.TimefilterEnd, r.Interval)
-	w.Header().Set("X-SQL-Query", query)
+	gbps := sb.Function("SUM",
+		sb.Op(sb.MustParseExpr("Bytes*SamplingRate*8"), "/", sb.Uint(r.Interval)))
+	// From bits per second to gigabits per second.
+	for range 3 {
+		gbps = sb.Op(gbps, "/", sb.Uint(1000))
+	}
+	sqlQuery := sb.Select(
+		sb.Alias(r.toStartOfInterval(), "Time"),
+		sb.Alias(gbps, "Gbps")).
+		From(r.Table).
+		Where(sb.And(r.timefilter(), c.homepageGraphFilter)).
+		GroupBy(sb.Column("Time")).
+		OrderBy(sb.Order(sb.Column("Time")).Fill(
+			r.timefilterStart(),
+			sb.Op(r.timefilterEnd(), "+", seconds(1)),
+			sb.Uint(r.Interval))).
+		String()
+	w.Header().Set("X-SQL-Query", sqlQuery)
 
 	results := []struct {
 		Time time.Time `json:"t"`
 		Gbps float64   `json:"gbps"`
 	}{}
 	c.metrics.clickhouseQueries.WithLabelValues(r.Table).Inc()
-	err := c.d.ClickHouseDB.Conn.Select(ctx, &results, strings.TrimSpace(query))
+	err := c.d.ClickHouseDB.Conn.Select(ctx, &results, sqlQuery)
 	if err != nil {
 		c.r.Err(err).Msg("unable to query database")
 		httpserver.WriteJSON(w, http.StatusInternalServerError, helpers.M{"message": "Unable to query database."})

--- a/console/widgets_test.go
+++ b/console/widgets_test.go
@@ -302,6 +302,26 @@ ORDER BY Time WITH FILL
  TO toDateTime('2009-11-11 23:00:00', 'UTC') + INTERVAL 1 second
  STEP 432`,
 		},
+		{
+			// Braces in the operator-provided filter are passed through as-is.
+			config: func() Configuration {
+				c := DefaultConfiguration()
+				c.HomepageGraphFilter = "InIfDescription != '{{ hello }}'"
+				return c
+			}(),
+			query: `
+SELECT
+ toStartOfInterval(TimeReceived + INTERVAL 144 second, INTERVAL 432 second) - INTERVAL 144 second AS Time,
+ SUM(Bytes*SamplingRate*8/432)/1000/1000/1000 AS Gbps
+FROM flows
+WHERE TimeReceived BETWEEN toDateTime('2009-11-10 23:00:00', 'UTC') AND toDateTime('2009-11-11 23:00:00', 'UTC')
+AND InIfDescription != '{{ hello }}'
+GROUP BY Time
+ORDER BY Time WITH FILL
+ FROM toDateTime('2009-11-10 23:00:00', 'UTC')
+ TO toDateTime('2009-11-11 23:00:00', 'UTC') + INTERVAL 1 second
+ STEP 432`,
+		},
 	}
 	for _, tcase := range testcases {
 		_, h, mockConn, mockClock := NewMock(t, tcase.config)

--- a/console/widgets_test.go
+++ b/console/widgets_test.go
@@ -6,7 +6,6 @@ package console
 import (
 	"net"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 
 	"akvorado/common/clickhousedb/mocks"
 	"akvorado/common/helpers"
+	sb "akvorado/common/sqlbuilder"
 )
 
 func TestWidgetLastFlow(t *testing.T) {
@@ -22,13 +22,13 @@ func TestWidgetLastFlow(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mockRows := mocks.NewMockRows(ctrl)
-	mockConn.EXPECT().Query(gomock.Any(), `
+	mockConn.EXPECT().Query(gomock.Any(), sb.SQLMatcher(t, `
 SELECT * EXCEPT (DstCommunities, DstLargeCommunities),
  arrayMap(c -> concat(toString(bitShiftRight(c, 16)), ':', toString(bitAnd(c, 0xffff))), DstCommunities) AS DstCommunities,
  arrayMap(c -> concat(toString(bitAnd(bitShiftRight(c, 64), 0xffffffff)), ':', toString(bitAnd(bitShiftRight(c, 32), 0xffffffff)), ':', toString(bitAnd(c, 0xffffffff))), DstLargeCommunities) AS DstLargeCommunities
 FROM flows
 WHERE TimeReceived=(SELECT MAX(TimeReceived) FROM flows)
-LIMIT 1`).
+LIMIT 1`)).
 		Return(mockRows, nil)
 	mockRows.EXPECT().Next().Return(true)
 	mockRows.EXPECT().Close()
@@ -153,8 +153,21 @@ func TestWidgetTop(t *testing.T) {
 	_, h, mockConn, _ := NewMock(t, DefaultConfiguration())
 
 	gomock.InOrder(
+		// The first query is pinned, the others only differ by the selector and
+		// the grouping.
 		mockConn.EXPECT().
-			Select(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).
+			Select(gomock.Any(), gomock.Any(), sb.SQLMatcher(t, `
+WITH
+ (SELECT SUM(Bytes*SamplingRate) FROM flows WHERE TimeReceived BETWEEN toDateTime('1969-12-31 23:55:00', 'UTC') AND toDateTime('1970-01-01 00:00:00', 'UTC') AND InIfBoundary = 'external') AS Total
+SELECT
+ if(empty(concat(dictGetOrDefault('protocols', 'name', Proto, '???'), '/', toString(SrcPort))),'Unknown',concat(dictGetOrDefault('protocols', 'name', Proto, '???'), '/', toString(SrcPort))) AS Name,
+ SUM(Bytes*SamplingRate) / Total * 100 AS Percent
+FROM flows
+WHERE TimeReceived BETWEEN toDateTime('1969-12-31 23:55:00', 'UTC') AND toDateTime('1970-01-01 00:00:00', 'UTC')
+AND InIfBoundary = 'external'
+GROUP BY Proto, SrcPort
+ORDER BY Percent DESC
+LIMIT 5`)).Return(nil).
 			SetArg(1, []topResult{
 				{"TCP/443", float64(51)},
 				{"UDP/443", float64(20)},
@@ -340,7 +353,7 @@ ORDER BY Time WITH FILL
 			{base.Add(5 * time.Minute), 24.7},
 		}
 		mockConn.EXPECT().
-			Select(gomock.Any(), gomock.Any(), strings.TrimSpace(tcase.query)).
+			Select(gomock.Any(), gomock.Any(), sb.SQLMatcher(t, tcase.query)).
 			SetArg(1, expected).
 			Return(nil)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
+	github.com/AfterShip/clickhouse-sql-parser v0.5.4
 	github.com/ClickHouse/ch-go v0.73.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
 	github.com/alecthomas/chroma/v2 v2.23.1
@@ -34,6 +35,7 @@ require (
 	github.com/openconfig/gnmic/pkg/api v0.1.11
 	github.com/oschwald/maxminddb-golang/v2 v2.4.1
 	github.com/osrg/gobgp/v4 v4.7.0
+	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25
 	github.com/prometheus/client_golang v1.24.0
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/redis/go-redis/v9 v9.21.0
@@ -132,7 +134,6 @@ require (
 	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
-	github.com/AfterShip/clickhouse-sql-parser v0.5.4
+	github.com/AfterShip/clickhouse-sql-parser v0.5.5-0.20260805022546-71e3f4d68c75
 	github.com/ClickHouse/ch-go v0.73.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
 	github.com/alecthomas/chroma/v2 v2.23.1
@@ -194,3 +194,5 @@ tool (
 	gotest.tools/gotestsum
 	honnef.co/go/tools/cmd/staticcheck
 )
+
+replace github.com/AfterShip/clickhouse-sql-parser => github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624

--- a/go.mod
+++ b/go.mod
@@ -195,4 +195,4 @@ tool (
 	honnef.co/go/tools/cmd/staticcheck
 )
 
-replace github.com/AfterShip/clickhouse-sql-parser => github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624
+replace github.com/AfterShip/clickhouse-sql-parser => github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805134228-45df8692241d

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/uptrace/bun/dialect/pgdialect v1.2.18/go.mod h1:Tqdf4QP1okrGYpXfodXvC
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18 h1:Z33SY/U++XK9uGWqS4h8OZVxfCXguIG+sU9cYq2PGFQ=
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18/go.mod h1:1MVOS/Ncy4FZbkJcgUFH6OqYoQinYNjkEwsmNQEXz2A=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624 h1:ht/o+7wr0KpEowAmAD3HCP8wuME1TWP1/nmb9eEJD6g=
-github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
+github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805134228-45df8692241d h1:ZDapctEXRW9yJR2yasVpHdJiUo6zKVpMZTiO4M4Zgjk=
+github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805134228-45df8692241d/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6M
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/AfterShip/clickhouse-sql-parser v0.5.4 h1:yiCQaMq8EO+dpKdnpP9YYd/ne6MSuOXgsMsNL33NiTI=
+github.com/AfterShip/clickhouse-sql-parser v0.5.4/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/AlekSi/pointer v1.2.0 h1:glcy/gc4h8HnG2Z3ZECSzZ1IX1x2JxRVuDzaJwQE0+w=
 github.com/AlekSi/pointer v1.2.0/go.mod h1:gZGfd3dpW4vEc/UlyfKKi1roIqcCgwOIvb0tSNSBle0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -282,8 +284,12 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scrapli/scrapligo v1.4.0 h1:gF7bIiRHT/aB1zTu9PYIK9R2A/gXr4fF/CKUyyWaNq4=
 github.com/scrapli/scrapligo v1.4.0/go.mod h1:pOWxVyPsQRrWTrkoSSDg05tjOqtWfLffAZtAsCc0w3M=
+github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
+github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
+github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil/v3 v3.23.11/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6M
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
-github.com/AfterShip/clickhouse-sql-parser v0.5.4 h1:yiCQaMq8EO+dpKdnpP9YYd/ne6MSuOXgsMsNL33NiTI=
-github.com/AfterShip/clickhouse-sql-parser v0.5.4/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/AlekSi/pointer v1.2.0 h1:glcy/gc4h8HnG2Z3ZECSzZ1IX1x2JxRVuDzaJwQE0+w=
 github.com/AlekSi/pointer v1.2.0/go.mod h1:gZGfd3dpW4vEc/UlyfKKi1roIqcCgwOIvb0tSNSBle0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -355,6 +353,8 @@ github.com/uptrace/bun/dialect/pgdialect v1.2.18/go.mod h1:Tqdf4QP1okrGYpXfodXvC
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18 h1:Z33SY/U++XK9uGWqS4h8OZVxfCXguIG+sU9cYq2PGFQ=
 github.com/uptrace/bun/dialect/sqlitedialect v1.2.18/go.mod h1:1MVOS/Ncy4FZbkJcgUFH6OqYoQinYNjkEwsmNQEXz2A=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624 h1:ht/o+7wr0KpEowAmAD3HCP8wuME1TWP1/nmb9eEJD6g=
+github.com/vincentbernat/clickhouse-sql-parser v0.0.0-20260805113902-1dc638d03624/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -8,10 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 
-	"akvorado/common/clickhousedb"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -64,19 +63,37 @@ func (c *Component) migrateDatabase() error {
 		ctx,
 		func(ctx context.Context) error {
 			return c.createDictionary(ctx, schema.DictionaryASNs, "hashed",
-				"`asn` UInt32 INJECTIVE, `name` String", "asn")
+				[]sb.DictionaryAttribute{
+					sb.Attribute("asn", "UInt32").Injective(),
+					sb.Attribute("name", "String"),
+				}, sb.Columns("asn"))
 		}, func(ctx context.Context) error {
 			return c.createDictionary(ctx, schema.DictionaryProtocols, "hashed",
-				"`proto` UInt8 INJECTIVE, `name` String, `description` String", "proto")
+				[]sb.DictionaryAttribute{
+					sb.Attribute("proto", "UInt8").Injective(),
+					sb.Attribute("name", "String"),
+					sb.Attribute("description", "String"),
+				}, sb.Columns("proto"))
 		}, func(ctx context.Context) error {
 			return c.createDictionary(ctx, schema.DictionaryICMP, "complex_key_hashed",
-				"`proto` UInt8, `type` UInt8, `code` UInt8, `name` String", "proto, type, code")
+				[]sb.DictionaryAttribute{
+					sb.Attribute("proto", "UInt8"),
+					sb.Attribute("type", "UInt8"),
+					sb.Attribute("code", "UInt8"),
+					sb.Attribute("name", "String"),
+				}, sb.Columns("proto", "type", "code"))
 		}, func(ctx context.Context) error {
 			return c.createDictionary(ctx, schema.DictionaryTCP, "hashed",
-				"`port` UInt16 INJECTIVE, `name` String", "port")
+				[]sb.DictionaryAttribute{
+					sb.Attribute("port", "UInt16").Injective(),
+					sb.Attribute("name", "String"),
+				}, sb.Columns("port"))
 		}, func(ctx context.Context) error {
 			return c.createDictionary(ctx, schema.DictionaryUDP, "hashed",
-				"`port` UInt16 INJECTIVE, `name` String", "port")
+				[]sb.DictionaryAttribute{
+					sb.Attribute("port", "UInt16").Injective(),
+					sb.Attribute("name", "String"),
+				}, sb.Columns("port"))
 		})
 	if err != nil {
 		return err
@@ -85,12 +102,12 @@ func (c *Component) migrateDatabase() error {
 	// Prepare custom dictionary migrations
 	var dictMigrations []func(context.Context) error
 	for k, v := range c.d.Schema.GetCustomDictConfig() {
-		var schemaStr []string
-		var keys []string
+		var attributes []sb.DictionaryAttribute
+		var keys []sb.Expr
 		for _, a := range v.Keys {
 			// This is a key. We need it in the schema and in primary keys.
-			schemaStr = append(schemaStr, fmt.Sprintf("`%s` %s", a.Name, a.Type))
-			keys = append(keys, a.Name)
+			attributes = append(attributes, sb.Attribute(a.Name, a.Type))
+			keys = append(keys, sb.Column(a.Name))
 		}
 
 		for _, a := range v.Attributes {
@@ -99,16 +116,16 @@ func (c *Component) migrateDatabase() error {
 				defaultValue = a.Default
 			}
 			// This is only an attribute. We only need it in the schema
-			schemaStr = append(schemaStr, fmt.Sprintf("`%s` %s DEFAULT %s",
-				a.Name, a.Type, quoteString(defaultValue)))
+			attributes = append(attributes,
+				sb.Attribute(a.Name, a.Type).Default(defaultValue))
 		}
 		dictMigrations = append(dictMigrations, func(ctx context.Context) error {
 			return c.createDictionary(
 				ctx,
 				fmt.Sprintf("custom_dict_%s", k),
 				string(v.Layout),
-				strings.Join(schemaStr[:], ", "),
-				strings.Join(keys[:], ", "))
+				attributes,
+				keys)
 		})
 	}
 	// Create custom dictionaries
@@ -207,8 +224,8 @@ func (c *Component) reloadDictionaries(ctx context.Context) {
 func (c *Component) ReloadDictionary(ctx context.Context, dictName string) error {
 	if c.d.ClickHouse != nil {
 		return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s.%s",
-			clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
-			clickhousedb.QuoteIdentifier(dictName)))
+			sb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
+			sb.QuoteIdentifier(dictName)))
 	}
 	return nil
 }

--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -223,9 +223,8 @@ func (c *Component) reloadDictionaries(ctx context.Context) {
 // ReloadDictionary will reload the specified dictionnary.
 func (c *Component) ReloadDictionary(ctx context.Context, dictName string) error {
 	if c.d.ClickHouse != nil {
-		return c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("SYSTEM RELOAD DICTIONARY %s.%s",
-			sb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
-			sb.QuoteIdentifier(dictName)))
+		return c.d.ClickHouse.ExecOnCluster(ctx,
+			sb.SystemReloadDictionary(sb.Table(dictName).In(c.d.ClickHouse.DatabaseName())))
 	}
 	return nil
 }

--- a/orchestrator/clickhouse/migrations_helpers.go
+++ b/orchestrator/clickhouse/migrations_helpers.go
@@ -224,7 +224,7 @@ func (c *Component) createDictionary(ctx context.Context, name, layout string, a
 		return errSkipStep
 	}
 	c.r.Info().Msgf("create dictionary %s", name)
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace()); err != nil {
 		return fmt.Errorf("cannot create dictionary %s: %w", name, err)
 	}
 	return nil
@@ -266,7 +266,7 @@ func (c *Component) createExportersTable(ctx context.Context) error {
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace()); err != nil {
 		return fmt.Errorf("cannot create exporters table: %w", err)
 	}
 
@@ -310,11 +310,11 @@ func (c *Component) createExportersConsumerView(ctx context.Context) error {
 
 	// Drop existing table and recreate
 	c.r.Info().Msg("create exporters view")
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(name)).String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(name))); err != nil {
 		return fmt.Errorf("cannot drop existing exporters view: %w", err)
 	}
 	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
-		sb.Table(name), sb.Table("exporters"), selectQuery).String()); err != nil {
+		sb.Table(name), sb.Table("exporters"), selectQuery)); err != nil {
 		return fmt.Errorf("cannot create exporters view: %w", err)
 	}
 
@@ -351,14 +351,14 @@ func (c *Component) createRawFlowsTable(ctx context.Context) error {
 		fmt.Sprintf("%s_consumer", tableName),
 		tableName,
 	} {
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(table)).String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(table))); err != nil {
 			return fmt.Errorf("cannot drop %s: %w", table, err)
 		}
 	}
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery); err != nil {
 		return fmt.Errorf("cannot create raw flows table: %w", err)
 	}
 
@@ -393,12 +393,12 @@ func (c *Component) createRawFlowsConsumerView(ctx context.Context) error {
 
 	// Drop and create
 	c.r.Info().Msg("create raw flows consumer view")
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName))); err != nil {
 		return fmt.Errorf("cannot drop table %s: %w", viewName, err)
 	}
 	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
 		sb.Table(viewName), sb.Table(c.distributedTable("flows")),
-		selectQuery).String()); err != nil {
+		selectQuery)); err != nil {
 		return fmt.Errorf("cannot create raw flows consumer view: %w", err)
 	}
 
@@ -457,7 +457,7 @@ func (c *Component) createOrUpdateFlowsTable(ctx context.Context, resolution Res
 		for _, setting := range settings {
 			createQuery.Setting(setting.name, setting.expr())
 		}
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery); err != nil {
 			return fmt.Errorf("cannot create %s: %w", tableName, err)
 		}
 		if _, err := c.applySkipIndexes(ctx, tableName, resolution.Interval == 0); err != nil {
@@ -520,7 +520,7 @@ outer:
 					// either the column was an alias and should be none, or the other way around. Either way, we need to recreate.
 					c.r.Debug().Msg(fmt.Sprintf("column %s alias content has changed, recreating. New ALIAS: %s", existingColumn.Name, wantedColumn.ClickHouseAlias))
 					err := c.d.ClickHouse.ExecOnCluster(ctx,
-						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name).String())
+						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name))
 					if err != nil {
 						return fmt.Errorf("cannot drop %s from %s to cleanup aliasing: %w",
 							existingColumn.Name, tableName, err)
@@ -536,7 +536,7 @@ outer:
 				if resolution.Interval > 0 && !wantedColumn.ClickHouseNotSortingKey && existingColumn.IsSortingKey == 0 {
 					// That's something we can fix, but we need to drop it before recreating it
 					err := c.d.ClickHouse.ExecOnCluster(ctx,
-						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name).String())
+						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name))
 					if err != nil {
 						return fmt.Errorf("cannot drop %s from %s to fix ordering: %w",
 							existingColumn.Name, tableName, err)
@@ -569,11 +569,11 @@ outer:
 		if resolution.Interval > 0 {
 			// Drop the view
 			viewName := fmt.Sprintf("%s_consumer", tableName)
-			if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
+			if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName))); err != nil {
 				return fmt.Errorf("cannot drop %s: %w", viewName, err)
 			}
 		}
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterQuery.String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterQuery); err != nil {
 			return fmt.Errorf("cannot update table %s: %w", tableName, err)
 		}
 		modified = true
@@ -590,7 +590,7 @@ outer:
 		for _, setting := range settings {
 			alterSettings.ModifySetting(setting.name, setting.expr())
 		}
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterSettings.String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterSettings); err != nil {
 			return fmt.Errorf("cannot modify settings for table %s: %w", tableName, err)
 		}
 		modified = true
@@ -606,7 +606,7 @@ outer:
 			clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 				"materialize_ttl_after_modify": 0,
 			})),
-			sb.AlterTable(sb.Table(tableName)).ModifyTTL(ttlExpr).String())
+			sb.AlterTable(sb.Table(tableName)).ModifyTTL(ttlExpr))
 		if err != nil {
 			return fmt.Errorf("cannot modify TTL for table %s: %w", tableName, err)
 		}
@@ -714,13 +714,13 @@ func (c *Component) applySkipIndexes(ctx context.Context, tableName string, isMa
 	// Batch drops before adds (drop must precede re-add when type changes).
 	if toDrop.Len() > 0 {
 		c.r.Info().Msgf("removing %d skip index(es) from %s", toDrop.Len(), tableName)
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, toDrop.String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, toDrop); err != nil {
 			return false, fmt.Errorf("cannot drop skip indexes on %s: %w", tableName, err)
 		}
 	}
 	if toAdd.Len() > 0 {
 		c.r.Info().Msgf("adding %d skip index(es) to %s", toAdd.Len(), tableName)
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, toAdd.String()); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, toAdd); err != nil {
 			return false, fmt.Errorf("cannot add skip indexes on %s: %w", tableName, err)
 		}
 	}
@@ -760,12 +760,12 @@ func (c *Component) createFlowsConsumerView(ctx context.Context, resolution Reso
 
 	// Drop and create
 	c.r.Info().Msgf("create %s", viewName)
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName))); err != nil {
 		return fmt.Errorf("cannot drop table %s: %w", viewName, err)
 	}
 	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
 		sb.Table(viewName), sb.Table(c.localTable(tableName)),
-		selectQuery).String()); err != nil {
+		selectQuery)); err != nil {
 		return fmt.Errorf("cannot create %s: %w", viewName, err)
 	}
 	return nil
@@ -833,7 +833,7 @@ ORDER BY position ASC
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace()); err != nil {
 		return fmt.Errorf("cannot create %s: %w", c.distributedTable(source), err)
 	}
 	return nil

--- a/orchestrator/clickhouse/migrations_helpers.go
+++ b/orchestrator/clickhouse/migrations_helpers.go
@@ -12,14 +12,13 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 
-	"akvorado/common/clickhousedb"
 	"akvorado/common/helpers"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 )
 
 var errSkipStep = errors.New("migration: skip this step")
@@ -33,12 +32,33 @@ var defaultTableSettings = TableSettings{
 	"ttl_only_drop_parts": 1,
 }
 
-// renderTableSettings merges extra settings with the default table settings and
-// returns a stable settings string suitable for ClickHouse SETTINGS clauses.
-// Default settings appear first (index_granularity, ttl_only_drop_parts),
-// followed by extra settings sorted alphabetically. Integer values are rendered
-// unquoted; string values are single-quoted.
-func renderTableSettings(extra TableSettings) string {
+// tableSetting is one ClickHouse table setting with its value.
+type tableSetting struct {
+	name  string
+	value any
+}
+
+// expr returns the value of the setting as a SQL expression.
+func (s tableSetting) expr() sb.Expr {
+	switch value := s.value.(type) {
+	case int:
+		return sb.Int(int64(value))
+	case string:
+		return sb.String(value)
+	}
+	return sb.Expr{}
+}
+
+// String renders the setting the way ClickHouse writes it back in engine_full.
+func (s tableSetting) String() string {
+	return fmt.Sprintf("%s = %s", s.name, s.expr())
+}
+
+// tableSettings merges extra settings with the default table settings and
+// returns them in a stable order. Default settings come first
+// (index_granularity, ttl_only_drop_parts), followed by extra settings sorted
+// alphabetically.
+func tableSettings(extra TableSettings) []tableSetting {
 	merged := TableSettings{}
 	maps.Copy(merged, defaultTableSettings)
 	maps.Copy(merged, extra)
@@ -50,16 +70,24 @@ func renderTableSettings(extra TableSettings) string {
 		}
 	}
 	slices.Sort(extraKeys)
-	keys := append(slices.Clone(defaultTableSettingsKeys), extraKeys...)
 
-	parts := make([]string, 0, len(keys))
-	for _, k := range keys {
-		switch v := merged[k].(type) {
-		case int:
-			parts = append(parts, fmt.Sprintf("%s = %d", k, v))
-		case string:
-			parts = append(parts, fmt.Sprintf("%s = %s", k, quoteString(v)))
+	settings := []tableSetting{}
+	for _, k := range slices.Concat(defaultTableSettingsKeys, extraKeys) {
+		switch merged[k].(type) {
+		case int, string:
+			settings = append(settings, tableSetting{name: k, value: merged[k]})
 		}
+	}
+	return settings
+}
+
+// renderTableSettings renders the settings the way ClickHouse writes them back,
+// so they can be looked for in engine_full.
+func renderTableSettings(extra TableSettings) string {
+	settings := tableSettings(extra)
+	parts := make([]string, len(settings))
+	for i, setting := range settings {
+		parts[i] = setting.String()
 	}
 	return strings.Join(parts, ", ")
 }
@@ -80,89 +108,77 @@ func (c *Component) wrapMigrations(ctx context.Context, fns ...func(context.Cont
 	return nil
 }
 
-// stemplate is a simple wrapper around text/template.
-func stemplate(t string, data any) (string, error) {
-	tpl, err := template.New("tpl").
-		Option("missingkey=error").
-		Funcs(template.FuncMap{
-			"qi": clickhousedb.QuoteIdentifier, // identifier: `name`
-			"qs": quoteString,                  // string: 'value'
-		}).
-		Parse(t)
-	if err != nil {
-		return "", err
-	}
-	var result strings.Builder
-	if err := tpl.Execute(&result, data); err != nil {
-		return "", err
-	}
-	return result.String(), nil
+// table names a table of the database akvorado uses.
+func (c *Component) table(name string) sb.TableName {
+	return sb.Table(name).In(c.d.ClickHouse.DatabaseName())
 }
 
-// quoteString quotes a string to be used in ClickHouse. This is to be used on user-provided strings.
-func quoteString(s string) string {
-	quoteEscaper := strings.NewReplacer(`'`, `\'`, `"`, `\"`, `\`, `\\`)
-	return fmt.Sprintf("'%s'", quoteEscaper.Replace(s))
+// statement is a SQL statement we can compare with what ClickHouse kept about
+// an existing table.
+type statement interface {
+	fmt.Stringer
+	Matches(sql string) bool
 }
 
-// tableAlreadyExists compare the provided table with the one in database.
-// `column` can either be "create_table_query" or "as_select". target is the
-// expected value.
-func (c *Component) tableAlreadyExists(ctx context.Context, table, column, target string) (bool, error) {
-	// Normalize a bit the target. This is far from perfect, but we test that
-	// and we hope this does not differ between ClickHouse versions!
-	target = strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(target, " "))
+// settingsRegexp matches the settings ClickHouse appends to a table
+// definition. They are checked on their own, see createOrUpdateFlowsTable.
+var settingsRegexp = regexp.MustCompile(` SETTINGS .*$`)
 
-	// Fetch the existing one
+// tableColumn fetches one column of system.tables for the provided table. The
+// column can be any expression. An empty string is returned when the table does
+// not exist.
+func (c *Component) tableColumn(ctx context.Context, table, column string) (string, error) {
 	row := c.d.ClickHouse.QueryRow(ctx,
 		fmt.Sprintf("SELECT %s FROM system.tables WHERE name = $1 AND database = $2", column),
 		table, c.d.ClickHouse.DatabaseName())
 	var existing string
 	if err := row.Scan(&existing); err != nil && err != sql.ErrNoRows {
-		return false, fmt.Errorf("cannot check if table %s already exists: %w", table, err)
+		return "", fmt.Errorf("cannot check if table %s already exists: %w", table, err)
 	}
-	// Add a few tweaks
-	existing = strings.ReplaceAll(existing,
-		fmt.Sprintf(`dictGetOrDefault('%s.`, c.d.ClickHouse.DatabaseName()),
-		"dictGetOrDefault('")
-	existing = strings.ReplaceAll(existing,
-		fmt.Sprintf(`dictGet('%s.`, c.d.ClickHouse.DatabaseName()),
-		"dictGet('")
-	existing = regexp.MustCompile(` SETTINGS .*$`).ReplaceAllString(existing, "")
-	existing = strings.ReplaceAll(existing,
-		"ENGINE = Null",
-		"ENGINE = `Null`") // from ClickHouse 25.8
+	return existing, nil
+}
 
-	// Compare!
-	if existing == target {
+// tableAlreadyExists compares the table in the database with the statement we
+// would use to create it. `column` is either "create_table_query" or
+// "as_select".
+func (c *Component) tableAlreadyExists(ctx context.Context, table, column string, target statement) (bool, error) {
+	existing, err := c.tableColumn(ctx, table, column)
+	if err != nil {
+		return false, err
+	}
+	// ClickHouse adds the database in front of the dictionaries, we do not.
+	for _, function := range []string{"dictGetOrDefault", "dictGet"} {
+		existing = strings.ReplaceAll(existing,
+			fmt.Sprintf("%s('%s.", function, c.d.ClickHouse.DatabaseName()),
+			fmt.Sprintf("%s('", function))
+	}
+	existing = settingsRegexp.ReplaceAllString(existing, "")
+
+	if target.Matches(existing) {
 		return true, nil
 	}
 	c.r.Debug().
-		Str("target", target).Str("existing", existing).
+		Str("target", target.String()).Str("existing", existing).
 		Msgf("table %s state difference detected", table)
 	return false, nil
 }
 
 // mergeTreeEngine returns a MergeTree engine definition, either plain or using
 // Replicated if we are on a cluster.
-func (c *Component) mergeTreeEngine(table, variant string, args ...string) string {
+func (c *Component) mergeTreeEngine(table, variant string, args ...sb.Expr) sb.Engine {
 	if c.d.ClickHouse.ClusterName() != "" {
 		zkPath := fmt.Sprintf("/clickhouse/tables/shard-{shard}/%s", table)
 		if helpers.Testing() {
 			zkPath = fmt.Sprintf("/clickhouse/tables/shard-{shard}/%s/%s",
 				c.d.ClickHouse.DatabaseName(), table)
 		}
-		return fmt.Sprintf(`Replicated%sMergeTree(%s)`, variant, strings.Join(
-			append([]string{
-				fmt.Sprintf("'%s'", zkPath),
-				"'replica-{replica}'",
-			}, args...),
-			", "))
+		return sb.NewEngine(fmt.Sprintf("Replicated%sMergeTree", variant),
+			slices.Concat([]sb.Expr{
+				sb.String(zkPath),
+				sb.String("replica-{replica}"),
+			}, args)...)
 	}
-	if len(args) == 0 {
-		return fmt.Sprintf("%sMergeTree", variant)
-	}
-	return fmt.Sprintf("%sMergeTree(%s)", variant, strings.Join(args, ", "))
+	return sb.NewEngine(fmt.Sprintf("%sMergeTree", variant), args...)
 }
 
 // distributedTable turns a table name to the matching distributed table if we
@@ -181,39 +197,24 @@ func (c *Component) localTable(table string) string {
 }
 
 // createDictionary creates the provided dictionary.
-func (c *Component) createDictionary(ctx context.Context, name, layout, schema, primary string) error {
+func (c *Component) createDictionary(ctx context.Context, name, layout string, attributes []sb.DictionaryAttribute, keys []sb.Expr) error {
 	url := fmt.Sprintf("%s/api/v0/orchestrator/clickhouse/%s.csv", c.config.OrchestratorURL, name)
-	sourceParams := []string{
-		fmt.Sprintf("URL %s", quoteString(url)),
-		"FORMAT 'CSVWithNames'",
+	source := []sb.SourceParam{
+		sb.Param("URL", sb.String(url)),
+		sb.Param("FORMAT", sb.String("CSVWithNames")),
 	}
 	if c.config.OrchestratorBasicAuth != nil {
-		sourceParams = append(sourceParams,
-			fmt.Sprintf("CREDENTIALS(user %s password %s)",
-				quoteString(c.config.OrchestratorBasicAuth.Username),
-				quoteString(c.config.OrchestratorBasicAuth.Password)))
+		source = append(source, sb.ParamGroup("CREDENTIALS",
+			sb.Param("user", sb.String(c.config.OrchestratorBasicAuth.Username)),
+			sb.Param("password", sb.String(c.config.OrchestratorBasicAuth.Password))))
 	}
-	source := fmt.Sprintf(`SOURCE(HTTP(%s))`, strings.Join(sourceParams, " "))
-	settings := `SETTINGS(format_csv_allow_single_quotes = 0)`
-	createQuery, err := stemplate(`
-CREATE DICTIONARY {{ qi .Database }}.{{ qi .Name }} ({{ .Schema }})
-PRIMARY KEY {{ .PrimaryKey}}
-{{ .Source }}
-LIFETIME(MIN 0 MAX 3600)
-LAYOUT({{ .Layout }}())
-{{ .Settings }}
-`, helpers.M{
-		"Database":   c.d.ClickHouse.DatabaseName(),
-		"Name":       name,
-		"Schema":     schema,
-		"PrimaryKey": primary,
-		"Layout":     strings.ToUpper(layout),
-		"Source":     source,
-		"Settings":   settings,
-	})
-	if err != nil {
-		return fmt.Errorf("cannot build query to create dictionary %s: %w", name, err)
-	}
+	createQuery := sb.CreateDictionary(c.table(name)).
+		Attributes(attributes...).
+		PrimaryKey(keys...).
+		Source("HTTP", source...).
+		Lifetime(0, 3600).
+		Layout(strings.ToUpper(layout)).
+		Setting("format_csv_allow_single_quotes", sb.Uint(0))
 
 	// Check if dictionary exists and create it if not
 	if ok, err := c.tableAlreadyExists(ctx, name, "create_table_query", createQuery); err != nil {
@@ -223,8 +224,7 @@ LAYOUT({{ .Layout }}())
 		return errSkipStep
 	}
 	c.r.Info().Msgf("create dictionary %s", name)
-	createOrReplaceQuery := strings.Replace(createQuery, "CREATE ", "CREATE OR REPLACE ", 1)
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createOrReplaceQuery); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
 		return fmt.Errorf("cannot create dictionary %s: %w", name, err)
 	}
 	return nil
@@ -232,36 +232,26 @@ LAYOUT({{ .Layout }}())
 
 // createExportersTable creates the exporters table. This table is always local.
 func (c *Component) createExportersTable(ctx context.Context) error {
-	// Select the columns we need
-	cols := []string{}
+	// Select the columns we need. Codecs and aliases are not carried over.
+	columns := []sb.ColumnDef{}
 	for _, column := range c.d.Schema.Columns() {
 		if column.Key == schema.ColumnTimeReceived || strings.HasPrefix(column.Name, "Exporter") {
-			cols = append(cols, fmt.Sprintf("`%s` %s", column.Name, column.ClickHouseType))
+			columns = append(columns, sb.NewColumnDef(column.Name, column.ClickHouseType))
 		}
 		if strings.HasPrefix(column.Name, "InIf") {
-			cols = append(cols, fmt.Sprintf("`%s` %s",
-				column.Name[2:], column.ClickHouseType,
-			))
+			columns = append(columns,
+				sb.NewColumnDef(column.Name[2:], column.ClickHouseType))
 		}
 	}
 
 	// Build CREATE TABLE
 	name := "exporters"
-	createQuery, err := stemplate(
-		`CREATE TABLE {{ qi .Database }}.{{ qi .Table }}
-({{ .Schema }})
-ENGINE = {{ .Engine }}
-ORDER BY (ExporterAddress, IfName)
-TTL TimeReceived + toIntervalDay(1)`,
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    name,
-			"Schema":   strings.Join(cols, ", "),
-			"Engine":   c.mergeTreeEngine(name, "Replacing", "TimeReceived"),
-		})
-	if err != nil {
-		return fmt.Errorf("cannot build query to create exporters view: %w", err)
-	}
+	createQuery := sb.CreateTable(c.table(name)).
+		Columns(columns...).
+		Engine(c.mergeTreeEngine(name, "Replacing", sb.Column("TimeReceived"))).
+		OrderBy(sb.Columns("ExporterAddress", "IfName")...).
+		TTL(sb.Op(sb.Column("TimeReceived"), "+",
+			sb.Function("toIntervalDay", sb.Uint(1))))
 
 	// Check if the table already exists
 	if ok, err := c.tableAlreadyExists(ctx, name, "create_table_query", createQuery); err != nil {
@@ -276,8 +266,7 @@ TTL TimeReceived + toIntervalDay(1)`,
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	createOrReplaceQuery := strings.Replace(createQuery, "CREATE ", "CREATE OR REPLACE ", 1)
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createOrReplaceQuery); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
 		return fmt.Errorf("cannot create exporters table: %w", err)
 	}
 
@@ -286,35 +275,33 @@ TTL TimeReceived + toIntervalDay(1)`,
 
 // createExportersConsumerView creates the exporters view.
 func (c *Component) createExportersConsumerView(ctx context.Context) error {
-	// Select the columns we need
-	cols := []string{}
+	// Select the columns we need. The In/Out pair of an interface column
+	// becomes two rows, picked by the ARRAY JOIN below.
+	items := []sb.Expr{}
 	for _, column := range c.d.Schema.Columns() {
 		if column.Key == schema.ColumnTimeReceived || strings.HasPrefix(column.Name, "Exporter") {
-			cols = append(cols, column.Name)
+			items = append(items, sb.Column(column.Name))
 		}
 		if strings.HasPrefix(column.Name, "InIf") {
-			cols = append(cols, fmt.Sprintf("[InIf%s, OutIf%s][num] AS If%s",
-				column.Name[4:], column.Name[4:], column.Name[4:],
-			))
+			suffix := column.Name[4:]
+			items = append(items, sb.Alias(
+				sb.Index(sb.Array(
+					sb.Column(fmt.Sprintf("InIf%s", suffix)),
+					sb.Column(fmt.Sprintf("OutIf%s", suffix))),
+					sb.Column("num")),
+				fmt.Sprintf("If%s", suffix)))
 		}
 	}
 
 	// Build SELECT query
-	selectQuery, err := stemplate(
-		`SELECT {{ .Columns }} FROM {{ qi .Database }}.{{ qi .Table }} ARRAY JOIN arrayEnumerate([1, 2]) AS num`,
-		helpers.M{
-			"Table":    c.distributedTable("flows"),
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Columns":  strings.Join(cols, ", "),
-		})
-	if err != nil {
-		return fmt.Errorf("cannot build query to create exporters view: %w", err)
-	}
+	name := "exporters_consumer"
+	selectQuery := sb.Select(items...).
+		From(c.table(c.distributedTable("flows"))).
+		ArrayJoin(sb.Alias(
+			sb.Function("arrayEnumerate", sb.Array(sb.Uint(1), sb.Uint(2))), "num"))
 
 	// Check if the table already exists with these columns and with a TTL.
-	if ok, err := c.tableAlreadyExists(ctx,
-		"exporters_consumer", "as_select",
-		selectQuery); err != nil {
+	if ok, err := c.tableAlreadyExists(ctx, name, "as_select", selectQuery); err != nil {
 		return err
 	} else if ok {
 		c.r.Info().Msg("exporters view already exists, skip migration")
@@ -323,12 +310,11 @@ func (c *Component) createExportersConsumerView(ctx context.Context) error {
 
 	// Drop existing table and recreate
 	c.r.Info().Msg("create exporters view")
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, `DROP TABLE IF EXISTS exporters_consumer SYNC`); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(name)).String()); err != nil {
 		return fmt.Errorf("cannot drop existing exporters view: %w", err)
 	}
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(`
-CREATE MATERIALIZED VIEW exporters_consumer TO %s AS %s
-`, "exporters", selectQuery)); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
+		sb.Table(name), sb.Table("exporters"), selectQuery).String()); err != nil {
 		return fmt.Errorf("cannot create exporters view: %w", err)
 	}
 
@@ -341,18 +327,15 @@ func (c *Component) createRawFlowsTable(ctx context.Context) error {
 	tableName := fmt.Sprintf("flows_%s_raw", hash)
 
 	// Build CREATE query
-	createQuery, err := stemplate(
-		"CREATE TABLE {{ qi .Database }}.{{ qi .Table }} ({{ .Schema }}) ENGINE = `Null`",
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    tableName,
-			"Schema": c.d.Schema.ClickHouseCreateTable(
-				schema.ClickHouseSkipGeneratedColumns,
-				schema.ClickHouseSkipAliasedColumns),
-		})
+	columns, err := sb.ParseColumnDefs(c.d.Schema.ClickHouseCreateTable(
+		schema.ClickHouseSkipGeneratedColumns,
+		schema.ClickHouseSkipAliasedColumns))
 	if err != nil {
 		return fmt.Errorf("cannot build query to create raw flows table: %w", err)
 	}
+	createQuery := sb.CreateTable(c.table(tableName)).
+		Columns(columns...).
+		Engine(sb.NewEngine("Null"))
 
 	// Check if the table already exists with the right schema
 	if ok, err := c.tableAlreadyExists(ctx, tableName, "create_table_query", createQuery); err != nil {
@@ -368,14 +351,14 @@ func (c *Component) createRawFlowsTable(ctx context.Context) error {
 		fmt.Sprintf("%s_consumer", tableName),
 		tableName,
 	} {
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s SYNC`, table)); err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(table)).String()); err != nil {
 			return fmt.Errorf("cannot drop %s: %w", table, err)
 		}
 	}
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.String()); err != nil {
 		return fmt.Errorf("cannot create raw flows table: %w", err)
 	}
 
@@ -387,26 +370,17 @@ func (c *Component) createRawFlowsConsumerView(ctx context.Context) error {
 	viewName := fmt.Sprintf("%s_consumer", tableName)
 
 	// Build SELECT query
-	selectQuery, err := stemplate(
-		`SELECT {{ .Columns }} FROM {{ qi .Database }}.{{ qi .Table }}`,
-		helpers.M{
-			"Columns": strings.Join(c.d.Schema.ClickHouseSelectColumns(
-				schema.ClickHouseSubstituteGenerates,
-				schema.ClickHouseSkipAliasedColumns), ", "),
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Table":    tableName,
-		})
+	items, err := sb.ParseExprs(c.d.Schema.ClickHouseSelectColumns(
+		schema.ClickHouseSubstituteGenerates,
+		schema.ClickHouseSkipAliasedColumns))
 	if err != nil {
 		return fmt.Errorf("cannot build select statement for raw flows consumer view: %w", err)
 	}
-	with := []string{}
+	selectQuery := sb.Select(items...).From(c.table(tableName))
 	// c_DstAsPath
 	if column, ok := c.d.Schema.LookupColumnByKey(schema.ColumnDstASPath); ok && !column.Disabled {
-		with = append(with, "arrayCompact(DstASPath) AS c_DstASPath")
-	}
-
-	if len(with) > 0 {
-		selectQuery = fmt.Sprintf("WITH %s %s", strings.Join(with, ", "), selectQuery)
+		selectQuery.WithAlias(
+			sb.Function("arrayCompact", sb.Column("DstASPath")), "c_DstASPath")
 	}
 
 	// Check the existing one
@@ -419,12 +393,12 @@ func (c *Component) createRawFlowsConsumerView(ctx context.Context) error {
 
 	// Drop and create
 	c.r.Info().Msg("create raw flows consumer view")
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s SYNC`, viewName)); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
 		return fmt.Errorf("cannot drop table %s: %w", viewName, err)
 	}
-	if err := c.d.ClickHouse.ExecOnCluster(ctx,
-		fmt.Sprintf("CREATE MATERIALIZED VIEW %s TO %s AS %s",
-			viewName, c.distributedTable("flows"), selectQuery)); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
+		sb.Table(viewName), sb.Table(c.distributedTable("flows")),
+		selectQuery).String()); err != nil {
 		return fmt.Errorf("cannot create raw flows consumer view: %w", err)
 	}
 
@@ -444,55 +418,46 @@ func (c *Component) createOrUpdateFlowsTable(ctx context.Context, resolution Res
 	tableName = c.localTable(tableName)
 	partitionInterval := uint64((resolution.TTL / time.Duration(c.config.MaxPartitions)).Seconds())
 	ttl := uint64(resolution.TTL.Seconds())
-	settings := renderTableSettings(resolution.TableSettings)
+	ttlExpr := sb.Op(sb.Column("TimeReceived"), "+",
+		sb.Function("toIntervalSecond", sb.Uint(ttl)))
+	settings := tableSettings(resolution.TableSettings)
 
 	// Create table if it does not exist
-	if ok, err := c.tableAlreadyExists(ctx, tableName, "name", tableName); err != nil {
+	if existing, err := c.tableColumn(ctx, tableName, "name"); err != nil {
 		return err
-	} else if !ok {
-		var createQuery string
-		var err error
-		if resolution.Interval == 0 {
-			createQuery, err = stemplate(`
-CREATE TABLE {{ .Table }} ({{ .Schema }})
-ENGINE = {{ .Engine }}
-PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{ .PartitionInterval }} second))
-PRIMARY KEY toStartOfFiveMinutes(TimeReceived)
-ORDER BY (toStartOfFiveMinutes(TimeReceived), ExporterAddress, InIfName, OutIfName)
-TTL TimeReceived + toIntervalSecond({{ .TTL }})
-SETTINGS {{ .Settings }}
-`, helpers.M{
-				"Table":             tableName,
-				"Schema":            c.d.Schema.ClickHouseCreateTable(),
-				"PartitionInterval": partitionInterval,
-				"TTL":               ttl,
-				"Engine":            c.mergeTreeEngine(tableName, ""),
-				"Settings":          settings,
-			})
-		} else {
-			createQuery, err = stemplate(`
-CREATE TABLE {{ .Table }} ({{ .Schema }})
-ENGINE = {{ .Engine }}
-PARTITION BY toYYYYMMDDhhmmss(toStartOfInterval(TimeReceived, INTERVAL {{ .PartitionInterval }} second))
-PRIMARY KEY ({{ .PrimaryKey }})
-ORDER BY ({{ .SortingKey }})
-TTL TimeReceived + toIntervalSecond({{ .TTL }})
-SETTINGS {{ .Settings }}
-`, helpers.M{
-				"Table":             tableName,
-				"Schema":            c.d.Schema.ClickHouseCreateTable(schema.ClickHouseSkipMainOnlyColumns),
-				"PartitionInterval": partitionInterval,
-				"PrimaryKey":        strings.Join(c.d.Schema.ClickHousePrimaryKeys(), ", "),
-				"SortingKey":        strings.Join(c.d.Schema.ClickHouseSortingKeys(), ", "),
-				"TTL":               ttl,
-				"Engine":            c.mergeTreeEngine(tableName, "Summing", "(Bytes, Packets)"),
-				"Settings":          settings,
-			})
+	} else if existing == "" {
+		options := []schema.ClickHouseTableOption{}
+		if resolution.Interval > 0 {
+			options = append(options, schema.ClickHouseSkipMainOnlyColumns)
 		}
+		columns, err := sb.ParseColumnDefs(c.d.Schema.ClickHouseCreateTable(options...))
 		if err != nil {
 			return fmt.Errorf("cannot build create table statement for %s: %w", tableName, err)
 		}
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery); err != nil {
+		createQuery := sb.CreateTable(sb.Table(tableName)).
+			Columns(columns...).
+			PartitionBy(sb.Function("toYYYYMMDDhhmmss",
+				sb.Function("toStartOfInterval", sb.Column("TimeReceived"),
+					sb.Interval(sb.Uint(partitionInterval), "second")))).
+			TTL(ttlExpr)
+		if resolution.Interval == 0 {
+			fiveMinutes := sb.Function("toStartOfFiveMinutes", sb.Column("TimeReceived"))
+			createQuery.
+				Engine(c.mergeTreeEngine(tableName, "")).
+				PrimaryKey(fiveMinutes).
+				OrderBy(slices.Concat([]sb.Expr{fiveMinutes},
+					sb.Columns("ExporterAddress", "InIfName", "OutIfName"))...)
+		} else {
+			createQuery.
+				Engine(c.mergeTreeEngine(tableName, "Summing",
+					sb.Tuple(sb.Columns("Bytes", "Packets")...))).
+				PrimaryKey(sb.Columns(c.d.Schema.ClickHousePrimaryKeys()...)...).
+				OrderBy(sb.Columns(c.d.Schema.ClickHouseSortingKeys()...)...)
+		}
+		for _, setting := range settings {
+			createQuery.Setting(setting.name, setting.expr())
+		}
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.String()); err != nil {
 			return fmt.Errorf("cannot create %s: %w", tableName, err)
 		}
 		if _, err := c.applySkipIndexes(ctx, tableName, resolution.Interval == 0); err != nil {
@@ -522,12 +487,16 @@ ORDER BY position ASC
 
 	// Plan for modifications. We don't check everything: we assume the
 	// modifications to be done are covered by the unit tests.
-	modifications := []string{}
+	alterQuery := sb.AlterTable(sb.Table(tableName))
 	previousColumn := ""
 outer:
 	for _, wantedColumn := range c.d.Schema.Columns() {
 		if resolution.Interval > 0 && wantedColumn.ClickHouseMainOnly {
 			continue
+		}
+		wantedDefinition, err := sb.ParseColumnDef(wantedColumn.ClickHouseDefinition())
+		if err != nil {
+			return fmt.Errorf("cannot parse the definition of column %s: %w", wantedColumn.Name, err)
 		}
 		// Check if the column already exists
 		for _, existingColumn := range existingColumns {
@@ -551,14 +520,13 @@ outer:
 					// either the column was an alias and should be none, or the other way around. Either way, we need to recreate.
 					c.r.Debug().Msg(fmt.Sprintf("column %s alias content has changed, recreating. New ALIAS: %s", existingColumn.Name, wantedColumn.ClickHouseAlias))
 					err := c.d.ClickHouse.ExecOnCluster(ctx,
-						fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableName, existingColumn.Name))
+						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name).String())
 					if err != nil {
 						return fmt.Errorf("cannot drop %s from %s to cleanup aliasing: %w",
 							existingColumn.Name, tableName, err)
 					}
 					// Schedule adding it back
-					modifications = append(modifications,
-						fmt.Sprintf("ADD COLUMN %s AFTER %s", wantedColumn.ClickHouseDefinition(), previousColumn))
+					alterQuery.AddColumn(wantedDefinition, previousColumn)
 				}
 
 				if resolution.Interval > 0 && slices.Contains(c.d.Schema.ClickHousePrimaryKeys(), wantedColumn.Name) && existingColumn.IsPrimaryKey == 0 {
@@ -568,17 +536,15 @@ outer:
 				if resolution.Interval > 0 && !wantedColumn.ClickHouseNotSortingKey && existingColumn.IsSortingKey == 0 {
 					// That's something we can fix, but we need to drop it before recreating it
 					err := c.d.ClickHouse.ExecOnCluster(ctx,
-						fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableName, existingColumn.Name))
+						sb.AlterTable(sb.Table(tableName)).DropColumn(existingColumn.Name).String())
 					if err != nil {
 						return fmt.Errorf("cannot drop %s from %s to fix ordering: %w",
 							existingColumn.Name, tableName, err)
 					}
 					// Schedule adding it back
-					modifications = append(modifications,
-						fmt.Sprintf("ADD COLUMN %s AFTER %s", wantedColumn.ClickHouseDefinition(), previousColumn))
+					alterQuery.AddColumn(wantedDefinition, previousColumn)
 				} else if modifyTypeOrCodec {
-					modifications = append(modifications,
-						fmt.Sprintf("MODIFY COLUMN %s", wantedColumn.ClickHouseDefinition()))
+					alterQuery.ModifyColumn(wantedDefinition)
 				}
 				previousColumn = wantedColumn.Name
 				continue outer
@@ -590,49 +556,49 @@ outer:
 				tableName, wantedColumn.Name)
 		}
 		c.r.Debug().Msgf("add missing column %s to %s", wantedColumn.Name, tableName)
-		modifications = append(modifications,
-			fmt.Sprintf("ADD COLUMN %s AFTER %s", wantedColumn.ClickHouseDefinition(), previousColumn))
+		alterQuery.AddColumn(wantedDefinition, previousColumn)
 		previousColumn = wantedColumn.Name
 	}
 	modified := false
-	if len(modifications) > 0 {
+	if alterQuery.Len() > 0 {
 		// Also update ORDER BY
 		if resolution.Interval > 0 {
-			modifications = append(modifications,
-				fmt.Sprintf("MODIFY ORDER BY (%s)", strings.Join(c.d.Schema.ClickHouseSortingKeys(), ", ")))
+			alterQuery.ModifyOrderBy(sb.Columns(c.d.Schema.ClickHouseSortingKeys()...)...)
 		}
-		c.r.Info().Msgf("apply %d modifications to %s", len(modifications), tableName)
+		c.r.Info().Msgf("apply %d modifications to %s", alterQuery.Len(), tableName)
 		if resolution.Interval > 0 {
 			// Drop the view
 			viewName := fmt.Sprintf("%s_consumer", tableName)
-			if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s SYNC`, viewName)); err != nil {
+			if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
 				return fmt.Errorf("cannot drop %s: %w", viewName, err)
 			}
 		}
-		err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("ALTER TABLE %s %s", tableName, strings.Join(modifications, ", ")))
-		if err != nil {
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterQuery.String()); err != nil {
 			return fmt.Errorf("cannot update table %s: %w", tableName, err)
 		}
 		modified = true
 	}
 
-	// Check if we need to update the settings
-	settingsClauseLike := fmt.Sprintf("CAST(engine_full LIKE '%% SETTINGS %s', 'String')",
-		strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(settings))
-	if ok, err := c.tableAlreadyExists(ctx, tableName, settingsClauseLike, "1"); err != nil {
+	// Check if we need to update the settings. They are the last part of the
+	// engine, so the pattern is not open on the right.
+	if ok, err := c.engineFullMatches(ctx, tableName,
+		fmt.Sprintf("%% SETTINGS %s", renderTableSettings(resolution.TableSettings))); err != nil {
 		return err
 	} else if !ok {
 		c.r.Info().Msgf("updating settings of %s to %s", tableName, resolution.Interval)
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf("ALTER TABLE %s MODIFY SETTING %s", tableName, settings)); err != nil {
+		alterSettings := sb.AlterTable(sb.Table(tableName))
+		for _, setting := range settings {
+			alterSettings.ModifySetting(setting.name, setting.expr())
+		}
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, alterSettings.String()); err != nil {
 			return fmt.Errorf("cannot modify settings for table %s: %w", tableName, err)
 		}
 		modified = true
 	}
 
 	// Check if we need to update the TTL
-	ttlClause := fmt.Sprintf("TTL TimeReceived + toIntervalSecond(%d)", ttl)
-	ttlClauseLike := fmt.Sprintf("CAST(engine_full LIKE '%% %s %%', 'String')", ttlClause)
-	if ok, err := c.tableAlreadyExists(ctx, tableName, ttlClauseLike, "1"); err != nil {
+	if ok, err := c.engineFullMatches(ctx, tableName,
+		fmt.Sprintf("%% TTL %s %%", ttlExpr)); err != nil {
 		return err
 	} else if !ok {
 		c.r.Info().Msgf("updating TTL of %s with interval %s", tableName, resolution.Interval)
@@ -640,7 +606,7 @@ outer:
 			clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 				"materialize_ttl_after_modify": 0,
 			})),
-			fmt.Sprintf("ALTER TABLE %s MODIFY %s", tableName, ttlClause))
+			sb.AlterTable(sb.Table(tableName)).ModifyTTL(ttlExpr).String())
 		if err != nil {
 			return fmt.Errorf("cannot modify TTL for table %s: %w", tableName, err)
 		}
@@ -661,12 +627,24 @@ outer:
 	return errSkipStep
 }
 
+// engineFullMatches tells if the engine of the table matches the provided LIKE
+// pattern. This is how the settings and the TTL of an existing table are
+// checked: they are not part of the create_table_query ClickHouse keeps.
+func (c *Component) engineFullMatches(ctx context.Context, tableName, pattern string) (bool, error) {
+	value, err := c.tableColumn(ctx, tableName,
+		fmt.Sprintf("CAST(engine_full LIKE %s, 'String')", sb.String(pattern)))
+	if err != nil {
+		return false, err
+	}
+	return value == "1", nil
+}
+
 // applySkipIndexes reconciles the skip indexes on tableName with the configured
 // schema indexes. It returns true if any change was made.
 func (c *Component) applySkipIndexes(ctx context.Context, tableName string, isMainTable bool) (bool, error) {
 	skipIndexes := c.d.Schema.GetSkipIndexes()
-	var toDrop []string
-	var toAdd []string
+	toDrop := sb.AlterTable(sb.Table(tableName))
+	toAdd := sb.AlterTable(sb.Table(tableName))
 
 	// Collect existing skip indexes.
 	existingIndexes := map[string]string{}
@@ -706,43 +684,43 @@ func (c *Component) applySkipIndexes(ctx context.Context, tableName string, isMa
 		if err != nil {
 			return false, fmt.Errorf("schema index for %s: %w", col.Name, err)
 		}
+		indexType, err := sb.ParseExpr(chType)
+		if err != nil {
+			return false, fmt.Errorf("schema index for %s: %w", col.Name, err)
+		}
 		idxName := fmt.Sprintf("idx_%s", strings.ToLower(col.Name))
 		wantedIndexNames[idxName] = struct{}{}
 
 		existingType := existingIndexes[idxName]
 		if existingType != "" && existingType != chType {
-			toDrop = append(toDrop, fmt.Sprintf("DROP INDEX %s", idxName))
+			toDrop.DropIndex(idxName)
 		}
 		if existingType == "" || existingType != chType {
-			toAdd = append(toAdd, fmt.Sprintf("ADD INDEX %s %s TYPE %s GRANULARITY 4", idxName, col.Name, chType))
+			toAdd.AddIndex(idxName, sb.Column(col.Name), indexType, 4)
 		}
 	}
 
 	// Drop stale skip indexes that are no longer wanted.
 	for name := range existingIndexes {
 		if _, wanted := wantedIndexNames[name]; !wanted {
-			toDrop = append(toDrop, fmt.Sprintf("DROP INDEX %s", name))
+			toDrop.DropIndex(name)
 		}
 	}
 
-	if len(toDrop) == 0 && len(toAdd) == 0 {
+	if toDrop.Len() == 0 && toAdd.Len() == 0 {
 		return false, nil
 	}
 
 	// Batch drops before adds (drop must precede re-add when type changes).
-	if len(toDrop) > 0 {
-		c.r.Info().Msgf("removing %d skip index(es) from %s", len(toDrop), tableName)
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(
-			"ALTER TABLE %s %s", tableName, strings.Join(toDrop, ", "),
-		)); err != nil {
+	if toDrop.Len() > 0 {
+		c.r.Info().Msgf("removing %d skip index(es) from %s", toDrop.Len(), tableName)
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, toDrop.String()); err != nil {
 			return false, fmt.Errorf("cannot drop skip indexes on %s: %w", tableName, err)
 		}
 	}
-	if len(toAdd) > 0 {
-		c.r.Info().Msgf("adding %d skip index(es) to %s", len(toAdd), tableName)
-		if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(
-			"ALTER TABLE %s %s", tableName, strings.Join(toAdd, ", "),
-		)); err != nil {
+	if toAdd.Len() > 0 {
+		c.r.Info().Msgf("adding %d skip index(es) to %s", toAdd.Len(), tableName)
+		if err := c.d.ClickHouse.ExecOnCluster(ctx, toAdd.String()); err != nil {
 			return false, fmt.Errorf("cannot add skip indexes on %s: %w", tableName, err)
 		}
 	}
@@ -758,22 +736,19 @@ func (c *Component) createFlowsConsumerView(ctx context.Context, resolution Reso
 	viewName := fmt.Sprintf("%s_consumer", tableName)
 
 	// Build SELECT query
-	selectQuery, err := stemplate(`
-SELECT
- toStartOfInterval(TimeReceived, toIntervalSecond({{ .Seconds }})) AS TimeReceived,
- {{ .Columns }}
-FROM {{ .Database }}.{{ .Table }}`, helpers.M{
-		"Database": clickhousedb.QuoteIdentifier(c.d.ClickHouse.DatabaseName()),
-		"Table":    c.localTable("flows"),
-		"Seconds":  uint64(resolution.Interval.Seconds()),
-		"Columns": strings.Join(c.d.Schema.ClickHouseSelectColumns(
-			schema.ClickHouseSkipTimeReceived,
-			schema.ClickHouseSkipMainOnlyColumns,
-			schema.ClickHouseSkipAliasedColumns), ",\n "),
-	})
+	columns, err := sb.ParseExprs(c.d.Schema.ClickHouseSelectColumns(
+		schema.ClickHouseSkipTimeReceived,
+		schema.ClickHouseSkipMainOnlyColumns,
+		schema.ClickHouseSkipAliasedColumns))
 	if err != nil {
 		return fmt.Errorf("cannot build select statement for consumer %s: %w", viewName, err)
 	}
+	items := slices.Concat([]sb.Expr{
+		sb.Alias(sb.Function("toStartOfInterval", sb.Column("TimeReceived"),
+			sb.Function("toIntervalSecond", sb.Uint(uint64(resolution.Interval.Seconds())))),
+			"TimeReceived"),
+	}, columns)
+	selectQuery := sb.Select(items...).From(c.table(c.localTable("flows")))
 
 	// Check the existing one
 	if ok, err := c.tableAlreadyExists(ctx, viewName, "as_select", selectQuery); err != nil {
@@ -785,12 +760,12 @@ FROM {{ .Database }}.{{ .Table }}`, helpers.M{
 
 	// Drop and create
 	c.r.Info().Msgf("create %s", viewName)
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s SYNC`, viewName)); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.DropTable(sb.Table(viewName)).String()); err != nil {
 		return fmt.Errorf("cannot drop table %s: %w", viewName, err)
 	}
-	if err := c.d.ClickHouse.ExecOnCluster(ctx,
-		fmt.Sprintf(`CREATE MATERIALIZED VIEW %s TO %s AS %s`, viewName,
-			c.localTable(tableName), selectQuery)); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, sb.CreateMaterializedView(
+		sb.Table(viewName), sb.Table(c.localTable(tableName)),
+		selectQuery).String()); err != nil {
 		return fmt.Errorf("cannot create %s: %w", viewName, err)
 	}
 	return nil
@@ -819,6 +794,7 @@ ORDER BY position ASC
 `, c.d.ClickHouse.DatabaseName(), c.localTable(source)); err != nil {
 		return fmt.Errorf("cannot query columns table: %w", err)
 	}
+	// The columns are copied from the local table as ClickHouse writes them.
 	cols := []string{}
 	for _, column := range existingColumns {
 		col := fmt.Sprintf("`%s` %s", column.Name, column.Type)
@@ -830,22 +806,19 @@ ORDER BY position ASC
 		}
 		cols = append(cols, col)
 	}
+	columns, err := sb.ParseColumnDefs(strings.Join(cols, ", "))
+	if err != nil {
+		return fmt.Errorf("cannot parse the schema of %s: %w", c.localTable(source), err)
+	}
 
 	// Build the CREATE TABLE
-	createQuery, err := stemplate(
-		`CREATE TABLE {{ qi .Database }}.{{ qi .Target }}
-({{ .Schema }})
-ENGINE = Distributed({{ qs .Cluster }}, {{ qs .Database }}, {{ qs .Source }}, rand())`,
-		helpers.M{
-			"Database": c.d.ClickHouse.DatabaseName(),
-			"Cluster":  c.d.ClickHouse.ClusterName(),
-			"Source":   c.localTable(source),
-			"Target":   c.distributedTable(source),
-			"Schema":   strings.Join(cols, ", "),
-		})
-	if err != nil {
-		return fmt.Errorf("cannot build query to create exporters view: %w", err)
-	}
+	createQuery := sb.CreateTable(c.table(c.distributedTable(source))).
+		Columns(columns...).
+		Engine(sb.NewEngine("Distributed",
+			sb.String(c.d.ClickHouse.ClusterName()),
+			sb.String(c.d.ClickHouse.DatabaseName()),
+			sb.String(c.localTable(source)),
+			sb.Function("rand")))
 
 	// Check if the table already exists
 	if ok, err := c.tableAlreadyExists(ctx, c.distributedTable(source), "create_table_query", createQuery); err != nil {
@@ -857,11 +830,10 @@ ENGINE = Distributed({{ qs .Cluster }}, {{ qs .Database }}, {{ qs .Source }}, ra
 
 	// Recreate the table
 	c.r.Info().Msgf("create %s", c.distributedTable(source))
-	createOrReplaceQuery := strings.Replace(createQuery, "CREATE ", "CREATE OR REPLACE ", 1)
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"allow_suspicious_low_cardinality_types": 1,
 	}))
-	if err := c.d.ClickHouse.ExecOnCluster(ctx, createOrReplaceQuery); err != nil {
+	if err := c.d.ClickHouse.ExecOnCluster(ctx, createQuery.OrReplace().String()); err != nil {
 		return fmt.Errorf("cannot create %s: %w", c.distributedTable(source), err)
 	}
 	return nil

--- a/orchestrator/clickhouse/migrations_test.go
+++ b/orchestrator/clickhouse/migrations_test.go
@@ -27,6 +27,7 @@ import (
 	"akvorado/common/httpserver"
 	"akvorado/common/reporter"
 	"akvorado/common/schema"
+	sb "akvorado/common/sqlbuilder"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -92,7 +93,7 @@ func dumpAllTables(t *testing.T, ch *clickhousedb.Component, schemaComponent *sc
 }
 
 func dropAllTables(t *testing.T, ch *clickhousedb.Component) {
-	db := clickhousedb.QuoteIdentifier(ch.DatabaseName())
+	db := sb.QuoteIdentifier(ch.DatabaseName())
 	t.Logf("(%s) Drop database %s", time.Now(), db)
 	for _, sql := range []string{
 		fmt.Sprintf("DROP DATABASE IF EXISTS %s SYNC", db),
@@ -866,23 +867,5 @@ func TestRenderTableSettings(t *testing.T) {
 				t.Fatalf("renderTableSettings() (-got, +want):\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestQuoteString(t *testing.T) {
-	cases := []struct {
-		s        string
-		expected string
-	}{
-		{"nothing", "'nothing'"},
-		{`"hello world"`, `'\"hello world\"'`},
-		{`he's happy`, `'he\'s happy'`},
-		{`mix "everything' \"`, `'mix \"everything\' \\\"'`},
-	}
-	for _, tc := range cases {
-		got := quoteString(tc.s)
-		if diff := helpers.Diff(got, tc.expected); diff != "" {
-			t.Errorf("quoteString(%q) (-got, +want):\n%s", tc.s, diff)
-		}
 	}
 }

--- a/orchestrator/clickhouse/migrations_test.go
+++ b/orchestrator/clickhouse/migrations_test.go
@@ -30,6 +30,7 @@ import (
 	sb "akvorado/common/sqlbuilder"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"golang.org/x/sync/errgroup"
 )
 
 // dictionaryServerURL returns the URL of a shared HTTP server that returns
@@ -93,14 +94,14 @@ func dumpAllTables(t *testing.T, ch *clickhousedb.Component, schemaComponent *sc
 }
 
 func dropAllTables(t *testing.T, ch *clickhousedb.Component) {
-	db := sb.QuoteIdentifier(ch.DatabaseName())
-	t.Logf("(%s) Drop database %s", time.Now(), db)
-	for _, sql := range []string{
-		fmt.Sprintf("DROP DATABASE IF EXISTS %s SYNC", db),
-		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", db),
+	database := ch.DatabaseName()
+	t.Logf("(%s) Drop database %s", time.Now(), database)
+	for _, statement := range []sb.Statement{
+		sb.DropDatabase(database),
+		sb.CreateDatabase(database),
 	} {
-		if err := ch.ExecOnCluster(t.Context(), sql); err != nil {
-			t.Fatalf("Exec(%q) error:\n%+v", sql, err)
+		if err := ch.ExecOnCluster(t.Context(), statement); err != nil {
+			t.Fatalf("Exec(%q) error:\n%+v", statement, err)
 		}
 	}
 }
@@ -149,15 +150,42 @@ func loadTables(t *testing.T, ch *clickhousedb.Component, sch *schema.Component,
 		return 0
 	})
 
+	// The schemas are the SQL ClickHouse wrote back: they take no ON CLUSTER
+	// clause, so each server gets them as is.
+	conns := connectToEachServer(t, ch)
 	for _, tws := range tables {
 		if isOldTable(sch, tws.Table) {
 			continue
 		}
 		t.Logf("Load table %s", tws.Table)
-		if err := ch.ExecOnCluster(ctx, tws.Schema); err != nil {
+		var loading errgroup.Group
+		for _, conn := range conns {
+			loading.Go(func() error { return conn.Exec(ctx, tws.Schema) })
+		}
+		if err := loading.Wait(); err != nil {
 			t.Fatalf("Exec(%q) error:\n%+v", tws.Schema, err)
 		}
 	}
+}
+
+// connectToEachServer opens a connection to each server the component talks to.
+// The connection of the component only picks one server for each query.
+func connectToEachServer(t *testing.T, ch *clickhousedb.Component) []clickhouse.Conn {
+	t.Helper()
+	servers := ch.Servers()
+	conns := make([]clickhouse.Conn, 0, len(servers))
+	for _, server := range servers {
+		conn, err := clickhouse.Open(&clickhouse.Options{
+			Addr:        []string{server},
+			DialTimeout: 5 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("clickhouse.Open(%q) error:\n%+v", server, err)
+		}
+		t.Cleanup(func() { conn.Close() })
+		conns = append(conns, conn)
+	}
+	return conns
 }
 
 // loadAllTables load tables from a CSV file. Use `format CSV` with


### PR DESCRIPTION
And use it for the console. This is a pretty big change. Notably, the
PEG parser now handles expressions instead of strings. And instead of
concatenating strings to build SQL queries, we use a more type-safe
alternative.

It could be useful to reverse the direction, but no Clone() method is
exposed, so it does not seem worth it.

Tests are only slightly modified, so it's invisible to the user.

Fix #2389 (at least, partially, it would be needed for migrations as
well, but the use of concatenation is smaller).

There are other commits before that would be worth their own PR, notably the build of the SQL request in one pass.

I need to also update the migrations to use this builder as well, but the parser has some limitations that need to be worked around.