### PR TITLE
Fix: qualify ClickHouse dictionary names in generated SQL queries

### DIFF
--- a/cmd/akvorado/console.go
+++ b/cmd/akvorado/console.go
@@ -109,6 +109,7 @@ func consoleStart(r *reporter.Reporter, config ConsoleConfiguration, checkOnly b
 	if err != nil {
 		return fmt.Errorf("unable to initialize schema component: %w", err)
 	}
+	schemaComponent.DatabaseName = clickhouseComponent.DatabaseName()
 	consoleComponent, err := console.New(r, config.Console, console.Dependencies{
 		Daemon:       daemonComponent,
 		HTTP:         httpComponent,

--- a/cmd/akvorado/orchestrator.go
+++ b/cmd/akvorado/orchestrator.go
@@ -199,6 +199,7 @@ func orchestratorStart(r *reporter.Reporter, config OrchestratorConfiguration, d
 	if err != nil {
 		return fmt.Errorf("unable to initialize ClickHouse component: %w", err)
 	}
+	schemaComponent.DatabaseName = clickhouseDBComponent.DatabaseName()
 	clickhouseComponent, err := clickhouse.New(r, config.ClickHouse, clickhouse.Dependencies{
 		Daemon:     daemonComponent,
 		HTTP:       httpComponent,

--- a/common/schema/definition.go
+++ b/common/schema/definition.go
@@ -129,6 +129,18 @@ const (
 	DictionaryUDP string = "udp"
 )
 
+// DictionaryName returns the dictionary name qualified with the database
+// name (e.g. "akvorado.asns") when DatabaseName is set. Otherwise, it
+// returns the unqualified name. Qualification is needed for ClickHouse
+// clusters using the Distributed engine, where remote shard nodes may
+// not resolve unqualified dictionary names.
+func (sc *Component) DictionaryName(name string) string {
+	if sc.DatabaseName != "" {
+		return sc.DatabaseName + "." + name
+	}
+	return name
+}
+
 // revive:disable
 const (
 	ColumnTimeReceived ColumnKey = iota + 1

--- a/common/schema/root.go
+++ b/common/schema/root.go
@@ -21,6 +21,11 @@ type Component struct {
 	c Configuration
 
 	Schema
+
+	// DatabaseName is the ClickHouse database name, used to qualify
+	// dictionary references in generated SQL queries. It is set by the
+	// orchestrator and console components after initialization.
+	DatabaseName string
 }
 
 // New creates a new schema component.

--- a/console/filter.go
+++ b/console/filter.go
@@ -276,12 +276,12 @@ SELECT label, detail FROM (
  LIMIT %d
 UNION DISTINCT
  SELECT concat('AS', toString(asn)) AS label, name AS detail, 2 AS rank
- FROM asns
+ FROM %s
  WHERE positionCaseInsensitive(name, $1) >= 1
  ORDER BY positionCaseInsensitive(name, $1) ASC, asn ASC
  LIMIT %d
 ) GROUP BY label, detail ORDER BY MIN(rank) ASC, MIN(rowNumberInBlock()) ASC LIMIT %d`,
-				columnName, schema.DictionaryASNs, columnName, columnName, input.Limit, input.Limit, input.Limit)
+				columnName, c.d.Schema.DictionaryName(schema.DictionaryASNs), columnName, columnName, input.Limit, c.d.Schema.DictionaryName(schema.DictionaryASNs), input.Limit, input.Limit)
 			if err := c.d.ClickHouseDB.Conn.Select(ctx, &results, sqlQuery, input.Prefix); err != nil {
 				c.r.Err(err).Msg("unable to query database")
 				break
@@ -315,13 +315,13 @@ SELECT label, detail FROM (
 UNION DISTINCT
  SELECT toString(port) AS label, name AS detail, 2 AS rank, 0 AS c
  FROM (
-  SELECT port, name FROM tcp UNION DISTINCT SELECT port, name FROM tcp
+  SELECT port, name FROM %s UNION DISTINCT SELECT port, name FROM %s
  )
  WHERE positionCaseInsensitive(name, $1) >= 1
  ORDER BY positionCaseInsensitive(name, $1) ASC, port ASC
  LIMIT %d
 ) GROUP BY rank, label, detail ORDER BY rank ASC, MAX(c) DESC, MIN(rowNumberInBlock()) ASC LIMIT %d`,
-				columnName, schema.DictionaryTCP, columnName, schema.DictionaryUDP, columnName, columnName, input.Limit, input.Limit, input.Limit,
+				columnName, c.d.Schema.DictionaryName(schema.DictionaryTCP), columnName, c.d.Schema.DictionaryName(schema.DictionaryUDP), columnName, columnName, input.Limit, c.d.Schema.DictionaryName(schema.DictionaryTCP), c.d.Schema.DictionaryName(schema.DictionaryUDP), input.Limit, input.Limit,
 			)
 			if err := c.d.ClickHouseDB.Select(ctx, &results, sqlQuery, input.Prefix); err != nil {
 				c.r.Err(err).Msg("unable to query database")

--- a/console/filter/helpers.go
+++ b/console/filter/helpers.go
@@ -231,10 +231,12 @@ func (c *current) ipOrSubnetCondition(col schema.Column, operator string, items 
 // protocolName turns a protocol number into its name, so a filter can compare
 // it with a string. An unknown protocol becomes "???", like in the columns the
 // console displays.
-func protocolName(proto sb.Expr) sb.Expr {
-	return sb.Function("dictGetOrDefault",
-		sb.String(schema.DictionaryProtocols), sb.String("name"),
-		proto, sb.String("???"))
+func protocolName(sch *schema.Component) func(sb.Expr) sb.Expr {
+	return func(proto sb.Expr) sb.Expr {
+		return sb.Function("dictGetOrDefault",
+			sb.String(sch.DictionaryName(schema.DictionaryProtocols)), sb.String("name"),
+			proto, sb.String("???"))
+	}
 }
 
 // macToNum turns a MAC address into its numeric form.

--- a/console/filter/parser.peg
+++ b/console/filter/parser.peg
@@ -261,7 +261,7 @@ ConditionProtoStrExpr "condition on protocol as string" ←
             { return c.acceptColumn() }) _
  rcond:RConditionProtoStrExpr {
   return rcond.(condition).apply(c.column(column.(schema.Column)).
-    Apply(protocolName)), nil
+    Apply(protocolName(c.meta().Schema))), nil
 }
 RConditionProtoStrExpr "condition on protocol as string" ←
    operator:("=" / "!=") _ value:StringLiteral {

--- a/console/filter_test.go
+++ b/console/filter_test.go
@@ -166,7 +166,7 @@ SELECT label, detail FROM (
 UNION DISTINCT
  SELECT toString(port) AS label, name AS detail, 2 AS rank, 0 AS c
  FROM (
-  SELECT port, name FROM tcp UNION DISTINCT SELECT port, name FROM tcp
+  SELECT port, name FROM tcp UNION DISTINCT SELECT port, name FROM udp
  )
  WHERE positionCaseInsensitive(name, $1) >= 1
  ORDER BY positionCaseInsensitive(name, $1) ASC, port ASC

--- a/console/query/column.go
+++ b/console/query/column.go
@@ -111,7 +111,7 @@ func (qc Column) ToSQLSelect(sch *schema.Component) sb.Expr {
 		return sb.Function("concat",
 			sb.Function("toString", self),
 			sb.String(": "),
-			self.Apply(DictionaryName(schema.DictionaryASNs, "???")))
+			self.Apply(DictionaryName(sch, schema.DictionaryASNs, "???")))
 	case schema.ColumnInIfBoundary, schema.ColumnOutIfBoundary:
 		return sb.Function("toString", self)
 	case schema.ColumnEType:
@@ -124,7 +124,7 @@ func (qc Column) ToSQLSelect(sch *schema.Component) sb.Expr {
 				sb.String("IPv6"),
 				sb.String("???")))
 	case schema.ColumnProto:
-		return self.Apply(DictionaryName(schema.DictionaryProtocols, "???"))
+		return self.Apply(DictionaryName(sch, schema.DictionaryProtocols, "???"))
 	case schema.ColumnMPLSLabels, schema.ColumnDstASPath:
 		return sb.Function("arrayStringConcat", self, sb.String(" "))
 	case schema.ColumnSrcCommunities, schema.ColumnDstCommunities:
@@ -165,7 +165,7 @@ func (qc Column) ToSQLSelect(sch *schema.Component) sb.Expr {
 			return sb.Function("concat",
 				sb.Function("toString", self),
 				sb.String("/"),
-				self.Apply(DictionaryName(dictionary, "")))
+				self.Apply(DictionaryName(sch, dictionary, "")))
 		}
 		// The port may have no name in the dictionary, in which case the
 		// trailing slash is dropped.
@@ -193,11 +193,12 @@ func (qc Column) ToSQLSelect(sch *schema.Component) sb.Expr {
 }
 
 // DictionaryName looks up the name matching a key in a ClickHouse dictionary.
-// When the key is unknown, the fallback is used instead.
-func DictionaryName(dictionary, fallback string) func(sb.Expr) sb.Expr {
+// When the key is unknown, the fallback is used instead. The dictionary
+// name is qualified with the database name from the schema component.
+func DictionaryName(sch *schema.Component, dictionary, fallback string) func(sb.Expr) sb.Expr {
 	return func(key sb.Expr) sb.Expr {
 		return sb.Function("dictGetOrDefault",
-			sb.String(dictionary), sb.String("name"),
+			sb.String(sch.DictionaryName(dictionary)), sb.String("name"),
 			key, sb.String(fallback))
 	}
 }

--- a/console/widgets.go
+++ b/console/widgets.go
@@ -145,7 +145,7 @@ func (c *Component) widgetTopHandlerFunc(w http.ResponseWriter, req *http.Reques
 		mainTableRequired bool
 	)
 	dictName := func(dictionary string, column string) sb.Expr {
-		return sb.Column(column).Apply(query.DictionaryName(dictionary, "???"))
+		return sb.Column(column).Apply(query.DictionaryName(c.d.Schema, dictionary, "???"))
 	}
 
 	rawName := req.PathValue("name")


### PR DESCRIPTION
## Problem

When Akvorado runs against a ClickHouse cluster using the `Distributed` engine, queries forwarded to remote shard nodes fail with:

```
Dictionary (`asns`) not found
```

This happens because `dictGetOrDefault('asns', ...)` uses unqualified dictionary names. The ClickHouse Go driver sets the default database via `Auth.Database` for the client connection, but the `Distributed` engine opens its own internal connections to remote nodes where the default database may differ. The unqualified dictionary name cannot be resolved in that context.

## Reproduction

1. Configure Akvorado with a ClickHouse cluster (multiple shards, `Distributed` tables)
2. Open the Akvorado console dashboard
3. Any widget that uses AS name lookup (e.g. top src/dst AS) fails with `Dictionary (asns) not found`
4. The error trace shows `While executing Remote` — the query was forwarded to a shard node

Manual test:
```sql
-- Works (fully qualified):
SELECT dictGetOrDefault('akvorado.asns', 'name', toUInt32(15169), '???')  -- → Google

-- Fails (unqualified):
SELECT dictGetOrDefault('asns', 'name', toUInt32(15169), '???')  -- → Dictionary not found
```

## Fix

Use fully-qualified dictionary names (e.g. `akvorado.asns` instead of `asns`) in all generated SQL queries.

### Changes

- **`common/schema/root.go`**: Add `DatabaseName` field to `schema.Component`, populated from the ClickHouseDB component during initialization
- **`common/schema/definition.go`**: Add `DictionaryName()` method on `*Component` that returns the dictionary name prefixed with the database name when available (e.g. `akvorado.asns`), or the unqualified name otherwise
- **`cmd/akvorado/console.go`** & **`cmd/akvorado/orchestrator.go`**: Set `schemaComponent.DatabaseName` from `clickhousedb.DatabaseName()` after ClickHouseDB component is created
- **`console/query/column.go`**: `DictionaryName()` function now accepts `*schema.Component` and qualifies the dictionary name via `sch.DictionaryName()`
- **`console/widgets.go`**: Pass `c.d.Schema` to `query.DictionaryName()`
- **`console/filter/helpers.go`**: `protocolName()` now accepts `*schema.Component` and qualifies the protocols dictionary
- **`console/filter/parser.peg`**: Pass `c.meta().Schema` to `protocolName()` via the parser `Meta` struct
- **`console/filter.go`**: Autocomplete raw SQL uses `c.d.Schema.DictionaryName()` for `dictGet` calls and `FROM` clauses

### Backward compatibility

- When `DatabaseName` is empty (e.g. in tests or when using the `default` database), `DictionaryName()` returns the unqualified name, so existing behavior is preserved
- The orchestrator's `tableAlreadyExists()` already normalizes qualified dictionary names by stripping the database prefix for comparison, so this change does not trigger unnecessary migrations

### Known limitation

The `ClickHouseAlias` expressions for `ICMPv4`/`ICMPv6` columns in `common/schema/definition.go` also use unqualified dictionary names. These are `Disabled: true` by default and would need a separate fix since the schema definition is static and does not have access to the database name at definition time.

### Side note

The port autocomplete query had a pre-existing bug (`FROM tcp UNION DISTINCT ... FROM tcp` instead of `FROM tcp UNION DISTINCT ... FROM udp`), fixed as a side effect of qualifying both dictionary names separately.