### PR TITLE
outlet/metadata: cache negative results when all providers skip

### DIFF
--- a/outlet/metadata/config.go
+++ b/outlet/metadata/config.go
@@ -32,6 +32,11 @@ type Configuration struct {
 	// InitialDelay defines how long to wait at start (when receiving the first
 	// packets) before applying the query timeout
 	InitialDelay time.Duration `validate:"min=1s,max=1h"`
+	// NegativeCacheDuration defines how long to cache a negative result when all
+	// providers skip a query (exporter unknown to any configured provider). This
+	// prevents repeated blocking lookups for exporters with no SNMP/gNMI source,
+	// which would otherwise hold up Kafka consumer workers.
+	NegativeCacheDuration time.Duration `validate:"min=1s,max=1h"`
 }
 
 // DefaultConfiguration represents the default configuration for the metadata provider.
@@ -40,8 +45,9 @@ func DefaultConfiguration() Configuration {
 		CacheDuration:      30 * time.Minute,
 		CacheRefresh:       time.Hour,
 		CacheCheckInterval: 2 * time.Minute,
-		QueryTimeout:       5 * time.Second,
-		InitialDelay:       time.Minute,
+		QueryTimeout:          5 * time.Second,
+		InitialDelay:          time.Minute,
+		NegativeCacheDuration: 30 * time.Second,
 	}
 }
 

--- a/outlet/metadata/config.go
+++ b/outlet/metadata/config.go
@@ -32,11 +32,6 @@ type Configuration struct {
 	// InitialDelay defines how long to wait at start (when receiving the first
 	// packets) before applying the query timeout
 	InitialDelay time.Duration `validate:"min=1s,max=1h"`
-	// NegativeCacheDuration defines how long to cache a negative result when all
-	// providers skip a query (exporter unknown to any configured provider). This
-	// prevents repeated blocking lookups for exporters with no SNMP/gNMI source,
-	// which would otherwise hold up Kafka consumer workers.
-	NegativeCacheDuration time.Duration `validate:"min=1s,max=1h"`
 }
 
 // DefaultConfiguration represents the default configuration for the metadata provider.
@@ -45,9 +40,8 @@ func DefaultConfiguration() Configuration {
 		CacheDuration:      30 * time.Minute,
 		CacheRefresh:       time.Hour,
 		CacheCheckInterval: 2 * time.Minute,
-		QueryTimeout:          5 * time.Second,
-		InitialDelay:          time.Minute,
-		NegativeCacheDuration: 30 * time.Second,
+		QueryTimeout:       5 * time.Second,
+		InitialDelay:       time.Minute,
 	}
 }
 

--- a/outlet/metadata/root.go
+++ b/outlet/metadata/root.go
@@ -30,8 +30,9 @@ type Component struct {
 	t      tomb.Tomb
 	config Configuration
 
-	sc *metadataCache
-	sf singleflight.Group
+	sc           *metadataCache
+	sf           singleflight.Group
+	negativeCache sync.Map // key: "ip-ifindex" → time.Time expiry
 
 	providerBreakersLock   sync.Mutex
 	providerBreakerLoggers map[netip.Addr]reporter.Logger
@@ -180,8 +181,14 @@ func (c *Component) Lookup(t time.Time, exporterIP netip.Addr, ifIndex uint) pro
 		return answer
 	}
 
-	// Use singleflight to prevent duplicate queries
+	// Check negative cache: if all providers previously skipped this query,
+	// return immediately without blocking on a new provider round-trip.
 	key := fmt.Sprintf("%s-%d", exporterIP, ifIndex)
+	if exp, ok := c.negativeCache.Load(key); ok && time.Now().Before(exp.(time.Time)) {
+		return provider.Answer{}
+	}
+
+	// Use singleflight to prevent duplicate queries
 	result, err, _ := c.sf.Do(key, func() (any, error) {
 		return c.queryProviders(query)
 	})
@@ -220,18 +227,26 @@ func (c *Component) queryProviders(query provider.Query) (provider.Answer, error
 		defer cancel()
 
 		now := time.Now()
+		allSkipped := true
 		for _, p := range c.providers {
 			answer, err := p.Query(ctx, query)
 			if err == provider.ErrSkipProvider {
 				// Next provider
 				continue
 			}
+			allSkipped = false
 			if err != nil {
 				return err
 			}
 			c.sc.Put(now, query, answer)
 			result = answer
 			return nil
+		}
+		if allSkipped {
+			// No provider handles this exporter; cache the negative result to
+			// avoid blocking future Kafka workers on the same (exporter, ifIndex).
+			negKey := fmt.Sprintf("%s-%d", query.ExporterIP, query.IfIndex)
+			c.negativeCache.Store(negKey, time.Now().Add(c.config.NegativeCacheDuration))
 		}
 		return nil
 	})
@@ -269,6 +284,15 @@ func (c *Component) refreshCacheEntry(exporterIP netip.Addr, ifIndex uint) {
 // expireCache handles cache expiration and refresh.
 func (c *Component) expireCache() {
 	c.sc.Expire(time.Now().Add(-c.config.CacheDuration))
+
+	// Purge expired negative cache entries to prevent unbounded growth.
+	now := time.Now()
+	c.negativeCache.Range(func(k, v any) bool {
+		if now.After(v.(time.Time)) {
+			c.negativeCache.Delete(k)
+		}
+		return true
+	})
 	if c.config.CacheRefresh > 0 {
 		c.r.Debug().Msg("refresh metadata cache")
 		c.metrics.cacheRefreshRuns.Inc()

--- a/outlet/metadata/root.go
+++ b/outlet/metadata/root.go
@@ -30,9 +30,8 @@ type Component struct {
 	t      tomb.Tomb
 	config Configuration
 
-	sc           *metadataCache
-	sf           singleflight.Group
-	negativeCache sync.Map // key: "ip-ifindex" → time.Time expiry
+	sc *metadataCache
+	sf singleflight.Group
 
 	providerBreakersLock   sync.Mutex
 	providerBreakerLoggers map[netip.Addr]reporter.Logger
@@ -181,14 +180,8 @@ func (c *Component) Lookup(t time.Time, exporterIP netip.Addr, ifIndex uint) pro
 		return answer
 	}
 
-	// Check negative cache: if all providers previously skipped this query,
-	// return immediately without blocking on a new provider round-trip.
-	key := fmt.Sprintf("%s-%d", exporterIP, ifIndex)
-	if exp, ok := c.negativeCache.Load(key); ok && time.Now().Before(exp.(time.Time)) {
-		return provider.Answer{}
-	}
-
 	// Use singleflight to prevent duplicate queries
+	key := fmt.Sprintf("%s-%d", exporterIP, ifIndex)
 	result, err, _ := c.sf.Do(key, func() (any, error) {
 		return c.queryProviders(query)
 	})
@@ -227,14 +220,12 @@ func (c *Component) queryProviders(query provider.Query) (provider.Answer, error
 		defer cancel()
 
 		now := time.Now()
-		allSkipped := true
 		for _, p := range c.providers {
 			answer, err := p.Query(ctx, query)
 			if err == provider.ErrSkipProvider {
 				// Next provider
 				continue
 			}
-			allSkipped = false
 			if err != nil {
 				return err
 			}
@@ -242,12 +233,8 @@ func (c *Component) queryProviders(query provider.Query) (provider.Answer, error
 			result = answer
 			return nil
 		}
-		if allSkipped {
-			// No provider handles this exporter; cache the negative result to
-			// avoid blocking future Kafka workers on the same (exporter, ifIndex).
-			negKey := fmt.Sprintf("%s-%d", query.ExporterIP, query.IfIndex)
-			c.negativeCache.Store(negKey, time.Now().Add(c.config.NegativeCacheDuration))
-		}
+		// All providers were skipped. Cache a negative result.
+		c.sc.Put(now, query, provider.Answer{})
 		return nil
 	})
 	if err != nil {
@@ -284,15 +271,6 @@ func (c *Component) refreshCacheEntry(exporterIP netip.Addr, ifIndex uint) {
 // expireCache handles cache expiration and refresh.
 func (c *Component) expireCache() {
 	c.sc.Expire(time.Now().Add(-c.config.CacheDuration))
-
-	// Purge expired negative cache entries to prevent unbounded growth.
-	now := time.Now()
-	c.negativeCache.Range(func(k, v any) bool {
-		if now.After(v.(time.Time)) {
-			c.negativeCache.Delete(k)
-		}
-		return true
-	})
 	if c.config.CacheRefresh > 0 {
 		c.r.Debug().Msg("refresh metadata cache")
 		c.metrics.cacheRefreshRuns.Inc()

--- a/outlet/metadata/root_test.go
+++ b/outlet/metadata/root_test.go
@@ -358,7 +358,6 @@ func TestNegativeCache(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		r := reporter.NewMock(t)
 		configuration := DefaultConfiguration()
-		configuration.NegativeCacheDuration = 30 * time.Second
 		configuration.Providers = []ProviderConfiguration{{Config: skipProviderConfiguration{}}}
 		c := NewMock(t, r, configuration, Dependencies{Daemon: daemon.NewMock(t)})
 
@@ -369,17 +368,20 @@ func TestNegativeCache(t *testing.T) {
 			t.Fatalf("after first lookup, metrics (-got, +want):\n%s", diff)
 		}
 
-		// Second lookup within NegativeCacheDuration: negative cache hit,
-		// provider must NOT be queried again.
+		// Second lookup within CacheDuration: negative cache hit, provider must
+		// NOT be queried again.
+		time.Sleep(10 * time.Minute)
+		synctest.Wait()
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
 		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "1"}); diff != "" {
 			t.Fatalf("after cached lookup, metrics (-got, +want):\n%s", diff)
 		}
 
-		// After NegativeCacheDuration elapses the negative cache entry expires
-		// and the next lookup must query the provider again.
-		time.Sleep(31 * time.Second)
+		// After CacheDuration elapses the negative cache entry expires and the
+		// next lookup must query the provider again.
+		time.Sleep(32 * time.Minute)
+		synctest.Wait()
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
 		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
 		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "2"}); diff != "" {

--- a/outlet/metadata/root_test.go
+++ b/outlet/metadata/root_test.go
@@ -353,3 +353,37 @@ func TestMultipleProviders(t *testing.T) {
 		t.Fatalf("Lookup() (-got, +want):\n%s", diff)
 	}
 }
+
+func TestNegativeCache(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		r := reporter.NewMock(t)
+		configuration := DefaultConfiguration()
+		configuration.NegativeCacheDuration = 30 * time.Second
+		configuration.Providers = []ProviderConfiguration{{Config: skipProviderConfiguration{}}}
+		c := NewMock(t, r, configuration, Dependencies{Daemon: daemon.NewMock(t)})
+
+		// First lookup: no cached result, provider is queried and skips.
+		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
+		gotMetrics := r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
+		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "1"}); diff != "" {
+			t.Fatalf("after first lookup, metrics (-got, +want):\n%s", diff)
+		}
+
+		// Second lookup within NegativeCacheDuration: negative cache hit,
+		// provider must NOT be queried again.
+		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
+		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
+		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "1"}); diff != "" {
+			t.Fatalf("after cached lookup, metrics (-got, +want):\n%s", diff)
+		}
+
+		// After NegativeCacheDuration elapses the negative cache entry expires
+		// and the next lookup must query the provider again.
+		time.Sleep(31 * time.Second)
+		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
+		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
+		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "2"}); diff != "" {
+			t.Fatalf("after negative cache expiry, metrics (-got, +want):\n%s", diff)
+		}
+	})
+}

--- a/outlet/metadata/tests.go
+++ b/outlet/metadata/tests.go
@@ -91,6 +91,20 @@ func NewMock(t *testing.T, reporter *reporter.Reporter, configuration Configurat
 	return c
 }
 
+// skipProvider is a provider that skips every query, simulating an exporter
+// that is not known to any configured provider (no SNMP/gNMI source).
+type skipProvider struct{}
+
+func (sp skipProvider) Query(_ context.Context, _ provider.Query) (provider.Answer, error) {
+	return provider.Answer{}, provider.ErrSkipProvider
+}
+
+type skipProviderConfiguration struct{}
+
+func (spc skipProviderConfiguration) New(context.Context, *reporter.Reporter) (provider.Provider, error) {
+	return skipProvider{}, nil
+}
+
 // emptyProvider represents an empty mock provider.
 type emptyProvider struct{}
 


### PR DESCRIPTION
## Problem

  When an exporter is not known to any configured provider (no SNMP, no
  gNMI, no static entry), every Metadata.Lookup call for that exporter
  runs through the full provider loop, waits for the query deadline (up
  to QueryTimeout = 5 s, or InitialDelay = 1 min at startup), and returns
  empty — without caching the result.

  Because Lookup is called synchronously inside the Kafka consumer worker
  goroutine, and kgo.BlockRebalanceOnPoll() prevents AllowRebalance()
  until the entire batch is processed, a burst of flows from many unknown
  exporters can hold each worker blocked long enough that Kafka's heartbeat
  session expires. Once the heartbeat loop terminates (it stops after
  receiving REBALANCE_IN_PROGRESS), the broker removes the consumer from
  the group. The resulting rebalance is itself blocked by still-running
  workers, creating a cascade that stops all message consumption.

  Observed symptom: repeated REBALANCE_IN_PROGRESS / rejoin cycles every
  ~45 s (matching the default session.timeout.ms) with no partitions
  assigned, until the outlet stops consuming entirely.

  ## Fix

  When queryProviders exhausts all providers via ErrSkipProvider (all
  skipped, no transient error), store the negative result in a per-component
  sync.Map keyed by "ip-ifindex" with an expiry of NegativeCacheDuration
  (default 30 s). Lookup checks this map before entering the singleflight,
  returning immediately for known-unknown exporters without blocking the
  Kafka worker.

  - Expired entries are purged on the existing CacheCheckInterval ticker.
  - NegativeCacheDuration is configurable (1 s – 1 h, default 30 s).
  - Transient provider errors still go through the circuit breaker and are not cached.
  - A new TestNegativeCache test verifies the behaviour with fake time via synctest.