### PR TITLE
outlet/metadata: expose when no provider has metadata for an exporter

### DIFF
--- a/outlet/metadata/root.go
+++ b/outlet/metadata/root.go
@@ -38,6 +38,7 @@ type Component struct {
 	providerBreakers       map[netip.Addr]*breaker.Breaker
 	providers              []provider.Provider
 	initialDeadline        time.Time
+	providerSkipLogger     reporter.Logger
 
 	metrics struct {
 		cacheRefreshRuns         reporter.Counter
@@ -45,6 +46,7 @@ type Component struct {
 		providerBreakerOpenCount *reporter.CounterVec
 		providerRequests         reporter.Counter
 		providerErrors           reporter.Counter
+		providerSkips            *reporter.CounterVec
 	}
 }
 
@@ -75,6 +77,7 @@ func New(r *reporter.Reporter, configuration Configuration, dependencies Depende
 		providerBreakers:       make(map[netip.Addr]*breaker.Breaker),
 		providerBreakerLoggers: make(map[netip.Addr]reporter.Logger),
 		providers:              make([]provider.Provider, 0, 1),
+		providerSkipLogger:     r.Sample(reporter.BurstSampler(time.Minute, 3)),
 	}
 	c.d.Daemon.Track(&c.t, "outlet/metadata")
 
@@ -113,6 +116,12 @@ func New(r *reporter.Reporter, configuration Configuration, dependencies Depende
 			Name: "provider_errors_total",
 			Help: "Number of provider errors.",
 		})
+	c.metrics.providerSkips = r.CounterVec(
+		reporter.CounterOpts{
+			Name: "provider_skips_total",
+			Help: "Number of queries no provider had an answer for.",
+		},
+		[]string{"exporter"})
 	return &c, nil
 }
 
@@ -234,6 +243,10 @@ func (c *Component) queryProviders(query provider.Query) (provider.Answer, error
 			return nil
 		}
 		// All providers were skipped. Cache a negative result.
+		c.metrics.providerSkips.WithLabelValues(query.ExporterIP.Unmap().String()).Inc()
+		c.providerSkipLogger.Warn().
+			Str("exporter", query.ExporterIP.Unmap().String()).
+			Msg("no provider has metadata for exporter")
 		c.sc.Put(now, query, provider.Answer{})
 		return nil
 	})

--- a/outlet/metadata/root_test.go
+++ b/outlet/metadata/root_test.go
@@ -361,20 +361,25 @@ func TestNegativeCache(t *testing.T) {
 		configuration.Providers = []ProviderConfiguration{{Config: skipProviderConfiguration{}}}
 		c := NewMock(t, r, configuration, Dependencies{Daemon: daemon.NewMock(t)})
 
-		// First lookup: no cached result, provider is queried and skips.
+		// First lookup: no cached result, provider is queried and skips. The
+		// skip is visible in metrics, labelled with the exporter address.
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
-		gotMetrics := r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
-		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "1"}); diff != "" {
+		gotMetrics := r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total", "skips_total")
+		expectedMetrics := map[string]string{
+			`requests_total`:                    "1",
+			`skips_total{exporter="127.0.0.1"}`: "1",
+		}
+		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
 			t.Fatalf("after first lookup, metrics (-got, +want):\n%s", diff)
 		}
 
 		// Second lookup within CacheDuration: negative cache hit, provider must
-		// NOT be queried again.
+		// NOT be queried again and the skip must not be counted again.
 		time.Sleep(10 * time.Minute)
 		synctest.Wait()
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
-		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
-		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "1"}); diff != "" {
+		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total", "skips_total")
+		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
 			t.Fatalf("after cached lookup, metrics (-got, +want):\n%s", diff)
 		}
 
@@ -383,8 +388,12 @@ func TestNegativeCache(t *testing.T) {
 		time.Sleep(32 * time.Minute)
 		synctest.Wait()
 		expectMockLookup(t, c, "127.0.0.1", 765, provider.Answer{})
-		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total")
-		if diff := helpers.Diff(gotMetrics, map[string]string{`requests_total`: "2"}); diff != "" {
+		gotMetrics = r.GetMetrics("akvorado_outlet_metadata_provider_", "requests_total", "skips_total")
+		expectedMetrics = map[string]string{
+			`requests_total`:                    "2",
+			`skips_total{exporter="127.0.0.1"}`: "2",
+		}
+		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
 			t.Fatalf("after negative cache expiry, metrics (-got, +want):\n%s", diff)
 		}
 	})


### PR DESCRIPTION
When every configured provider skips an exporter (no SNMP, no gNMI, no matching static entry), the flow is enriched with empty metadata and, since e5ca863, the negative result is also cached — with no trace anywhere: no log line and no metric.

Debugging this from the outside means staring at flows with empty interface names and guessing which layer dropped them. I recently lost a few hours to exactly this while pointing a device at the SNMP provider when the device could not answer ifXTable queries (SonicWall — it has no ifXTable at all): nothing anywhere said which exporter was failing to resolve, or why.

This PR adds:

- a `provider_skips_total` counter labelled with the exporter address — same pattern and cardinality bound as the existing `provider_breaker_opens_total`;
- a rate-limited warning log naming the exporter.

With this, an unmatched exporter is visible at a glance in metrics and logs. Includes a test following the style of the recent negative-caching test.
