### PR TITLE
[draft] outlet/bmp: flush removed peers in batches

### DIFF
--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -108,7 +108,7 @@ func (p *Provider) removePeer(pkey peerKey, reason string) {
 	if !ok {
 		return
 	}
-	routesRemoved, prefixesRemoved := p.rib.FlushPeer(pinfo.reference)
+	routesRemoved, prefixesRemoved := p.rib.FlushPeer(pinfo.reference, len(p.peers))
 	delete(p.peers, pkey)
 	p.metrics.routes.WithLabelValues(exporterStr).Sub(float64(routesRemoved))
 	p.metrics.prefixesRemoved.WithLabelValues(exporterStr).Add(float64(prefixesRemoved))

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -249,6 +249,8 @@ func (p *Provider) handlePeerUpNotification(pkey peerKey, body *bmp.BMPPeerUpNot
 		if !p.cancelRemovePeer(pkey) {
 			p.r.Info().Msgf("received extra peer up from exporter %s for peer %s",
 				exporterStr, peerStr)
+		} else {
+			pinfo.staleUntil = time.Time{}
 		}
 	} else {
 		// Peer does not exist at all
@@ -380,7 +382,9 @@ func (p *Provider) handleRouteMonitoring(pkey peerKey, body *bmp.BMPRouteMonitor
 
 	p.mu.Lock()
 	pinfo, ok := p.peers[pkey]
-	if !ok {
+	if ok {
+		p.cancelRemovePeer(pkey)
+	} else {
 		// We may have missed the peer down notification?
 		p.r.Info().Msgf("received route monitoring from exporter %s for peer %s, but no peer up",
 			exporterStr, peerStr)

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -32,6 +32,12 @@ type peerInfo struct {
 	marshallingOptions []*bgp.MarshallingOption // decoding option (add-path mostly)
 }
 
+// peerToRemove describes a peer queued for batched removal.
+type peerToRemove struct {
+	reference   uint32 // reference of the peer in the RIB when it was queued
+	exporterStr string // exporter the peer belongs to, for metrics
+}
+
 // peerKeyFromBMPPeerHeader computes the peer key from the BMP peer header.
 func peerKeyFromBMPPeerHeader(exporter netip.AddrPort, header *bmp.BMPPeerHeader) peerKey {
 	return peerKey{
@@ -46,7 +52,7 @@ func peerKeyFromBMPPeerHeader(exporter netip.AddrPort, header *bmp.BMPPeerHeader
 
 // scheduleStalePeersRemoval schedule the next time a peer should be
 // removed. This should be called with the lock held.
-func (p *Provider) scheduleStalePeersRemoval() {
+func (p *Provider) scheduleStalePeersRemoval(after time.Time) {
 	var next time.Time
 	for _, pinfo := range p.peers {
 		if pinfo.staleUntil.IsZero() {
@@ -61,7 +67,9 @@ func (p *Provider) scheduleStalePeersRemoval() {
 		p.staleTimer.Stop()
 	} else {
 		p.r.Debug().Msgf("next removal for stale peer scheduled on %s", next)
-		p.staleTimer.Reset(p.d.Clock.Until(next))
+		if next.After(after) {
+			p.staleTimer.Reset(p.d.Clock.Until(next))
+		}
 	}
 }
 
@@ -77,7 +85,7 @@ func (p *Provider) removeStalePeers() {
 		}
 		p.removePeer(pkey, "stale")
 	}
-	p.scheduleStalePeersRemoval()
+	p.scheduleStalePeersRemoval(start)
 }
 
 func (p *Provider) addPeer(pkey peerKey) *peerInfo {
@@ -96,24 +104,80 @@ func (p *Provider) addPeer(pkey peerKey) *peerInfo {
 	return pinfo
 }
 
-// removePeer remove a peer (with lock held)
+// removePeer queues a peer for removal. Its routes are flushed from the
+// RIB later, in batch, by removePeers. This should be called with the
+// lock held.
 func (p *Provider) removePeer(pkey peerKey, reason string) {
-	exporterStr := pkey.exporter.Addr().Unmap().String()
-	peerStr := pkey.ip.Unmap().String()
-	p.r.Info().Msgf("remove peer %s for exporter %s (reason: %s)", peerStr, exporterStr, reason)
-	start := p.d.Clock.Now()
-	defer p.metrics.locked.WithLabelValues("peer-removal").Observe(
-		float64(p.d.Clock.Now().Sub(start).Nanoseconds()) / 1000 / 1000 / 1000)
 	pinfo, ok := p.peers[pkey]
 	if !ok {
 		return
 	}
-	routesRemoved, prefixesRemoved := p.rib.FlushPeer(pinfo.reference)
-	delete(p.peers, pkey)
+
+	exporterStr := pkey.exporter.Addr().Unmap().String()
+	peerStr := pkey.ip.Unmap().String()
+	p.r.Info().Msgf("remove peer %s for exporter %s (reason: %s)", peerStr, exporterStr, reason)
+
+	p.muPeersToRemove.Lock()
+	defer p.muPeersToRemove.Unlock()
+	// (Re)start the timer if the queue was empty
+	if len(p.peersToRemove) == 0 {
+		p.removePeersTimer.Reset(10 * time.Second)
+	}
+	p.peersToRemove[pkey] = peerToRemove{
+		reference:   pinfo.reference,
+		exporterStr: exporterStr,
+	}
+}
+
+// removePeers flushes the peers queued for removal.
+func (p *Provider) removePeers() {
+	p.muRemovePeers.Lock()
+	defer p.muRemovePeers.Unlock()
+
+	start := p.d.Clock.Now()
+	defer p.metrics.locked.WithLabelValues("peer-removal").Observe(
+		float64(p.d.Clock.Now().Sub(start).Nanoseconds()) / 1000 / 1000 / 1000)
+
+	p.muPeersToRemove.Lock()
+	p.removePeersTimer.Stop()
+	queued := p.peersToRemove
+	p.peersToRemove = make(map[peerKey]peerToRemove, len(queued))
+	p.muPeersToRemove.Unlock()
+	if len(queued) == 0 {
+		return
+	}
+
+	exporterCounts := make(map[string]float64)
+	peers := make(map[uint32]struct{}, len(queued))
+
+	p.mu.Lock()
+	for pkey, queuedPeer := range queued {
+		// The peer may have come back up since it was queued, in which
+		// case it has a new reference and should be kept.
+		if pinfo, ok := p.peers[pkey]; ok && pinfo.reference == queuedPeer.reference {
+			delete(p.peers, pkey)
+		}
+		exporterCounts[queuedPeer.exporterStr]++
+		peers[queuedPeer.reference] = struct{}{}
+	}
+	p.mu.Unlock()
+
+	routesRemoved, prefixesRemoved := p.rib.FlushPeer(peers)
+
+	// FlushPeer does not separate removed routes and prefixes by exporter, so
+	// they can only be assigned if all peers were from a single exporter.
+	exporterStr := "batched"
+	if len(exporterCounts) == 1 {
+		for e := range exporterCounts {
+			exporterStr = e
+		}
+	}
 	p.metrics.routes.WithLabelValues(exporterStr).Sub(float64(routesRemoved))
 	p.metrics.prefixesRemoved.WithLabelValues(exporterStr).Add(float64(prefixesRemoved))
-	p.metrics.peers.WithLabelValues(exporterStr).Dec()
-	p.metrics.peerRemovalDone.WithLabelValues(exporterStr).Inc()
+	for exporterStr, count := range exporterCounts {
+		p.metrics.peers.WithLabelValues(exporterStr).Sub(count)
+		p.metrics.peerRemovalDone.WithLabelValues(exporterStr).Add(count)
+	}
 }
 
 // markExporterAsStale marks all peers from an exporter as stale.
@@ -126,7 +190,7 @@ func (p *Provider) markExporterAsStale(exporter netip.AddrPort, until time.Time)
 		}
 		pinfo.staleUntil = until
 	}
-	p.scheduleStalePeersRemoval()
+	p.scheduleStalePeersRemoval(p.d.Clock.Now())
 }
 
 // handlePeerDownNotification handles a peer-down notification by

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -108,7 +108,7 @@ func (p *Provider) removePeer(pkey peerKey, reason string) {
 	if !ok {
 		return
 	}
-	routesRemoved, prefixesRemoved := p.rib.FlushPeer(pinfo.reference, len(p.peers))
+	routesRemoved, prefixesRemoved := p.rib.FlushPeer(pinfo.reference)
 	delete(p.peers, pkey)
 	p.metrics.routes.WithLabelValues(exporterStr).Sub(float64(routesRemoved))
 	p.metrics.prefixesRemoved.WithLabelValues(exporterStr).Add(float64(prefixesRemoved))

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -149,23 +149,24 @@ func (p *Provider) removePeers() {
 	defer p.metrics.locked.WithLabelValues("peer-removal").Observe(
 		float64(p.d.Clock.Now().Sub(start).Nanoseconds()) / 1000 / 1000 / 1000)
 
+	p.mu.Lock()
 	p.muPeersToRemove.Lock()
 	p.removePeersTimer.Stop()
 	queued := p.peersToRemove
 	p.peersToRemove = make(map[peerKey]peerToRemove, len(queued))
 	p.muPeersToRemove.Unlock()
 	if len(queued) == 0 {
+		p.mu.Unlock()
 		return
 	}
 
 	exporterCounts := make(map[string]float64)
-	peers := make(map[uint32]struct{}, len(queued))
+	peers := make([]uint32, 0, len(queued))
 
-	p.mu.Lock()
 	for pkey, queuedPeer := range queued {
 		delete(p.peers, pkey)
 		exporterCounts[queuedPeer.exporterStr]++
-		peers[queuedPeer.reference] = struct{}{}
+		peers = append(peers, queuedPeer.reference)
 	}
 	p.mu.Unlock()
 
@@ -181,9 +182,9 @@ func (p *Provider) removePeers() {
 	}
 	p.metrics.routes.WithLabelValues(exporterStr).Sub(float64(routesRemoved))
 	p.metrics.prefixesRemoved.WithLabelValues(exporterStr).Add(float64(prefixesRemoved))
-	for exporterStr, count := range exporterCounts {
-		p.metrics.peers.WithLabelValues(exporterStr).Sub(count)
-		p.metrics.peerRemovalDone.WithLabelValues(exporterStr).Add(count)
+	for exporter, count := range exporterCounts {
+		p.metrics.peers.WithLabelValues(exporter).Sub(count)
+		p.metrics.peerRemovalDone.WithLabelValues(exporter).Add(count)
 	}
 }
 

--- a/outlet/routing/provider/bmp/events.go
+++ b/outlet/routing/provider/bmp/events.go
@@ -55,7 +55,7 @@ func peerKeyFromBMPPeerHeader(exporter netip.AddrPort, header *bmp.BMPPeerHeader
 func (p *Provider) scheduleStalePeersRemoval(after time.Time) {
 	var next time.Time
 	for _, pinfo := range p.peers {
-		if pinfo.staleUntil.IsZero() {
+		if pinfo.staleUntil.IsZero() || !pinfo.staleUntil.After(after) {
 			continue
 		}
 		if next.IsZero() || pinfo.staleUntil.Before(next) {
@@ -67,9 +67,7 @@ func (p *Provider) scheduleStalePeersRemoval(after time.Time) {
 		p.staleTimer.Stop()
 	} else {
 		p.r.Debug().Msgf("next removal for stale peer scheduled on %s", next)
-		if next.After(after) {
-			p.staleTimer.Reset(p.d.Clock.Until(next))
-		}
+		p.staleTimer.Reset(p.d.Clock.Until(next))
 	}
 }
 
@@ -102,6 +100,19 @@ func (p *Provider) addPeer(pkey peerKey) *peerInfo {
 	}
 	p.peers[pkey] = pinfo
 	return pinfo
+}
+
+func (p *Provider) cancelRemovePeer(pkey peerKey) bool {
+	p.muPeersToRemove.Lock()
+	defer p.muPeersToRemove.Unlock()
+	if _, found := p.peersToRemove[pkey]; found {
+		delete(p.peersToRemove, pkey)
+		if len(p.peersToRemove) == 0 {
+			p.removePeersTimer.Stop()
+		}
+		return true
+	}
+	return false
 }
 
 // removePeer queues a peer for removal. Its routes are flushed from the
@@ -152,11 +163,7 @@ func (p *Provider) removePeers() {
 
 	p.mu.Lock()
 	for pkey, queuedPeer := range queued {
-		// The peer may have come back up since it was queued, in which
-		// case it has a new reference and should be kept.
-		if pinfo, ok := p.peers[pkey]; ok && pinfo.reference == queuedPeer.reference {
-			delete(p.peers, pkey)
-		}
+		delete(p.peers, pkey)
 		exporterCounts[queuedPeer.exporterStr]++
 		peers[queuedPeer.reference] = struct{}{}
 	}
@@ -238,8 +245,10 @@ func (p *Provider) handlePeerUpNotification(pkey peerKey, body *bmp.BMPPeerUpNot
 	peerStr := pkey.ip.Unmap().String()
 	pinfo, ok := p.peers[pkey]
 	if ok {
-		p.r.Info().Msgf("received extra peer up from exporter %s for peer %s",
-			exporterStr, peerStr)
+		if !p.cancelRemovePeer(pkey) {
+			p.r.Info().Msgf("received extra peer up from exporter %s for peer %s",
+				exporterStr, peerStr)
+		}
 	} else {
 		// Peer does not exist at all
 		p.metrics.peers.WithLabelValues(exporterStr).Inc()

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -366,7 +366,7 @@ func BenchmarkRIBFlush(b *testing.B) {
 					}
 
 					b.StartTimer()
-					rib.FlushPeer(0)
+					rib.FlushPeer(map[uint32]struct{}{0: {}})
 				}
 				b.ReportMetric(0, "ns/op")
 				b.ReportMetric(float64(b.Elapsed())/float64(b.N)/1_000_000, "ms/op")

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -366,7 +366,7 @@ func BenchmarkRIBFlush(b *testing.B) {
 					}
 
 					b.StartTimer()
-					rib.FlushPeer(map[uint32]struct{}{0: {}})
+					rib.FlushPeer([]uint32{0})
 				}
 				b.ReportMetric(0, "ns/op")
 				b.ReportMetric(float64(b.Elapsed())/float64(b.N)/1_000_000, "ms/op")

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -366,7 +366,7 @@ func BenchmarkRIBFlush(b *testing.B) {
 					}
 
 					b.StartTimer()
-					rib.FlushPeer(0, peers)
+					rib.FlushPeer(0)
 				}
 				b.ReportMetric(0, "ns/op")
 				b.ReportMetric(float64(b.Elapsed())/float64(b.N)/1_000_000, "ms/op")

--- a/outlet/routing/provider/bmp/prefixes_test.go
+++ b/outlet/routing/provider/bmp/prefixes_test.go
@@ -330,7 +330,7 @@ func BenchmarkRIBLookup(b *testing.B) {
 
 func BenchmarkRIBFlush(b *testing.B) {
 	for _, routes := range []int{1_000, 10_000, 100_000} {
-		for _, peers := range []int{1, 2, 5} {
+		for _, peers := range []int{1, 2, 5, 10} {
 			name := fmt.Sprintf("%d routes, %d peers", routes, peers)
 
 			b.Run(name, func(b *testing.B) {
@@ -366,7 +366,7 @@ func BenchmarkRIBFlush(b *testing.B) {
 					}
 
 					b.StartTimer()
-					rib.FlushPeer(0)
+					rib.FlushPeer(0, peers)
 				}
 				b.ReportMetric(0, "ns/op")
 				b.ReportMetric(float64(b.Elapsed())/float64(b.N)/1_000_000, "ms/op")

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -404,13 +404,9 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
-func (r *rib) FlushPeer(peer uint32) (int, int) {
-	type shardResults struct {
-		prefixesRemoved int
-		routesRemoved   int
-	}
-
-	results := make([]shardResults, len(r.shards))
+func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
+	routesRemoved := 0
+	prefixesRemoved := 0
 
 	// Lock all shards in order, then the tree writer lock.
 	for _, rs := range r.shards {
@@ -419,53 +415,91 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	r.treeMu.Lock()
 	tree := r.tree.Load()
 
-	// Channel to communicate prefixes to remove
-	prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<1)
-
-	// Goroutine to handle prefix removal
-	var wgDelete sync.WaitGroup
-	wgDelete.Go(func() {
-		if prefix, ok := <-prefixesToRemove; ok {
-			newTree := tree.Clone()
-			newTree.Delete(prefix)
-			for prefix = range prefixesToRemove {
-				newTree.Delete(prefix)
-			}
-			r.tree.Store(newTree)
+	if peers >= 4 && tree.Size() >= len(r.shards)<<9 {
+		type workerState struct {
+			prefixesRemoved int
+			routesRemoved   int
 		}
-	})
 
-	// Iterate through all prefixes and remove peer routes.
-	var wg sync.WaitGroup
-	for i, rs := range r.shards {
-		wg.Go(func() {
-			for prefix, ref := range tree.All() {
-				if ref.idx.shardIdx() != rs.idx {
-					continue
+		// Iterate through all prefixes and remove peer routes.
+		prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<3)
+		states := make([]workerState, len(r.shards))
+
+		var wg sync.WaitGroup
+		for i, rs := range r.shards {
+			wg.Go(func() {
+				state := &states[i]
+				for prefix, ref := range tree.All() {
+					if ref.idx.shardIdx() != rs.idx {
+						continue
+					}
+					removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+						return route.peer == peer
+					}, false)
+					state.routesRemoved += removed
+					if empty {
+						rs.freePrefixIndex(ref.idx)
+						state.prefixesRemoved++
+						prefixesToRemove <- prefix
+					}
 				}
-				removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
-					return route.peer == peer
-				}, false)
-				results[i].routesRemoved += removed
-				if empty {
-					rs.freePrefixIndex(ref.idx)
-					results[i].prefixesRemoved++
-					prefixesToRemove <- prefix
+			})
+		}
+
+		// Goroutine to remove empty prefixes from the tree and publish it.
+		go func() {
+			if prefix, ok := <-prefixesToRemove; ok {
+				newTree := tree.Clone()
+				newTree.Delete(prefix)
+				for prefix = range prefixesToRemove {
+					newTree.Delete(prefix)
 				}
+				r.tree.Store(newTree)
 			}
-		})
-	}
-	wg.Wait()
+		}()
 
-	// Close the channel to signal the prefix removal goroutine to finish
-	close(prefixesToRemove)
-	wgDelete.Wait()
+		wg.Wait()
+		close(prefixesToRemove)
 
-	prefixesRemoved := 0
-	routesRemoved := 0
-	for _, r := range results {
-		prefixesRemoved += r.prefixesRemoved
-		routesRemoved += r.routesRemoved
+		for _, state := range states {
+			prefixesRemoved += state.prefixesRemoved
+			routesRemoved += state.routesRemoved
+		}
+	} else {
+		// Iterate through all prefixes and remove peer routes.
+		for _, ref := range tree.All() {
+			rs := r.shards[ref.idx.shardIdx()]
+			removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+				return route.peer == peer
+			}, false)
+			routesRemoved += removed
+			if empty {
+				rs.freePrefixIndex(ref.idx)
+				prefixesRemoved++
+			}
+		}
+
+		if routesRemoved > 0 {
+			if peers >= 4 {
+				// Remove empty prefixes from the tree and publish it.
+				newTree := tree.Clone()
+				for prefix, ref := range tree.All() {
+					if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; !hasRoutes {
+						newTree.Delete(prefix)
+					}
+				}
+				r.tree.Store(newTree)
+			} else {
+				// Rebuild the tree excluding empty prefixes and publish it.
+				newTree := &bart.Fast[prefixRef]{}
+				for prefix, ref := range tree.All() {
+					if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
+						newTree.Insert(prefix, ref)
+					}
+				}
+				r.tree.Store(newTree)
+			}
+		}
 	}
 
 	r.treeMu.Unlock()

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -463,7 +463,7 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 		routesRemoved += state.routesRemoved
 	}
 
-	if prefixesRemoved >= (tree.Size() >> 2) {
+	if prefixesRemoved > 0 && prefixesRemoved >= tree.Size()>>2 {
 		// Rebuild the tree from remaining prefixes and publish it.
 		newTree := &bart.Fast[prefixRef]{}
 		for _, state := range states {

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -405,6 +405,10 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
 func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
+	if peers >= 4 && r.tree.Load().Size() >= len(r.shards)<<9 {
+		return r.FlushPeerConcurrent(peer)
+	}
+
 	routesRemoved := 0
 	prefixesRemoved := 0
 
@@ -415,90 +419,38 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 	r.treeMu.Lock()
 	tree := r.tree.Load()
 
-	if peers >= 4 && tree.Size() >= len(r.shards)<<9 {
-		type workerState struct {
-			prefixesRemoved int
-			routesRemoved   int
+	// Iterate through all prefixes and remove peer routes.
+	for _, ref := range tree.All() {
+		rs := r.shards[ref.idx.shardIdx()]
+		removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+			return route.peer == peer
+		}, false)
+		routesRemoved += removed
+		if empty {
+			rs.freePrefixIndex(ref.idx)
+			prefixesRemoved++
 		}
+	}
 
-		// Iterate through all prefixes and remove peer routes.
-		prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<3)
-		states := make([]workerState, len(r.shards))
-
-		var wg sync.WaitGroup
-		for i, rs := range r.shards {
-			wg.Go(func() {
-				state := &states[i]
-				for prefix, ref := range tree.All() {
-					if ref.idx.shardIdx() != rs.idx {
-						continue
-					}
-					removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
-						return route.peer == peer
-					}, false)
-					state.routesRemoved += removed
-					if empty {
-						rs.freePrefixIndex(ref.idx)
-						state.prefixesRemoved++
-						prefixesToRemove <- prefix
-					}
-				}
-			})
-		}
-
-		// Goroutine to remove empty prefixes from the tree and publish it.
-		go func() {
-			if prefix, ok := <-prefixesToRemove; ok {
-				newTree := tree.Clone()
-				newTree.Delete(prefix)
-				for prefix = range prefixesToRemove {
+	if routesRemoved > 0 {
+		if peers >= 4 {
+			// Remove empty prefixes from the tree and publish it.
+			newTree := tree.Clone()
+			for prefix, ref := range tree.All() {
+				if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; !hasRoutes {
 					newTree.Delete(prefix)
 				}
-				r.tree.Store(newTree)
 			}
-		}()
-
-		wg.Wait()
-		close(prefixesToRemove)
-
-		for _, state := range states {
-			prefixesRemoved += state.prefixesRemoved
-			routesRemoved += state.routesRemoved
-		}
-	} else {
-		// Iterate through all prefixes and remove peer routes.
-		for _, ref := range tree.All() {
-			rs := r.shards[ref.idx.shardIdx()]
-			removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
-				return route.peer == peer
-			}, false)
-			routesRemoved += removed
-			if empty {
-				rs.freePrefixIndex(ref.idx)
-				prefixesRemoved++
-			}
-		}
-
-		if routesRemoved > 0 {
-			if peers >= 4 {
-				// Remove empty prefixes from the tree and publish it.
-				newTree := tree.Clone()
-				for prefix, ref := range tree.All() {
-					if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; !hasRoutes {
-						newTree.Delete(prefix)
-					}
+			r.tree.Store(newTree)
+		} else {
+			// Rebuild the tree excluding empty prefixes and publish it.
+			newTree := &bart.Fast[prefixRef]{}
+			for prefix, ref := range tree.All() {
+				if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
+					newTree.Insert(prefix, ref)
 				}
-				r.tree.Store(newTree)
-			} else {
-				// Rebuild the tree excluding empty prefixes and publish it.
-				newTree := &bart.Fast[prefixRef]{}
-				for prefix, ref := range tree.All() {
-					if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
-						newTree.Insert(prefix, ref)
-					}
-				}
-				r.tree.Store(newTree)
 			}
+			r.tree.Store(newTree)
 		}
 	}
 
@@ -507,6 +459,75 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 		v.mu.Unlock()
 	}
 
+	return routesRemoved, prefixesRemoved
+}
+
+// FlushPeerConcurrent behaves like FlushPeer, but removes the peer from all
+// shards concurrently.
+func (r *rib) FlushPeerConcurrent(peer uint32) (int, int) {
+	type workerState struct {
+		prefixesRemoved int
+		routesRemoved   int
+	}
+
+	// Lock all shards in order, then the tree writer lock.
+	for _, rs := range r.shards {
+		rs.mu.Lock()
+	}
+	r.treeMu.Lock()
+	tree := r.tree.Load()
+
+	// Iterate through all prefixes and remove peer routes.
+	prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<3)
+	states := make([]workerState, len(r.shards))
+
+	var wg sync.WaitGroup
+	for i, rs := range r.shards {
+		wg.Go(func() {
+			state := &states[i]
+			for prefix, ref := range tree.All() {
+				if ref.idx.shardIdx() != rs.idx {
+					continue
+				}
+				removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+					return route.peer == peer
+				}, false)
+				state.routesRemoved += removed
+				if empty {
+					rs.freePrefixIndex(ref.idx)
+					state.prefixesRemoved++
+					prefixesToRemove <- prefix
+				}
+			}
+		})
+	}
+
+	// Goroutine to remove empty prefixes from the tree and publish it.
+	go func() {
+		if prefix, ok := <-prefixesToRemove; ok {
+			newTree := tree.Clone()
+			newTree.Delete(prefix)
+			for prefix = range prefixesToRemove {
+				newTree.Delete(prefix)
+			}
+			r.tree.Store(newTree)
+		}
+	}()
+
+	wg.Wait()
+	close(prefixesToRemove)
+
+	r.treeMu.Unlock()
+	for i := len(r.shards) - 1; i >= 0; i-- {
+		r.shards[i].mu.Unlock()
+	}
+
+	prefixesRemoved := 0
+	routesRemoved := 0
+	for _, state := range states {
+		prefixesRemoved += state.prefixesRemoved
+		routesRemoved += state.routesRemoved
+	}
 	return routesRemoved, prefixesRemoved
 }
 

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -419,11 +419,27 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	r.treeMu.Lock()
 	tree := r.tree.Load()
 
+	// Channel to communicate prefixes to remove
+	prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<1)
+
+	// Goroutine to handle prefix removal
+	var wgDelete sync.WaitGroup
+	wgDelete.Go(func() {
+		if prefix, ok := <-prefixesToRemove; ok {
+			newTree := tree.Clone()
+			newTree.Delete(prefix)
+			for prefix = range prefixesToRemove {
+				newTree.Delete(prefix)
+			}
+			r.tree.Store(newTree)
+		}
+	})
+
 	// Iterate through all prefixes and remove peer routes.
 	var wg sync.WaitGroup
 	for i, rs := range r.shards {
 		wg.Go(func() {
-			for _, ref := range tree.All() {
+			for prefix, ref := range tree.All() {
 				if ref.idx.shardIdx() != rs.idx {
 					continue
 				}
@@ -434,28 +450,22 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 				if empty {
 					rs.freePrefixIndex(ref.idx)
 					results[i].prefixesRemoved++
+					prefixesToRemove <- prefix
 				}
 			}
 		})
 	}
 	wg.Wait()
 
+	// Close the channel to signal the prefix removal goroutine to finish
+	close(prefixesToRemove)
+	wgDelete.Wait()
+
 	prefixesRemoved := 0
 	routesRemoved := 0
 	for _, r := range results {
 		prefixesRemoved += r.prefixesRemoved
 		routesRemoved += r.routesRemoved
-	}
-
-	if prefixesRemoved > 0 {
-		// Rebuild the tree excluding empty prefixes and publish it.
-		newTree := &bart.Fast[prefixRef]{}
-		for prefix, ref := range tree.All() {
-			if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
-				newTree.Insert(prefix, ref)
-			}
-		}
-		r.tree.Store(newTree)
 	}
 
 	r.treeMu.Unlock()

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -406,7 +406,6 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 // of removed routes and the number of removed prefixes.
 func (r *rib) FlushPeer(peer uint32) (int, int) {
 	type shardResults struct {
-		anyEmpty        bool
 		prefixesRemoved int
 		routesRemoved   int
 	}
@@ -435,23 +434,20 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 				if empty {
 					rs.freePrefixIndex(ref.idx)
 					results[i].prefixesRemoved++
-					results[i].anyEmpty = true
 				}
 			}
 		})
 	}
 	wg.Wait()
 
-	anyEmpty := false
 	prefixesRemoved := 0
 	routesRemoved := 0
 	for _, r := range results {
-		anyEmpty = anyEmpty || r.anyEmpty
 		prefixesRemoved += r.prefixesRemoved
 		routesRemoved += r.routesRemoved
 	}
 
-	if anyEmpty {
+	if prefixesRemoved > 0 {
 		// Rebuild the tree excluding empty prefixes and publish it.
 		newTree := &bart.Fast[prefixRef]{}
 		for prefix, ref := range tree.All() {

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -24,6 +24,10 @@ const shardBits = 8
 // localPrefixMask masks off the shard bits, leaving only the local prefix ID.
 const localPrefixMask = (1 << (32 - shardBits)) - 1
 
+// flushPeerLinearScanMax defines the threshold for using linear search when checking for
+// routes to remove in FlushPeer(...). If more peers are passed a map is used instead.
+const flushPeerLinearScanMax = 8
+
 // prefixIndex is a typed index for prefixes in the RIB. The high shardBits
 // encode the shard index, the remaining bits are the local ID.
 type prefixIndex uint32
@@ -404,7 +408,7 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 
 // FlushPeer removes one or more peers from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
-func (r *rib) FlushPeer(peers map[uint32]struct{}) (int, int) {
+func (r *rib) FlushPeer(peers []uint32) (int, int) {
 	type prefixEntry struct {
 		prefix netip.Prefix
 		ref    prefixRef
@@ -414,6 +418,28 @@ func (r *rib) FlushPeer(peers map[uint32]struct{}) (int, int) {
 		prefixes        []prefixEntry
 		prefixesRemoved int
 		routesRemoved   int
+	}
+
+	// Check if route belongs to peer to remove: directly from the array for few peers and using a map for many.
+	var shouldRemove func(route route) bool
+	if len(peers) <= flushPeerLinearScanMax {
+		shouldRemove = func(route route) bool {
+			for _, p := range peers {
+				if p == route.peer {
+					return true
+				}
+			}
+			return false
+		}
+	} else {
+		peerSet := make(map[uint32]struct{}, len(peers))
+		for _, p := range peers {
+			peerSet[p] = struct{}{}
+		}
+		shouldRemove = func(route route) bool {
+			_, found := peerSet[route.peer]
+			return found
+		}
 	}
 
 	// Lock all shards in order, then the tree writer lock.
@@ -440,10 +466,7 @@ func (r *rib) FlushPeer(peers map[uint32]struct{}) (int, int) {
 		wg.Go(func() {
 			state := &states[rs.idx]
 			for i, entry := range state.prefixes {
-				removed, empty := rs.removeRoutes(entry.ref.idx, func(route route) bool {
-					_, found := peers[route.peer]
-					return found
-				}, false)
+				removed, empty := rs.removeRoutes(entry.ref.idx, shouldRemove, false)
 				state.routesRemoved += removed
 				if empty {
 					rs.freePrefixIndex(entry.ref.idx)

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -405,66 +405,6 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
 func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
-	if peers >= 4 && r.tree.Load().Size() >= len(r.shards)<<9 {
-		return r.FlushPeerConcurrent(peer)
-	}
-
-	routesRemoved := 0
-	prefixesRemoved := 0
-
-	// Lock all shards in order, then the tree writer lock.
-	for _, rs := range r.shards {
-		rs.mu.Lock()
-	}
-	r.treeMu.Lock()
-	tree := r.tree.Load()
-
-	// Iterate through all prefixes and remove peer routes.
-	for _, ref := range tree.All() {
-		rs := r.shards[ref.idx.shardIdx()]
-		removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
-			return route.peer == peer
-		}, false)
-		routesRemoved += removed
-		if empty {
-			rs.freePrefixIndex(ref.idx)
-			prefixesRemoved++
-		}
-	}
-
-	if routesRemoved > 0 {
-		if peers >= 4 {
-			// Remove empty prefixes from the tree and publish it.
-			newTree := tree.Clone()
-			for prefix, ref := range tree.All() {
-				if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; !hasRoutes {
-					newTree.Delete(prefix)
-				}
-			}
-			r.tree.Store(newTree)
-		} else {
-			// Rebuild the tree excluding empty prefixes and publish it.
-			newTree := &bart.Fast[prefixRef]{}
-			for prefix, ref := range tree.All() {
-				if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
-					newTree.Insert(prefix, ref)
-				}
-			}
-			r.tree.Store(newTree)
-		}
-	}
-
-	r.treeMu.Unlock()
-	for _, v := range slices.Backward(r.shards) {
-		v.mu.Unlock()
-	}
-
-	return routesRemoved, prefixesRemoved
-}
-
-// FlushPeerConcurrent behaves like FlushPeer, but removes the peer from all
-// shards concurrently.
-func (r *rib) FlushPeerConcurrent(peer uint32) (int, int) {
 	type workerState struct {
 		prefixesRemoved int
 		routesRemoved   int
@@ -477,8 +417,24 @@ func (r *rib) FlushPeerConcurrent(peer uint32) (int, int) {
 	r.treeMu.Lock()
 	tree := r.tree.Load()
 
+	// Goroutine to remove empty prefixes from the tree and publish it.
+	var prefixesToRemove chan netip.Prefix
+	if peers >= 4 {
+		prefixesToRemove = make(chan netip.Prefix, len(r.shards)<<3)
+
+		go func() {
+			if prefix, ok := <-prefixesToRemove; ok {
+				newTree := tree.Clone()
+				newTree.Delete(prefix)
+				for prefix = range prefixesToRemove {
+					newTree.Delete(prefix)
+				}
+				r.tree.Store(newTree)
+			}
+		}()
+	}
+
 	// Iterate through all prefixes and remove peer routes.
-	prefixesToRemove := make(chan netip.Prefix, len(r.shards)<<3)
 	states := make([]workerState, len(r.shards))
 
 	var wg sync.WaitGroup
@@ -486,9 +442,11 @@ func (r *rib) FlushPeerConcurrent(peer uint32) (int, int) {
 		wg.Go(func() {
 			state := &states[i]
 			for prefix, ref := range tree.All() {
+				// Only process the matching shard to avoid concurrent changes to intern pools
 				if ref.idx.shardIdx() != rs.idx {
 					continue
 				}
+
 				removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
 					return route.peer == peer
 				}, false)
@@ -496,30 +454,31 @@ func (r *rib) FlushPeerConcurrent(peer uint32) (int, int) {
 				if empty {
 					rs.freePrefixIndex(ref.idx)
 					state.prefixesRemoved++
-					prefixesToRemove <- prefix
+					if prefixesToRemove != nil {
+						prefixesToRemove <- prefix
+					}
 				}
 			}
 		})
 	}
-
-	// Goroutine to remove empty prefixes from the tree and publish it.
-	go func() {
-		if prefix, ok := <-prefixesToRemove; ok {
-			newTree := tree.Clone()
-			newTree.Delete(prefix)
-			for prefix = range prefixesToRemove {
-				newTree.Delete(prefix)
-			}
-			r.tree.Store(newTree)
-		}
-	}()
-
 	wg.Wait()
-	close(prefixesToRemove)
+
+	if prefixesToRemove != nil {
+		close(prefixesToRemove)
+	} else {
+		// Rebuild the tree excluding empty prefixes and publish it.
+		newTree := &bart.Fast[prefixRef]{}
+		for prefix, ref := range tree.All() {
+			if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
+				newTree.Insert(prefix, ref)
+			}
+		}
+		r.tree.Store(newTree)
+	}
 
 	r.treeMu.Unlock()
-	for i := len(r.shards) - 1; i >= 0; i-- {
-		r.shards[i].mu.Unlock()
+	for _, rs := range slices.Backward(r.shards) {
+		rs.mu.Unlock()
 	}
 
 	prefixesRemoved := 0

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -402,9 +402,9 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 	return removedCount, prefixRemoved
 }
 
-// FlushPeer removes a whole peer from the RIB, returning the number
+// FlushPeer removes one or more peers from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
-func (r *rib) FlushPeer(peer uint32) (int, int) {
+func (r *rib) FlushPeer(peers map[uint32]struct{}) (int, int) {
 	type prefixEntry struct {
 		prefix netip.Prefix
 		ref    prefixRef
@@ -441,7 +441,8 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 			state := &states[rs.idx]
 			for i, entry := range state.prefixes {
 				removed, empty := rs.removeRoutes(entry.ref.idx, func(route route) bool {
-					return route.peer == peer
+					_, found := peers[route.peer]
+					return found
 				}, false)
 				state.routesRemoved += removed
 				if empty {

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -405,9 +405,13 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
 func (r *rib) FlushPeer(peer uint32) (int, int) {
-	routesRemoved := 0
-	prefixesRemoved := 0
-	anyEmpty := false
+	type shardResults struct {
+		anyEmpty        bool
+		prefixesRemoved int
+		routesRemoved   int
+	}
+
+	results := make([]shardResults, len(r.shards))
 
 	// Lock all shards in order, then the tree writer lock.
 	for _, rs := range r.shards {
@@ -417,17 +421,34 @@ func (r *rib) FlushPeer(peer uint32) (int, int) {
 	tree := r.tree.Load()
 
 	// Iterate through all prefixes and remove peer routes.
-	for _, ref := range tree.All() {
-		rs := r.shards[ref.idx.shardIdx()]
-		removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
-			return route.peer == peer
-		}, false)
-		routesRemoved += removed
-		if empty {
-			rs.freePrefixIndex(ref.idx)
-			prefixesRemoved++
-		}
-		anyEmpty = anyEmpty || empty
+	var wg sync.WaitGroup
+	for i, rs := range r.shards {
+		wg.Go(func() {
+			for _, ref := range tree.All() {
+				if ref.idx.shardIdx() != rs.idx {
+					continue
+				}
+				removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+					return route.peer == peer
+				}, false)
+				results[i].routesRemoved += removed
+				if empty {
+					rs.freePrefixIndex(ref.idx)
+					results[i].prefixesRemoved++
+					results[i].anyEmpty = true
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	anyEmpty := false
+	prefixesRemoved := 0
+	routesRemoved := 0
+	for _, r := range results {
+		anyEmpty = anyEmpty || r.anyEmpty
+		prefixesRemoved += r.prefixesRemoved
+		routesRemoved += r.routesRemoved
 	}
 
 	if anyEmpty {

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -404,16 +404,16 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
-func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
+func (r *rib) FlushPeer(peer uint32) (int, int) {
 	type prefixEntry struct {
 		prefix netip.Prefix
 		ref    prefixRef
 	}
 
 	type workerState struct {
-		prefixesRemoved []netip.Prefix
-		routesRemoved   int
 		prefixes        []prefixEntry
+		prefixesRemoved int
+		routesRemoved   int
 	}
 
 	// Lock all shards in order, then the tree writer lock.
@@ -425,28 +425,31 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 
 	// Group prefixes by shard to avoid traversing the full tree in each goroutine.
 	states := make([]workerState, len(r.shards))
-	for i := 0; i < len(r.shards); i++ {
-		states[i].prefixesRemoved = make([]netip.Prefix, 0, tree.Size()/(peers*len(r.shards)))
+	for i := range states {
 		states[i].prefixes = make([]prefixEntry, 0, tree.Size()/len(r.shards))
 	}
 	for prefix, ref := range tree.All() {
 		state := &states[ref.idx.shardIdx()]
-		state.prefixes = append(state.prefixes, prefixEntry{prefix, ref})
+		state.prefixes = append(state.prefixes, prefixEntry{prefix: prefix, ref: ref})
 	}
 
 	// Iterate through all prefixes and remove peer routes.
+	// Move removed prefixes to the beginning of each shard's list.
 	var wg sync.WaitGroup
 	for _, rs := range r.shards {
 		wg.Go(func() {
 			state := &states[rs.idx]
-			for _, entry := range state.prefixes {
+			for i, entry := range state.prefixes {
 				removed, empty := rs.removeRoutes(entry.ref.idx, func(route route) bool {
 					return route.peer == peer
 				}, false)
 				state.routesRemoved += removed
 				if empty {
 					rs.freePrefixIndex(entry.ref.idx)
-					state.prefixesRemoved = append(state.prefixesRemoved, entry.prefix)
+					if i != state.prefixesRemoved {
+						state.prefixes[i], state.prefixes[state.prefixesRemoved] = state.prefixes[state.prefixesRemoved], state.prefixes[i]
+					}
+					state.prefixesRemoved++
 				}
 			}
 		})
@@ -456,18 +459,16 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 	prefixesRemoved := 0
 	routesRemoved := 0
 	for _, state := range states {
-		prefixesRemoved += len(state.prefixesRemoved)
+		prefixesRemoved += state.prefixesRemoved
 		routesRemoved += state.routesRemoved
 	}
 
 	if prefixesRemoved >= (tree.Size() >> 2) {
-		// Rebuild the tree excluding empty prefixes and publish it.
+		// Rebuild the tree from remaining prefixes and publish it.
 		newTree := &bart.Fast[prefixRef]{}
 		for _, state := range states {
-			for _, entry := range state.prefixes {
-				if _, hasRoutes := r.shards[entry.ref.idx.shardIdx()].routes[makeRouteKey(entry.ref.idx, 0)]; hasRoutes {
-					newTree.Insert(entry.prefix, entry.ref)
-				}
+			for _, entry := range state.prefixes[state.prefixesRemoved:] {
+				newTree.Insert(entry.prefix, entry.ref)
 			}
 		}
 		r.tree.Store(newTree)
@@ -475,8 +476,8 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 		// Remove empty prefixes from the tree and publish it.
 		newTree := tree.Clone()
 		for _, state := range states {
-			for _, prefix := range state.prefixesRemoved {
-				newTree.Delete(prefix)
+			for _, entry := range state.prefixes[:state.prefixesRemoved] {
+				newTree.Delete(entry.prefix)
 			}
 		}
 		r.tree.Store(newTree)

--- a/outlet/routing/provider/bmp/rib.go
+++ b/outlet/routing/provider/bmp/rib.go
@@ -405,9 +405,15 @@ func (r *rib) RemoveRoute(prefix netip.Prefix, rr rawRoute) (int, bool) {
 // FlushPeer removes a whole peer from the RIB, returning the number
 // of removed routes and the number of removed prefixes.
 func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
+	type prefixEntry struct {
+		prefix netip.Prefix
+		ref    prefixRef
+	}
+
 	type workerState struct {
-		prefixesRemoved int
+		prefixesRemoved []netip.Prefix
 		routesRemoved   int
+		prefixes        []prefixEntry
 	}
 
 	// Lock all shards in order, then the tree writer lock.
@@ -417,60 +423,60 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 	r.treeMu.Lock()
 	tree := r.tree.Load()
 
-	// Goroutine to remove empty prefixes from the tree and publish it.
-	var prefixesToRemove chan netip.Prefix
-	if peers >= 4 {
-		prefixesToRemove = make(chan netip.Prefix, len(r.shards)<<3)
-
-		go func() {
-			if prefix, ok := <-prefixesToRemove; ok {
-				newTree := tree.Clone()
-				newTree.Delete(prefix)
-				for prefix = range prefixesToRemove {
-					newTree.Delete(prefix)
-				}
-				r.tree.Store(newTree)
-			}
-		}()
+	// Group prefixes by shard to avoid traversing the full tree in each goroutine.
+	states := make([]workerState, len(r.shards))
+	for i := 0; i < len(r.shards); i++ {
+		states[i].prefixesRemoved = make([]netip.Prefix, 0, tree.Size()/(peers*len(r.shards)))
+		states[i].prefixes = make([]prefixEntry, 0, tree.Size()/len(r.shards))
+	}
+	for prefix, ref := range tree.All() {
+		state := &states[ref.idx.shardIdx()]
+		state.prefixes = append(state.prefixes, prefixEntry{prefix, ref})
 	}
 
 	// Iterate through all prefixes and remove peer routes.
-	states := make([]workerState, len(r.shards))
-
 	var wg sync.WaitGroup
-	for i, rs := range r.shards {
+	for _, rs := range r.shards {
 		wg.Go(func() {
-			state := &states[i]
-			for prefix, ref := range tree.All() {
-				// Only process the matching shard to avoid concurrent changes to intern pools
-				if ref.idx.shardIdx() != rs.idx {
-					continue
-				}
-
-				removed, empty := rs.removeRoutes(ref.idx, func(route route) bool {
+			state := &states[rs.idx]
+			for _, entry := range state.prefixes {
+				removed, empty := rs.removeRoutes(entry.ref.idx, func(route route) bool {
 					return route.peer == peer
 				}, false)
 				state.routesRemoved += removed
 				if empty {
-					rs.freePrefixIndex(ref.idx)
-					state.prefixesRemoved++
-					if prefixesToRemove != nil {
-						prefixesToRemove <- prefix
-					}
+					rs.freePrefixIndex(entry.ref.idx)
+					state.prefixesRemoved = append(state.prefixesRemoved, entry.prefix)
 				}
 			}
 		})
 	}
 	wg.Wait()
 
-	if prefixesToRemove != nil {
-		close(prefixesToRemove)
-	} else {
+	prefixesRemoved := 0
+	routesRemoved := 0
+	for _, state := range states {
+		prefixesRemoved += len(state.prefixesRemoved)
+		routesRemoved += state.routesRemoved
+	}
+
+	if prefixesRemoved >= (tree.Size() >> 2) {
 		// Rebuild the tree excluding empty prefixes and publish it.
 		newTree := &bart.Fast[prefixRef]{}
-		for prefix, ref := range tree.All() {
-			if _, hasRoutes := r.shards[ref.idx.shardIdx()].routes[makeRouteKey(ref.idx, 0)]; hasRoutes {
-				newTree.Insert(prefix, ref)
+		for _, state := range states {
+			for _, entry := range state.prefixes {
+				if _, hasRoutes := r.shards[entry.ref.idx.shardIdx()].routes[makeRouteKey(entry.ref.idx, 0)]; hasRoutes {
+					newTree.Insert(entry.prefix, entry.ref)
+				}
+			}
+		}
+		r.tree.Store(newTree)
+	} else if prefixesRemoved > 0 {
+		// Remove empty prefixes from the tree and publish it.
+		newTree := tree.Clone()
+		for _, state := range states {
+			for _, prefix := range state.prefixesRemoved {
+				newTree.Delete(prefix)
 			}
 		}
 		r.tree.Store(newTree)
@@ -481,12 +487,6 @@ func (r *rib) FlushPeer(peer uint32, peers int) (int, int) {
 		rs.mu.Unlock()
 	}
 
-	prefixesRemoved := 0
-	routesRemoved := 0
-	for _, state := range states {
-		prefixesRemoved += state.prefixesRemoved
-		routesRemoved += state.routesRemoved
-	}
 	return routesRemoved, prefixesRemoved
 }
 

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -579,7 +579,7 @@ func TestRIBHarness(t *testing.T) {
 
 		// Remove everything
 		for _, peer := range peers {
-			r.FlushPeer(map[uint32]struct{}{peer: {}})
+			r.FlushPeer([]uint32{peer})
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -577,10 +577,7 @@ func TestRIBHarness(t *testing.T) {
 			t.Error("did not remove more than 5 prefixes, suspicious...")
 		}
 
-		// Remove everything
-		for _, peer := range peers {
-			r.FlushPeer([]uint32{peer})
-		}
+		r.FlushPeer(peers)
 
 		// Check for leak of interned values across all shards
 		totalNlris := 0

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -578,8 +578,8 @@ func TestRIBHarness(t *testing.T) {
 		}
 
 		// Remove everything
-		for i, peer := range peers {
-			r.FlushPeer(peer, len(peers)-i)
+		for _, peer := range peers {
+			r.FlushPeer(peer)
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -579,11 +579,7 @@ func TestRIBHarness(t *testing.T) {
 
 		// Remove everything
 		for i, peer := range peers {
-			if i&1 == 0 {
-				r.FlushPeer(peer, len(peers)-i)
-			} else {
-				r.FlushPeerConcurrent(peer)
-			}
+			r.FlushPeer(peer, len(peers)-i)
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -579,7 +579,7 @@ func TestRIBHarness(t *testing.T) {
 
 		// Remove everything
 		for _, peer := range peers {
-			r.FlushPeer(peer)
+			r.FlushPeer(map[uint32]struct{}{peer: {}})
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -578,8 +578,8 @@ func TestRIBHarness(t *testing.T) {
 		}
 
 		// Remove everything
-		for _, peer := range peers {
-			r.FlushPeer(peer)
+		for i, peer := range peers {
+			r.FlushPeer(peer, len(peers)-i)
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/rib_test.go
+++ b/outlet/routing/provider/bmp/rib_test.go
@@ -579,7 +579,11 @@ func TestRIBHarness(t *testing.T) {
 
 		// Remove everything
 		for i, peer := range peers {
-			r.FlushPeer(peer, len(peers)-i)
+			if i&1 == 0 {
+				r.FlushPeer(peer, len(peers)-i)
+			} else {
+				r.FlushPeerConcurrent(peer)
+			}
 		}
 
 		// Check for leak of interned values across all shards

--- a/outlet/routing/provider/bmp/root.go
+++ b/outlet/routing/provider/bmp/root.go
@@ -42,6 +42,12 @@ type Provider struct {
 	lastPeerReference uint32
 	staleTimer        *clock.Timer
 	mu                sync.RWMutex
+
+	// batched peer removal
+	peersToRemove    map[peerKey]peerToRemove
+	muPeersToRemove  sync.Mutex // lock for peersToRemove and removePeersTimer
+	muRemovePeers    sync.Mutex // lock for the removePeers timer callback
+	removePeersTimer *clock.Timer
 }
 
 // Dependencies define the dependencies of the BMP component.
@@ -78,6 +84,11 @@ func (configuration Configuration) New(r *reporter.Reporter, dependencies Depend
 		}
 	}
 	p.staleTimer = p.d.Clock.AfterFunc(time.Hour, p.removeStalePeers)
+
+	// Queue peers to remove in order to process them in batches
+	p.peersToRemove = make(map[peerKey]peerToRemove)
+	p.removePeersTimer = p.d.Clock.AfterFunc(10*time.Second, p.removePeers)
+	p.removePeersTimer.Stop()
 
 	p.d.Daemon.Track(&p.t, "outlet/bmp")
 	p.initMetrics()

--- a/outlet/routing/provider/bmp/root_test.go
+++ b/outlet/routing/provider/bmp/root_test.go
@@ -348,6 +348,44 @@ func TestBMP(t *testing.T) {
 		}
 	})
 
+	t.Run("init, no peers up, eor, reach NLRI, peers up, down and up", func(t *testing.T) {
+		r := reporter.NewMock(t)
+		config := DefaultConfiguration()
+		c, mockClock := NewMock(t, r, config)
+		helpers.StartStop(t, c)
+		conn := dial(t, c)
+
+		send(t, conn, "bmp-init.pcap")
+		send(t, conn, "bmp-reach.pcap")
+		send(t, conn, "bmp-peers-up.pcap")
+		send(t, conn, "bmp-eor.pcap")
+		send(t, conn, "bmp-peer-down.pcap")
+		send(t, conn, "bmp-peer-up.pcap") // re-adding a peer should cancel any deferred removals
+		time.Sleep(20 * time.Millisecond)
+		mockClock.Add(time.Minute) // process deferred peer removals
+		gotMetrics := r.GetMetrics("akvorado_outlet_routing_provider_bmp_", "-buffer_size", "-message_queue")
+		expectedMetrics := map[string]string{
+			`received_messages_total{exporter="127.0.0.1",type="initiation"}`:             "1",
+			`received_messages_total{exporter="127.0.0.1",type="peer-down-notification"}`: "1",
+			`received_messages_total{exporter="127.0.0.1",type="peer-up-notification"}`:   "5",
+			`received_messages_total{exporter="127.0.0.1",type="route-mirroring"}`:        "0",
+			`received_messages_total{exporter="127.0.0.1",type="route-monitoring"}`:       "25",
+			`received_messages_total{exporter="127.0.0.1",type="statistics-report"}`:      "5",
+			`received_messages_total{exporter="127.0.0.1",type="termination"}`:            "0",
+			`received_messages_total{exporter="127.0.0.1",type="unknown"}`:                "0",
+			`closed_connections_total{exporter="127.0.0.1"}`:                              "0",
+			`opened_connections_total{exporter="127.0.0.1"}`:                              "1",
+			`peers{exporter="127.0.0.1"}`:                                                 "4",
+			`routes{exporter="127.0.0.1"}`:                                                "17",
+			`prefixes_added_total{exporter="127.0.0.1"}`:                                  "10",
+			`prefixes_removed_total{exporter="127.0.0.1"}`:                                "0",
+			`prefixes_updated_total{exporter="127.0.0.1"}`:                                "7",
+		}
+		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
+			t.Errorf("Metrics (-got, +want):\n%s", diff)
+		}
+	})
+
 	t.Run("init, peers up, eor, reach NLRI, 1 peer down, connection down", func(t *testing.T) {
 		r := reporter.NewMock(t)
 		config := DefaultConfiguration()

--- a/outlet/routing/provider/bmp/root_test.go
+++ b/outlet/routing/provider/bmp/root_test.go
@@ -348,10 +348,10 @@ func TestBMP(t *testing.T) {
 		}
 	})
 
-	t.Run("init, peers up, eor, reach NLRI, 1 peer down", func(t *testing.T) {
+	t.Run("init, peers up, eor, reach NLRI, 1 peer down, connection down", func(t *testing.T) {
 		r := reporter.NewMock(t)
 		config := DefaultConfiguration()
-		p, _ := NewMock(t, r, config)
+		p, mockClock := NewMock(t, r, config)
 		helpers.StartStop(t, p)
 		conn := dial(t, p)
 
@@ -361,7 +361,8 @@ func TestBMP(t *testing.T) {
 		send(t, conn, "bmp-reach.pcap")
 		send(t, conn, "bmp-peer-down.pcap")
 		time.Sleep(20 * time.Millisecond)
-		gotMetrics := r.GetMetrics("akvorado_outlet_routing_provider_bmp_", "-locked_duration", "-buffer_size", "-message_queue")
+		mockClock.Add(time.Minute) // process deferred peer removals
+		gotMetrics := r.GetMetrics("akvorado_outlet_routing_provider_bmp_", "-locked_duration_seconds{", "-locked_duration_seconds_sum", "-buffer_size", "-message_queue")
 		expectedMetrics := map[string]string{
 			`received_messages_total{exporter="127.0.0.1",type="initiation"}`:             "1",
 			`received_messages_total{exporter="127.0.0.1",type="peer-down-notification"}`: "1",
@@ -379,6 +380,7 @@ func TestBMP(t *testing.T) {
 			`prefixes_removed_total{exporter="127.0.0.1"}`:                                "1",
 			`prefixes_updated_total{exporter="127.0.0.1"}`:                                "7",
 			`removed_peers_total{exporter="127.0.0.1"}`:                                   "1",
+			`locked_duration_seconds_count{reason="peer-removal"}`:                        "1",
 		}
 		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
 			t.Errorf("Metrics (-got, +want):\n%s", diff)
@@ -405,6 +407,29 @@ func TestBMP(t *testing.T) {
 			},
 		}
 		gotRIB := dumpRIB(t, p)
+		if diff := helpers.Diff(gotRIB, expectedRIB); diff != "" {
+			t.Errorf("RIB (-got, +want):\n%s", diff)
+		}
+
+		// Closing the connection marks the three remaining peers as stale.
+		// They should all be removed at once, increasing the removed_peers_total metric by three,
+		// but locked_duration_seconds_count{reason="peer-removal"} only by one.
+		conn.Close()
+		time.Sleep(20 * time.Millisecond)
+		mockClock.Add(time.Hour)
+		gotMetrics = r.GetMetrics("akvorado_outlet_routing_provider_bmp_", "peers", "routes", "removed_peers_total", "locked_duration_seconds_count")
+		expectedMetrics = map[string]string{
+			`peers{exporter="127.0.0.1"}`:                          "0",
+			`routes{exporter="127.0.0.1"}`:                         "0",
+			`removed_peers_total{exporter="127.0.0.1"}`:            "4",
+			`locked_duration_seconds_count{reason="peer-removal"}`: "2",
+		}
+		if diff := helpers.Diff(gotMetrics, expectedMetrics); diff != "" {
+			t.Errorf("Metrics (-got, +want):\n%s", diff)
+		}
+
+		expectedRIB = map[netip.Addr][]string{}
+		gotRIB = dumpRIB(t, p)
 		if diff := helpers.Diff(gotRIB, expectedRIB); diff != "" {
 			t.Errorf("RIB (-got, +want):\n%s", diff)
 		}


### PR DESCRIPTION
This version of the PR depends on https://github.com/akvorado/akvorado/pull/2580. https://github.com/bogi788/akvorado/pull/1/changes shows only the changes on top.

As described in https://github.com/akvorado/akvorado/discussions/2587 BMP connections dropping and reconnecting leads to multiple peers becoming stale and subsequently being removed concurrently, which can cause a delay with inserting flows into clickhouse.

To work around this issue we've implemented batching of peer removals - both from BMP messages as well as from becoming stale - by accumulating peers over a ten second window before flushing them.